### PR TITLE
ci: add sync-required-checks workflow to apply required-check annotations

### DIFF
--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -1,0 +1,64 @@
+name: Sync required status checks
+
+# Apply half of the check-required-reporter pair. The pre-commit hook forces
+# every always() reporter to carry a `# required-check: true|false` annotation;
+# the apply tool (hosted in ci-truth-serum) reads those annotations (the SSOT),
+# expands each required job's name across its own matrix, and rewrites the
+# branch-protection ruleset's required_status_checks to exactly that set — so a
+# reporter's classification and the gate that actually blocks merges can never
+# silently drift apart.
+#
+# Runs only post-merge on main (and on demand). It mutates branch protection, so
+# it needs a token with `administration: write`; the stock GITHUB_TOKEN cannot
+# edit rulesets. Provide it as the RULESET_SYNC_TOKEN secret — the job fails loud
+# if it is absent. Not a required check itself (no pull_request trigger).
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/**
+      - .pre-commit-config.yaml
+  workflow_dispatch:
+    inputs:
+      check-only:
+        description: "Report drift without mutating the ruleset"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize ruleset writes so two back-to-back merges can't race the PATCH.
+  # Static group is intentional and safe here: this workflow has no pull_request
+  # trigger, so it never backs a required check that a cancelled run could hang.
+  group: sync-required-checks
+  cancel-in-progress: false
+  # static-concurrency-ok: not a required check (push/dispatch only)
+
+jobs:
+  sync:
+    name: Sync ruleset to required-check annotations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install the apply tool (ci-truth-serum)
+        # Pin to the same ci-truth-serum commit the pre-commit hook uses so the
+        # lint and the apply step share one parser version.
+        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@55b3c2af0b83f77f15eba92aac743bdf8ff254be"
+
+      - name: Sync required status checks
+        env:
+          GH_TOKEN: ${{ secrets.RULESET_SYNC_TOKEN }}
+          REPO: ${{ github.repository }}
+          CHECK_ONLY: ${{ inputs.check-only }}
+        run: |
+          args=(--repo "$REPO")
+          if [[ "$CHECK_ONLY" == "true" ]]; then
+            args+=(--check)
+          fi
+          python3 -m hooks.sync_required_checks "${args[@]}"


### PR DESCRIPTION
## Summary

- The `ci-truth-serum` pre-commit lints already force every `if: always()` reporter job to carry a `# required-check: true|false` annotation (the SSOT), but nothing applied those annotations to branch protection — keeping the ruleset in sync was manual.
- This adds the missing back half (mirroring `claude-guard`'s `sync-required-checks.yaml`): a workflow that reads the annotations and rewrites the branch-protection ruleset's `required_status_checks` to exactly match, so a reporter's classification and the gate that blocks merges can't silently drift apart.

## Changes

- Add `.github/workflows/sync-required-checks.yaml`:
  - Triggers post-merge on `main` (paths: `.github/workflows/**`, `.pre-commit-config.yaml`) plus manual `workflow_dispatch` with a `check-only` drift-report mode.
  - Runs `python3 -m hooks.sync_required_checks --repo $REPO`, pinning `ci-truth-serum` to the same commit this template's pre-commit hook uses (`55b3c2a`) so the lint and the apply step share one parser version.
  - Static serialized concurrency (safe — no `pull_request` trigger, so it never backs a required check a cancelled run could hang), `persist-credentials: false`, checkout pinned to SHA.
  - Intentionally **not** a required check itself.

## Configuration required

The workflow needs a **`RULESET_SYNC_TOKEN`** repo secret with `administration: write` scope — the stock `GITHUB_TOKEN` cannot edit rulesets, and the job fails loud if the token is absent.

## Testing

- `zizmor --offline` on the new workflow: no findings.
- Verified `hooks/sync_required_checks` exists at the pinned `ci-truth-serum` commit and exposes the `--repo`/`--check` CLI used here.
- `actionlint`, `check-tier1`, and `check-tier2` couldn't run locally (the sandbox proxy blocks pre-commit from fetching hook repos); CI runs the full lint set. The file is a faithful port of `claude-guard`'s, which already passes those exact lints.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJcUErcydLCWrh4K74YrQk)_