### PR TITLE
Remove path filters from required-check workflows

### DIFF
--- a/.claude/hooks/safe-launch.sh
+++ b/.claude/hooks/safe-launch.sh
@@ -24,7 +24,9 @@
 set -uo pipefail
 
 target="${1:-}"
-shift || true
+# Drop the target arg only when present; `|| true` would also swallow an
+# unexpected shift failure (CLAUDE.md: branch on the condition instead).
+[[ $# -gt 0 ]] && shift
 
 if [[ -z "$target" ]] || [[ ! -f "$target" ]]; then
   echo "safe-launch: missing target hook: $target" >&2

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -33,6 +33,10 @@ webi_install_if_missing() {
   if ! command -v "$cmd" &>/dev/null; then
     local installer
     installer=$(mktemp "${TMPDIR:-/tmp}/webi-${cmd}-XXXXXX.sh")
+    # webi.sh serves a per-tool bootstrap generated on the fly, so there is no
+    # stable digest to pin; we harden with HTTPS-only (--proto =https), the
+    # shebang check below, and a version-pinned $pkg instead.
+    # pin-exempt: webi.sh bootstrap is generated per-request, no stable digest
     if curl --proto '=https' -fsSL "https://webi.sh/$pkg" -o "$installer" 2>/dev/null; then
       if head -n 1 "$installer" | grep -q '^#!'; then
         sh "$installer" >/dev/null 2>&1 || warn "Failed to install $cmd"

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -35,7 +35,7 @@ jobs:
   # protected branch never gets stuck on a check that never reports. Each
   # workflow's gate has a distinct name so it can be marked Required without
   # colliding with the others in branch-protection settings.
-  format-check-passed:
+  format-check-passed: # required-check: true
     if: always()
     needs: [format]
     runs-on: ubuntu-latest

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -17,7 +17,7 @@ on:
       - ".pre-commit-config.yaml"
       - ".github/scripts/run-hook-lifecycle.sh"
       - ".github/workflows/hook-lifecycle.yaml"
-  pull_request:
+  pull_request: # not-required-check: single advisory job, path-gated, no required reporter
     paths:
       - ".claude/hooks/**"
       - ".hooks/**"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,23 +1,13 @@
 name: Lint
 
+# No paths filter: lint-passed is a required status check, so the workflow must
+# always fire and report — a path-gated required check hangs at
+# "Expected — Waiting" forever when a PR doesn't touch the filtered paths. The
+# lint job no-ops when no lint/check script is configured, so it stays cheap.
 on:
   push:
     branches: ["main"]
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - "package.json"
-      - ".github/workflows/lint.yaml"
   pull_request:
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - "package.json"
-      - ".github/workflows/lint.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -64,7 +54,7 @@ jobs:
 
   # Stable Required check: runs even when `lint` is cancelled/skipped, so a
   # protected branch never gets stuck on a check that never reports.
-  lint-passed:
+  lint-passed: # required-check: true
     if: always()
     needs: [lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -1,23 +1,13 @@
 name: Node tests
 
+# No paths filter: node-tests-passed is a required status check, so the workflow
+# must always fire and report — a path-gated required check hangs at
+# "Expected — Waiting" forever when a PR doesn't touch the filtered paths. The
+# test job no-ops when no test script is configured, so it stays cheap.
 on:
   push:
     branches: ["main"]
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - "package.json"
-      - ".github/workflows/node-tests.yaml"
   pull_request:
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "**/*.js"
-      - "**/*.jsx"
-      - "package.json"
-      - ".github/workflows/node-tests.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -54,7 +44,7 @@ jobs:
 
   # Stable Required check: runs even when `test` is cancelled/skipped, so a
   # protected branch never gets stuck on a check that never reports.
-  node-tests-passed:
+  node-tests-passed: # required-check: true
     if: always()
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -27,7 +27,7 @@ jobs:
 
   # Stable Required check: runs even when `pre-commit` is cancelled/skipped, so
   # a protected branch never gets stuck on a check that never reports.
-  pre-commit-passed:
+  pre-commit-passed: # required-check: true
     if: always()
     needs: [pre-commit]
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -1,21 +1,11 @@
 name: Validate config
+# No paths filter: validate-config-passed is a required status check, so the
+# workflow must always fire and report — a path-gated required check hangs at
+# "Expected — Waiting" forever when a PR doesn't touch the filtered paths.
 on:
   push:
-    paths:
-      - ".claude/**"
-      - ".hooks/**"
-      - ".github/workflows/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - "uv.lock"
+    branches: ["main"]
   pull_request:
-    paths:
-      - ".claude/**"
-      - ".hooks/**"
-      - ".github/workflows/**"
-      - "tests/**"
-      - "pyproject.toml"
-      - "uv.lock"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -46,7 +36,7 @@ jobs:
 
   # Stable Required check: runs even when `validate` is cancelled/skipped, so a
   # protected branch never gets stuck on a check that never reports.
-  validate-config-passed:
+  validate-config-passed: # required-check: true
     if: always()
     needs: [validate]
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
     paths:
       - ".github/**"
-  pull_request:
+  pull_request: # not-required-check: single advisory job, path-gated, no required reporter
     paths:
       - ".github/**"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,20 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  # Honesty + identity CI lints: catch a green check that hides a failed
+  # command (pipefail/|| true/2>/dev/null), a path-filtered required check that
+  # hangs forever, or a mutable base-image/download pin. Tier 2 adds the
+  # required-check-shape lints this template's workflows already follow
+  # (classified always() reporters, explicit concurrency, externalized run
+  # blocks). check-claude-model enforces an explicit --model on the
+  # claude-code-action steps this template ships.
+  - repo: https://github.com/alexander-turner/ci-truth-serum
+    rev: 55b3c2af0b83f77f15eba92aac743bdf8ff254be # newest (no tag cut yet)
+    hooks:
+      - id: check-tier1
+      - id: check-tier2
+      - id: check-claude-model
+
   - repo: local
     hooks:
       - id: zizmor


### PR DESCRIPTION
Removes `paths` filters from three required-status-check workflows (`lint.yaml`, `node-tests.yaml`, `validate-config.yaml`) and adds the `ci-truth-serum` pre-commit hook to catch this pattern in the future.

## Changes

- **lint.yaml, node-tests.yaml, validate-config.yaml**: Removed `paths` filters from both `push` and `pull_request` triggers. These workflows have required-check summary jobs that must always report a status; path-gated required checks hang at "Expected — Waiting" forever when a PR doesn't touch the filtered paths. The underlying jobs are cheap (they no-op when no script is configured), so firing unconditionally is safe.

- **.pre-commit-config.yaml**: Added `ci-truth-serum` hook (tier 1 + tier 2 + claude-model checks) to catch path-filtered required checks, hidden command failures, and other CI hygiene issues in future commits.

- **Workflow summary jobs**: Added `# required-check: true` comments to all required-check summary jobs (`lint-passed`, `node-tests-passed`, `validate-config-passed`, `format-check-passed`, `pre-commit-passed`) for clarity and to satisfy the new linter.

- **Advisory workflows**: Added `# not-required-check:` comments to `hook-lifecycle.yaml` and `zizmor.yaml` pull_request triggers to document that these are single advisory jobs with no required reporter.

- **.claude/hooks/safe-launch.sh**: Replaced `shift || true` with `[[ $# -gt 0 ]] && shift` to avoid silently swallowing unexpected shift failures (per CLAUDE.md guidance on branching on exit codes instead of using `|| true`).

- **.claude/hooks/session-setup.sh**: Added explanatory comment about webi.sh bootstrap pinning and added `pin-exempt:` marker for the curl call that fetches the generated installer.

## Implementation Notes

The path-filter removal follows the pattern already documented in the workflows: required checks must always fire and report, or they leave PRs stuck in "Expected — Waiting" state. The `ci-truth-serum` linter now enforces this pattern automatically on future changes.

https://claude.ai/code/session_01EJWpZuvcJLqbcMGrEdu11Y