### PR TITLE
Remove punctilio dependency and related configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,20 +9,6 @@ version: 2
 # monitoring with explicit opt-in for packages you actively care about.
 
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    versioning-strategy: auto
-    allow:
-      - dependency-name: "punctilio"
-    groups:
-      npm-tracked:
-        patterns:
-          - "*"
-    cooldown:
-      default-days: 7
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,1 @@
-{
-  "plugins": ["punctilio/prettier-plugin"]
-}
+{}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
     "lint-staged": "^17.0.5",
-    "prettier": "^3.0.0",
-    "punctilio": "^3.10.0"
+    "prettier": "^3.0.0"
   }
 }


### PR DESCRIPTION
Removes the `punctilio` package and its associated configuration from the project.

## Changes

- Removed `punctilio` from npm dependencies in `package.json`
- Removed `punctilio/prettier-plugin` from Prettier configuration in `.prettierrc.json`
- Removed npm package ecosystem configuration from Dependabot (`.github/dependabot.yml`), keeping only GitHub Actions updates

The project now relies on standard Prettier without custom plugins, and Dependabot monitoring is limited to GitHub Actions only.

https://claude.ai/code/session_01PKdNEzrsKNgrmYjZGmDFW5