### PR TITLE
ci: run template sync weekly instead of daily

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -35,8 +35,8 @@ on:
         default: "false"
         type: boolean
   schedule:
-    # Run daily at 9am UTC
-    - cron: "0 9 * * *"
+    # Run weekly on Mondays at 9am UTC
+    - cron: "0 9 * * 1"
 
 env:
   TEMPLATE_REPO: "alexander-turner/claude-automation-template"


### PR DESCRIPTION
## Summary

Changes the `template-sync.yaml` schedule from a daily cron to a weekly one. The sync now runs on Mondays at 9am UTC instead of every day at 9am UTC.

## Changes

- `.github/workflows/template-sync.yaml`: `schedule.cron` changed from `"0 9 * * *"` (daily) to `"0 9 * * 1"` (weekly, Mondays). Adjacent comment updated to match.

Nothing else is touched — `workflow_dispatch`, `SYNC_PATHS`, `EXCLUDE_PATHS`, and the rest of the workflow are unchanged. Manual runs via `workflow_dispatch` remain available for on-demand syncs.

## Why

Daily runs are more frequent than needed for template propagation; weekly cadence reduces noise and CI usage while still keeping downstream repos current.