### PR TITLE
Enforce double-bracket syntax in shell scripts

### DIFF
--- a/.claude/hooks/safe-launch.sh
+++ b/.claude/hooks/safe-launch.sh
@@ -26,7 +26,7 @@ set -uo pipefail
 target="${1:-}"
 shift || true
 
-if [ -z "$target" ] || [ ! -f "$target" ]; then
+if [[ -z "$target" ]] || [[ ! -f "$target" ]]; then
   echo "safe-launch: missing target hook: $target" >&2
   exit 1
 fi
@@ -40,7 +40,7 @@ fi
 # Degraded path. Read the PreToolUse payload before we touch stdin again.
 parse_error=$(bash -n "$target" 2>&1)
 echo "safe-launch: target hook failed to parse — degrading open: $target" >&2
-[ -n "$parse_error" ] && echo "$parse_error" >&2
+[[ -n "$parse_error" ]] && echo "$parse_error" >&2
 
 # Cap the read at 10 MiB so a pathological payload can't OOM the degraded path.
 # (No timeout: stdin is the in-flight PreToolUse payload, already fully buffered
@@ -51,7 +51,7 @@ project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 tool_name=""
 tool_path=""
 parser="$(dirname "$0")/safe-launch-parse.py"
-if command -v python3 &>/dev/null && [ -f "$parser" ]; then
+if command -v python3 &>/dev/null && [[ -f "$parser" ]]; then
   parsed=$(printf '%s' "$payload" | python3 "$parser" "$project_dir" 2>/dev/null)
   tool_name=$(printf '%s\n' "$parsed" | sed -n '1p')
   tool_path=$(printf '%s\n' "$parsed" | sed -n '2p')
@@ -62,10 +62,10 @@ fi
 # caller falls through to the "ask" default.
 is_under() {
   local candidate="$1" parent="$2" parent_dir resolved
-  [ -n "$candidate" ] && [ -n "$parent" ] || return 1
+  [[ -n "$candidate" ]] && [[ -n "$parent" ]] || return 1
   case "$candidate" in *..*) return 1 ;; esac
   parent_dir=$(cd "$(dirname "$candidate")" 2>/dev/null && pwd -P) || return 1
