### PR TITLE
docs(pr-creation): use pyright in the Python validation-commands example

### DIFF
--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -97,7 +97,7 @@ pnpm lint         # Run linter
 **Python:**
 
 ```bash
-mypy <changed_files>
+pyright <changed_files>
 pylint <changed_files>
 ruff check <changed_files>
 pytest <test_files>


### PR DESCRIPTION
## Summary

The `pr-creation` skill's PR template lists illustrative Python validation commands. This swaps the `mypy <changed_files>` example for `pyright <changed_files>`, matching the move from mypy to pyright across the repo family.

One-line doc change; no behavior or tooling impact (these repos don't run a type checker — the block is illustrative and prefaced with "Customize these commands based on your project's tooling").


---
_Generated by [Claude Code](https://claude.ai/code/session_01FT54jhfCeLkXPzZcufg5D2)_