-  [ -n "$parent_dir" ] || return 1
+  [[ -n "$parent_dir" ]] || return 1
   resolved="$parent_dir/$(basename "$candidate")"
   case "$resolved" in
   "$parent"/*) return 0 ;;
@@ -76,7 +76,7 @@ is_under() {
 case "$tool_name" in
 Edit | Write | MultiEdit | NotebookEdit)
   for safe in "$project_dir/.claude/hooks" "$project_dir/.hooks"; do
-    [ -d "$safe" ] || continue
+    [[ -d "$safe" ]] || continue
     safe_resolved=$(cd "$safe" && pwd -P)
     if is_under "$tool_path" "$safe_resolved"; then
       echo "safe-launch: allowing self-repair edit under ${safe#"$project_dir/"}" >&2

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -15,7 +15,7 @@ warn() {
   echo "WARNING: $1" >&2
   SETUP_WARNINGS=$((SETUP_WARNINGS + 1))
 }
-is_root() { [ "$(id -u)" = "0" ]; }
+is_root() { [[ "$(id -u)" = "0" ]]; }
 
 # Install a command via uv if missing
 uv_install_if_missing() {
@@ -57,19 +57,19 @@ webi_install_if_missing() {
 _check_hook_syntax() {
   local dir file out
   for dir in "$PROJECT_DIR/.claude/hooks" "$PROJECT_DIR/.hooks"; do
-    [ -d "$dir" ] || continue
+    [[ -d "$dir" ]] || continue
     while IFS= read -r -d '' file; do
       case "$file" in
       *.sh | *.bash)
         if ! out=$(bash -n "$file" 2>&1); then
           warn "hook has bash syntax error: ${file#"$PROJECT_DIR/"}"
-          [ -n "$out" ] && echo "$out" >&2
+          [[ -n "$out" ]] && echo "$out" >&2
         fi
         ;;
       *.py)
         if command -v python3 &>/dev/null && ! out=$(python3 -m py_compile "$file" 2>&1); then
           warn "hook has python syntax error: ${file#"$PROJECT_DIR/"}"
-          [ -n "$out" ] && echo "$out" >&2
+          [[ -n "$out" ]] && echo "$out" >&2
         fi
         ;;
       esac
@@ -84,7 +84,7 @@ _check_hook_syntax
 #######################################
 
 export PATH="$HOME/.local/bin:$PATH"
-if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
   echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
 fi
 
@@ -103,7 +103,7 @@ fi
 # Python projects: the pre-commit and pre-push hooks shell out to ruff, which
 # isn't a project dependency. Install it (pinned to match .pre-commit-config.yaml
 # so local hooks format identically to CI). Skip for non-Python repos.
-if { [ -f "$PROJECT_DIR/pyproject.toml" ] || [ -f "$PROJECT_DIR/uv.lock" ]; } && command -v uv &>/dev/null; then
+if { [[ -f "$PROJECT_DIR/pyproject.toml" ]] || [[ -f "$PROJECT_DIR/uv.lock" ]]; } && command -v uv &>/dev/null; then
   uv_install_if_missing ruff "ruff==0.14.5"
   uv_install_if_missing zizmor "zizmor==1.25.2"
 fi
@@ -117,7 +117,7 @@ git config core.hooksPath .hooks
 
 # Pre-fetch the base branch so diffs against $CLAUDE_CODE_BASE_REF work
 # immediately (e.g. when creating PRs). Failure is non-fatal.
-if [ -n "${CLAUDE_CODE_BASE_REF:-}" ]; then
+if [[ -n "${CLAUDE_CODE_BASE_REF:-}" ]]; then
   git fetch origin "$CLAUDE_CODE_BASE_REF" --quiet 2>/dev/null ||
     warn "Failed to fetch base branch $CLAUDE_CODE_BASE_REF"
 fi
@@ -128,7 +128,7 @@ fi
 
 if ! command -v gh &>/dev/null; then
   warn "gh CLI not found"
-elif [ -z "${GH_TOKEN:-}" ]; then
+elif [[ -z "${GH_TOKEN:-}" ]]; then
   warn "GH_TOKEN is not set — GitHub CLI requires authentication"
 fi
 
@@ -141,13 +141,13 @@ fi
 # The gh CLI can't detect the GitHub repo from this, so we extract
 # owner/repo and export GH_REPO to make all gh commands work.
 
-if [ -z "${GH_REPO:-}" ]; then
+if [[ -z "${GH_REPO:-}" ]]; then
   remote_url=$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null)
   if [[ "$remote_url" =~ /git/([^/]+/[^/]+)$ ]]; then
     GH_REPO="${BASH_REMATCH[1]}"
     GH_REPO="${GH_REPO%.git}"
     export GH_REPO
-    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
       echo "export GH_REPO=\"$GH_REPO\"" >>"$CLAUDE_ENV_FILE"
     fi
   fi
@@ -162,7 +162,7 @@ fi
 remote_url="${remote_url:-$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null)}"
 if [[ "$remote_url" =~ 127\.0\.0\.1.*/git/ ]]; then
   local_settings="$PROJECT_DIR/.claude/settings.local.json"
-  if [ ! -f "$local_settings" ]; then
+  if [[ ! -f "$local_settings" ]]; then
     cat >"$local_settings" <<'SETTINGS'
 {
   "permissions": {
@@ -189,7 +189,7 @@ fi
 # Project dependencies
 #######################################
 
-if [ -f "$PROJECT_DIR/package.json" ]; then
+if [[ -f "$PROJECT_DIR/package.json" ]]; then
   # Always run install (git hooks are configured in package.json postinstall)
   if command -v pnpm &>/dev/null; then
     pnpm install --silent || warn "Failed to install Node dependencies"
@@ -198,17 +198,17 @@ if [ -f "$PROJECT_DIR/package.json" ]; then
   fi
 fi
 
-if [ -f "$PROJECT_DIR/uv.lock" ] && command -v uv &>/dev/null; then
+if [[ -f "$PROJECT_DIR/uv.lock" ]] && command -v uv &>/dev/null; then
   uv sync --quiet || warn "Failed to sync Python dependencies"
   # Add .venv/bin to PATH so Python tools are available to hooks
-  if [ -d "$PROJECT_DIR/.venv/bin" ]; then
+  if [[ -d "$PROJECT_DIR/.venv/bin" ]]; then
     export PATH="$PROJECT_DIR/.venv/bin:$PATH"
-    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
       echo "export PATH=\"$PROJECT_DIR/.venv/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
     fi
   fi
 fi
 
-if [ "$SETUP_WARNINGS" -gt 0 ]; then
+if [[ "$SETUP_WARNINGS" -gt 0 ]]; then
   echo "Setup done with $SETUP_WARNINGS warning(s) — see above" >&2
 fi

--- a/.github/scripts/check-existing-security-pr.sh
+++ b/.github/scripts/check-existing-security-pr.sh
@@ -17,7 +17,7 @@ GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
 EXISTING_BRANCH=$(gh pr list --label "security-scan" --state open \
   --json headRefName --jq '.[0].headRefName // empty')
 
-if [ -n "$EXISTING_BRANCH" ]; then
+if [[ -n "$EXISTING_BRANCH" ]]; then
   echo "Found existing security PR branch: $EXISTING_BRANCH"
   git fetch origin "$EXISTING_BRANCH"
   git checkout "$EXISTING_BRANCH"

--- a/.github/scripts/check-symlinks.sh
+++ b/.github/scripts/check-symlinks.sh
@@ -6,18 +6,18 @@ set -euo pipefail
 
 violations=""
 while IFS= read -r line; do
-  [ -z "$line" ] && continue
+  [[ -z "$line" ]] && continue
   mode=$(printf '%s' "$line" | awk '{print $1}')
   hash=$(printf '%s' "$line" | awk '{print $2}')
   path=$(printf '%s' "$line" | cut -f2-)
-  [ "$mode" = "120000" ] || continue
+  [[ "$mode" = "120000" ]] || continue
   target=$(git cat-file blob "$hash")
   case "$target" in
   /*) violations="${violations}${path} -> ${target}"$'\n' ;;
   esac
 done < <(git ls-files -s)
 
-if [ -n "$violations" ]; then
+if [[ -n "$violations" ]]; then
   echo "::error::Tracked symlinks resolve to absolute paths (not portable across machines):"
   printf '%s' "$violations"
   exit 1

--- a/.github/scripts/fetch-security-report.sh
+++ b/.github/scripts/fetch-security-report.sh
@@ -57,11 +57,11 @@ gh_api_section \
 } >>"$REPORT_PATH"
 # Skip when there's no Node project — setup-base-env leaves pnpm uninstalled
 # in that case, and `pnpm audit` would error out instead of returning "clean".
-if [ -f package.json ]; then
+if [[ -f package.json ]]; then
   pnpm audit 2>&1 | head -100 >>"$REPORT_PATH"
   pnpm_rc=${PIPESTATUS[0]}
   # Exit 0 = clean, exit 1 = vulnerabilities found (expected); higher = real error
-  [ "${pnpm_rc:-0}" -le 1 ] || echo "_pnpm audit encountered an error (exit code $pnpm_rc); output above may be incomplete._" >>"$REPORT_PATH"
+  [[ "${pnpm_rc:-0}" -le 1 ]] || echo "_pnpm audit encountered an error (exit code $pnpm_rc); output above may be incomplete._" >>"$REPORT_PATH"
 else
   echo "_Skipped: no package.json (not a Node project)._" >>"$REPORT_PATH"
 fi
@@ -87,7 +87,7 @@ for pr_num in $(gh api "repos/${REPO}/pulls?state=open&per_page=5" --jq '.[].num
     # prior iteration's content can't leak into this PR's section.
     : >"$socket_tmp"
   fi
-  if [ -s "$socket_tmp" ]; then
+  if [[ -s "$socket_tmp" ]]; then
     socket_found=true
     {
       echo "### PR #${pr_num}"
@@ -96,7 +96,7 @@ for pr_num in $(gh api "repos/${REPO}/pulls?state=open&per_page=5" --jq '.[].num
     } >>"$REPORT_PATH"
   fi
 done
-if [ "$socket_found" = "false" ]; then
+if [[ "$socket_found" = "false" ]]; then
   echo "_No Socket.dev alerts found in recent open PRs._" >>"$REPORT_PATH"
 fi
 
@@ -105,7 +105,7 @@ cat "$REPORT_PATH"
 # Use a random sentinel to prevent delimiter injection — report content comes
 # from external sources (advisory descriptions, bot comments) that an attacker
 # could craft to contain a static sentinel and inject arbitrary env vars.
-if [ -r /proc/sys/kernel/random/uuid ]; then
+if [[ -r /proc/sys/kernel/random/uuid ]]; then
   report_sentinel="REPORT_EOF_$(cat /proc/sys/kernel/random/uuid)"
 elif command -v uuidgen >/dev/null 2>&1; then
   report_sentinel="REPORT_EOF_$(uuidgen)"
@@ -113,7 +113,7 @@ else
   report_sentinel="REPORT_EOF_$$_${RANDOM}_${RANDOM}"
 fi
 report_size=$(wc -c <"$REPORT_PATH" | tr -d '[:space:]')
-if [ "$report_size" -gt 50000 ]; then
+if [[ "$report_size" -gt 50000 ]]; then
   echo "::warning::Security report is ${report_size} bytes; truncating to 50 KB for \$GITHUB_ENV. Full report is at $REPORT_PATH on the runner."
 fi
 {

--- a/.github/scripts/list-dependabot-prs.sh
+++ b/.github/scripts/list-dependabot-prs.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 : "${GH_TOKEN:?GH_TOKEN must be set}"
 GITHUB_ENV="${GITHUB_ENV:-/dev/null}"
 
-if [ -r /proc/sys/kernel/random/uuid ]; then
+if [[ -r /proc/sys/kernel/random/uuid ]]; then
   sentinel="PR_EOF_$(cat /proc/sys/kernel/random/uuid)"
 elif command -v uuidgen >/dev/null 2>&1; then
   sentinel="PR_EOF_$(uuidgen)"

--- a/.github/scripts/request-claude-resolve.sh
+++ b/.github/scripts/request-claude-resolve.sh
@@ -21,7 +21,7 @@ BODY="@claude Resolve this template sync PR so it's ready to merge.
 
 **Important:** Check whether newly added workflow files duplicate CI that the target repo already has (e.g., the repo may already have its own test or lint workflows under different names or configurations). If a synced workflow (like \`node-tests.yaml\`, \`lint.yaml\`, \`format-check.yaml\`) duplicates existing CI, delete the redundant template workflow and add its path to EXCLUDE_PATHS in \`template-sync.yaml\` so it won't be re-added on future syncs."
 
-if [ "$HAS_CONFLICTS" = "true" ]; then
+if [[ "$HAS_CONFLICTS" = "true" ]]; then
   BODY="$BODY
 
 **Resolve conflicts in:** $CONFLICT_FILES
@@ -34,7 +34,7 @@ For each file:
 5. Remove the \`.template-sync-conflicts\` tracking file once all conflicts are resolved"
 fi
 
-if [ "$HAS_DELETIONS" = "true" ]; then
+if [[ "$HAS_DELETIONS" = "true" ]]; then
   BODY="$BODY
 
 **Deleted files:** These files were removed from the template: $DELETED_FILES

--- a/.github/scripts/show-sync-diff.sh
+++ b/.github/scripts/show-sync-diff.sh
@@ -16,12 +16,12 @@ DELETED_FILES="${DELETED_FILES:-}"
 
 echo "=== Changes that would be made ==="
 git diff
-if [ "$HAS_CONFLICTS" = "true" ]; then
+if [[ "$HAS_CONFLICTS" = "true" ]]; then
   echo ""
   echo "=== CONFLICTS (will need Claude resolution) ==="
   echo "$CONFLICT_FILES"
 fi
-if [ "$HAS_DELETIONS" = "true" ]; then
+if [[ "$HAS_DELETIONS" = "true" ]]; then
   echo ""
   echo "=== FILES DELETED IN TEMPLATE ==="
   echo "$DELETED_FILES"

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -42,7 +42,7 @@ PREV_TEMPLATE_FILES="$WORK_DIR/prev_template_files.txt"
 is_excluded() {
   local candidate="$1" exclude
   for exclude in $EXCLUDE_PATHS; do
-    [ "$candidate" = "$exclude" ] && return 0
+    [[ "$candidate" = "$exclude" ]] && return 0
   done
   return 1
 }
@@ -51,7 +51,7 @@ is_excluded() {
 # (always present on Linux runners and inside containers) but falls back to
 # `uuidgen` or $RANDOM so the script works in stripped-down environments.
 random_token() {
-  if [ -r /proc/sys/kernel/random/uuid ]; then
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
     cat /proc/sys/kernel/random/uuid
   elif command -v uuidgen >/dev/null 2>&1; then
     uuidgen
@@ -84,7 +84,7 @@ TEMPLATE_SHA_SHORT="${TEMPLATE_SHA:0:7}"
 } >>"$GITHUB_OUTPUT"
 
 PREV_SHA=""
-if [ -f .template-version ]; then
+if [[ -f .template-version ]]; then
   PREV_SHA=$(cat .template-version)
   echo "Previous template version: $PREV_SHA"
 else
@@ -92,7 +92,7 @@ else
 fi
 echo "Current template version: $TEMPLATE_SHA"
 
-if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$TEMPLATE_SHA" ]; then
+if [[ -n "$PREV_SHA" ]] && [[ "$PREV_SHA" != "$TEMPLATE_SHA" ]]; then
   if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
     CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA")
   else
@@ -100,7 +100,7 @@ if [ -n "$PREV_SHA" ] && [ "$PREV_SHA" != "$TEMPLATE_SHA" ]; then
     CHANGELOG="Previous SHA \`$PREV_SHA\` no longer exists in template history (force-push/rebase). Showing last 20 commits instead:"$'\n'
     CHANGELOG+=$(git -C _template log --oneline -20 "$TEMPLATE_SHA")
   fi
-  [ -n "$CHANGELOG" ] && emit_multiline_output "changelog" "$CHANGELOG"
+  [[ -n "$CHANGELOG" ]] && emit_multiline_output "changelog" "$CHANGELOG"
 fi
 
 echo "$TEMPLATE_SHA" >.template-version
@@ -130,10 +130,10 @@ process_file() {
 
   local parent_dir
   parent_dir=$(dirname "$rel_path")
-  [ "$parent_dir" != "." ] && mkdir -p "$parent_dir"
+  [[ "$parent_dir" != "." ]] && mkdir -p "$parent_dir"
 
   # Case 1: new file in template.
-  if [ ! -f "$rel_path" ]; then
+  if [[ ! -f "$rel_path" ]]; then
     cp "$template_file" "$rel_path"
     echo "Added: $rel_path"
     return
@@ -145,7 +145,7 @@ process_file() {
   fi
 
   # Case 3: no merge base — first sync or history unavailable.
-  if [ -z "$PREV_SHA" ]; then
+  if [[ -z "$PREV_SHA" ]]; then
     record_no_base_conflict "$rel_path" "$template_file"
     return
   fi
@@ -228,7 +228,7 @@ record_no_base_conflict() {
     # Capture into a variable so truncating with `head` can't SIGPIPE the diff.
     diff_rc=0
     diff_out=$(diff -u "$rel_path" "$template_file") || diff_rc=$?
-    [ "${diff_rc:-0}" -le 1 ] || exit "${diff_rc}"
+    [[ "${diff_rc:-0}" -le 1 ]] || exit "${diff_rc}"
     head -500 <<<"$diff_out"
     echo "\`\`\`"
     echo "</details>"
@@ -244,7 +244,7 @@ record_no_base_conflict() {
 # A path is "deleted" only if it existed in the template at PREV_SHA but no
 # longer exists at the current template HEAD. This avoids false positives for
 # project-specific files that were never in the template.
-if [ -n "$PREV_SHA" ]; then
+if [[ -n "$PREV_SHA" ]]; then
   if ! git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES"; then
     : >"$PREV_TEMPLATE_FILES" # PREV_SHA not in template history; treat as no prior files
   fi
@@ -253,23 +253,23 @@ fi
 for path in $SYNC_PATHS; do
   is_excluded "$path" && continue
 
-  if [ -n "$PREV_SHA" ]; then
+  if [[ -n "$PREV_SHA" ]]; then
     while IFS= read -r prev_file; do
       case "$prev_file" in "$path" | "$path/"*) ;; *) continue ;; esac
       is_excluded "$prev_file" && continue
-      if [ ! -f "_template/$prev_file" ]; then
+      if [[ ! -f "_template/$prev_file" ]]; then
         echo "DELETED in template: $prev_file"
         echo "$prev_file" >>"$DELETED_FILES"
       fi
     done <"$PREV_TEMPLATE_FILES"
   fi
 
-  if [ ! -e "_template/$path" ]; then
+  if [[ ! -e "_template/$path" ]]; then
     echo "Warning: $path not found in template, skipping"
     continue
   fi
 
-  if [ -d "_template/$path" ]; then
+  if [[ -d "_template/$path" ]]; then
     while IFS= read -r template_file; do
       rel_path="${template_file#_template/}"
       is_excluded "$rel_path" && continue
@@ -286,12 +286,12 @@ rm -rf _template
 # Set outputs
 #############################################
 
-if [ -s "$AUTO_MERGED_FILES" ]; then
+if [[ -s "$AUTO_MERGED_FILES" ]]; then
   auto_merged=$(tr '\n' ' ' <"$AUTO_MERGED_FILES")
   echo "auto_merged_files=$auto_merged" >>"$GITHUB_OUTPUT"
 fi
 
-if [ -s "$CONFLICT_FILES" ]; then
+if [[ -s "$CONFLICT_FILES" ]]; then
   conflicts=$(tr '\n' ' ' <"$CONFLICT_FILES")
   {
     echo "has_conflicts=true"
@@ -304,7 +304,7 @@ else
   rm -f .template-sync-conflicts
 fi
 
-if [ -s "$DELETED_FILES" ]; then
+if [[ -s "$DELETED_FILES" ]]; then
   deleted=$(tr '\n' ' ' <"$DELETED_FILES")
   {
     echo "has_deletions=true"
@@ -314,7 +314,7 @@ else
   echo "has_deletions=false" >>"$GITHUB_OUTPUT"
 fi
 
-if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+if git diff --quiet && [[ -z "$(git ls-files --others --exclude-standard)" ]]; then
   echo "has_changes=false" >>"$GITHUB_OUTPUT"
 else
   changed_paths=$({

--- a/.github/scripts/validate-config.sh
+++ b/.github/scripts/validate-config.sh
@@ -13,20 +13,20 @@ echo ""
 
 # 1. All hook scripts referenced in .claude/settings.json exist on disk
 echo "Checking Claude hook script paths..."
-if [ -f .claude/settings.json ]; then
+if [[ -f .claude/settings.json ]]; then
   if ! commands=$(jq -r '.. | objects | select(.command?) | .command' .claude/settings.json 2>/dev/null); then
     error ".claude/settings.json could not be parsed (invalid JSON?)"
     commands=""
   fi
   while IFS= read -r cmd; do
-    [ -z "$cmd" ] && continue
+    [[ -z "$cmd" ]] && continue
     # shellcheck disable=SC2016  # literal $CLAUDE_PROJECT_DIR matched by sed
     resolved=$(echo "$cmd" | sed 's|"\$CLAUDE_PROJECT_DIR"/\?|./|g; s|"||g; s|\$CLAUDE_PROJECT_DIR/\?|./|g')
     read -ra tokens <<<"$resolved"
     for token in "${tokens[@]}"; do
       case "$token" in
       ./.claude/hooks/* | ./.hooks/*)
-        if [ ! -f "$token" ]; then
+        if [[ ! -f "$token" ]]; then
           error "Hook script missing: $token"
         fi
         ;;
@@ -42,14 +42,14 @@ fi
 # shebang are loaded by another hook and don't need +x.
 echo "Checking hook script permissions and syntax..."
 for f in .hooks/* .claude/hooks/*; do
-  [ -f "$f" ] || continue
+  [[ -f "$f" ]] || continue
   has_shebang=0
   # read returns 1 at EOF (empty file = no shebang, fine); >1 is a real error.
   rc=0
   IFS= read -r first_line <"$f" || rc=$?
-  [ "${rc:-0}" -le 1 ] || error "Failed to read $f (exit $rc)"
+  [[ "${rc:-0}" -le 1 ]] || error "Failed to read $f (exit $rc)"
   case "$first_line" in '#!'*) has_shebang=1 ;; esac
-  if [ "$has_shebang" = "1" ] && [ ! -x "$f" ]; then
+  if [[ "$has_shebang" = "1" ]] && [[ ! -x "$f" ]]; then
     error "$f has a shebang but is not executable"
   fi
   case "$f" in
@@ -71,13 +71,13 @@ done
 # token (the program actually executed), not a substring, so a command that
 # merely mentions "safe-launch.sh" in an argument can't pass by accident.
 echo "Checking PreToolUse hooks use safe-launch.sh..."
-if [ -f .claude/settings.json ]; then
+if [[ -f .claude/settings.json ]]; then
   if ! pretooluse_cmds=$(jq -r '.hooks.PreToolUse // [] | .[] | .hooks[] | select(.type == "command") | .command' .claude/settings.json 2>/dev/null); then
     error ".claude/settings.json could not be parsed (invalid JSON?)"
     pretooluse_cmds=""
   fi
   while IFS= read -r cmd; do
-    [ -z "$cmd" ] && continue
+    [[ -z "$cmd" ]] && continue
     read -ra tokens <<<"$cmd"
     case "${tokens[0]}" in
     */safe-launch.sh | safe-launch.sh) ;;
@@ -88,7 +88,7 @@ fi
 
 # Summary
 echo ""
-if [ "$errors" -gt 0 ]; then
+if [[ "$errors" -gt 0 ]]; then
   echo "Validation failed with $errors error(s)"
   exit 1
 else

--- a/.hooks/commit-msg
+++ b/.hooks/commit-msg
@@ -8,7 +8,7 @@ git_root="$(git rev-parse --show-toplevel)"
 
 # Git hooks run in a separate shell and don't inherit CLAUDE_ENV_FILE modifications.
 # Explicitly add .venv/bin to PATH so Python tools from uv are available.
-if [ -d "$git_root/.venv/bin" ]; then
+if [[ -d "$git_root/.venv/bin" ]]; then
   export PATH="$git_root/.venv/bin:$PATH"
 fi
 
@@ -16,7 +16,7 @@ fi
 # to downloading on demand so sandboxed environments without node_modules
 # still get conventional-commit enforcement.
 config="config/javascript/commitlint.config.js"
-if [ -f "$git_root/node_modules/.bin/commitlint" ]; then
+if [[ -f "$git_root/node_modules/.bin/commitlint" ]]; then
   if command -v pnpm >/dev/null 2>&1; then
     pnpm exec commitlint --edit "$1" --config "$config"
   else

--- a/.hooks/lint-skills.sh
+++ b/.hooks/lint-skills.sh
@@ -71,7 +71,7 @@ for file in "$@"; do
   # still produces an empty (not failing) result — required under `pipefail`.
   desc_block=$(awk '/^---$/{n++; next} n==1' "$file" | sed -n '/^description:/,/^[a-z]/p')
   periods=$(printf '%s' "$desc_block" | tr -dc '.')
-  if [ "${#periods}" -lt 2 ]; then
+  if [[ "${#periods}" -lt 2 ]]; then
     echo "ERROR: $file description too short — use 2-3 sentences with specific activation triggers" >&2
     errors=$((errors + 1))
   fi
@@ -83,4 +83,4 @@ for file in "$@"; do
   fi
 done
 
-[ "$errors" -gt 0 ] && exit 1 || exit 0
+[[ "$errors" -gt 0 ]] && exit 1 || exit 0

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -14,11 +14,11 @@ if ! git diff --cached --check; then
   exit 1
 fi
 
-if [ -d "$git_root/.venv/bin" ]; then
+if [[ -d "$git_root/.venv/bin" ]]; then
   export PATH="$git_root/.venv/bin:$PATH"
 fi
 
-if [ ! -f "$git_root/node_modules/.bin/lint-staged" ]; then
+if [[ ! -f "$git_root/node_modules/.bin/lint-staged" ]]; then
   exit 0
 fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,13 +29,23 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
-        args: [-x, -P, .claude/hooks]
+        # Enable one optional check beyond the defaults: require [[ ]] over
+        # [ ] in bash/ksh.
+        args: [-x, -P, .claude/hooks, -o, require-double-brackets]
 
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.12.0-2
     hooks:
       - id: shfmt
         args: [-i, "2", -w]
+
+  # Lints workflow/action correctness and runs shellcheck on inline `run:`
+  # blocks that the standalone shellcheck hook can't see. Python-wrapped so it
+  # needs no Go toolchain in the Python-only pre-commit CI job.
+  - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
+    rev: v1.7.12.24
+    hooks:
+      - id: actionlint
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.5
@@ -67,3 +77,10 @@ repos:
         entry: bash .hooks/lint-skills.sh
         language: system
         files: ^\.claude/skills/.*\.md$
+
+      - id: validate-changelog-fragments
+        name: validate changelog.d fragment names
+        entry: "bash -c 'node .github/scripts/assemble-changelog.mjs --check'"
+        language: system
+        pass_filenames: false
+        files: ^changelog\.d/

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ echo "Setting up Claude automation template..."
 # Configure git hooks
 git config core.hooksPath .hooks
 
-if [ -f package.json ]; then
+if [[ -f package.json ]]; then
   # Install pnpm if not available
   if ! command -v pnpm &>/dev/null; then
     echo "Installing pnpm..."
@@ -20,18 +20,18 @@ if [ -f package.json ]; then
 fi
 
 # Install Python dependencies if applicable
-if [ -f uv.lock ] && command -v uv &>/dev/null; then
+if [[ -f uv.lock ]] && command -v uv &>/dev/null; then
   uv sync
 fi
 
 # Verify setup
-if [ "$(git config core.hooksPath)" = ".hooks" ]; then
+if [[ "$(git config core.hooksPath)" = ".hooks" ]]; then
   echo ""
   echo "✓ Setup complete!"
   echo ""
   echo "Next steps:"
   echo "  1. Edit CLAUDE.md with your project details"
-  if [ -f package.json ]; then
+  if [[ -f package.json ]]; then
     echo "  2. Configure scripts in package.json"
   fi
   echo "  Start coding!"


### PR DESCRIPTION
Replace all single-bracket `[ ]` test conditionals with double-bracket `[[ ]]` syntax across shell scripts in the repository, and enable the `require-double-brackets` shellcheck option to enforce this going forward.

## Changes

- **Shell script updates**: Converted 60+ instances of `[ ]` to `[[ ]]` in:
  - `.github/scripts/template-sync.sh`
  - `.claude/hooks/session-setup.sh`
  - `.github/scripts/validate-config.sh`
  - `.claude/hooks/safe-launch.sh`
  - `.github/scripts/fetch-security-report.sh`
  - `setup.sh`
  - `.github/scripts/check-symlinks.sh`
  - `.github/scripts/request-claude-resolve.sh`
  - `.github/scripts/show-sync-diff.sh`
  - `.hooks/commit-msg`
  - `.hooks/lint-skills.sh`
  - `.hooks/pre-commit`
  - `.github/scripts/check-existing-security-pr.sh`
  - `.github/scripts/list-dependabot-prs.sh`

- **Linting configuration**: Updated `.pre-commit-config.yaml` to:
  - Enable `require-double-brackets` in shellcheck args
  - Add `actionlint-py` hook for GitHub Actions workflow validation
  - Add changelog fragment validation hook

## Rationale

Double-bracket syntax `[[ ]]` is the modern bash/ksh standard and avoids word-splitting and globbing pitfalls inherent to single brackets. This change improves script robustness and consistency across the codebase. The shellcheck enforcement prevents regressions.

https://claude.ai/code/session_01ARU48wDRtdygfyRLCtmzsP