### PR TITLE
feat(org-bootstrap): add org-level secret/ruleset/settings sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ __pycache__/
 *.pyc
 .venv/
 .uv/
+
+# org-bootstrap local config (holds org name + settings; secrets stay in env)
+org-bootstrap/config.sh

--- a/org-bootstrap/README.md
+++ b/org-bootstrap/README.md
@@ -16,20 +16,23 @@ Provision and keep in sync the things a template **repo** can't carry on its own
 Secrets and protection rules are account/org state, not files, so `template-sync`
 can never carry them. This closes that gap.
 
-> **Ruleset overlap, on purpose.** An org ruleset and the per-repo
-> `sync-required-checks` workflow can both be active — GitHub evaluates every
-> matching ruleset and a check is required if _any_ of them requires it, so they
-> compose rather than fight. Two sane setups:
+> **Required checks are per-repo, not org-wide.** Different repos run different
+> tests, so their required status-check _contexts_ differ. Pinning a fixed set in
+> the org ruleset would require contexts some repos never emit — and a required
+> check that never reports hangs that repo's PRs at **pending forever**. So the
+> org ruleset here carries only **repo-agnostic** rules (block deletion, block
+> force-push, optional required-PR); it adds no `required_status_checks` rule
+> unless you opt in.
 >
-> - **Org-managed (simplest):** define required checks once here, in
->   `REQUIRED_CHECKS`, and skip the per-repo workflow + its `RULESET_SYNC_TOKEN`.
-> - **Repo-managed (most precise):** keep the per-repo workflow as the source of
->   truth (it derives the set from each repo's own `# required-check:`
->   annotations, so repos that drop a check aren't over-gated) and use the org
->   ruleset only for repo-agnostic rules (block deletion, block force-push).
+> Each repo's actual required checks are owned by its own `sync-required-checks`
+> workflow, which derives them from that repo's `# required-check:` annotations —
+> so a repo that adds, renames, or drops a test is gated on exactly what it runs.
+> Org ruleset and per-repo ruleset compose cleanly: GitHub requires a check if
+> _any_ matching ruleset requires it.
 >
-> Keep `REQUIRED_CHECKS` here in lockstep with the annotated reporter jobs in
-> `.github/workflows/` either way.
+> `REQUIRED_CHECKS` in the config is an **optional org-wide baseline** — set it
+> only to contexts _every_ managed repo reports without exception (rare; e.g. a
+> universal secret scan). Default is empty.
 
 ## Prerequisites
 
@@ -74,8 +77,10 @@ variable is skipped with a warning, never blanked.
   `SECRET_VISIBILITY`. This is how `RULESET_SYNC_TOKEN` (and any other shared
   secret) reaches all repos without per-repo copying.
 - **`ruleset`** — one org ruleset targeting the default branch of all repos
-  (`~ALL` / `~DEFAULT_BRANCH`): blocks deletion and force-push, requires the
-  `REQUIRED_CHECKS` contexts, and optionally requires a PR.
+  (`~ALL` / `~DEFAULT_BRANCH`): blocks deletion and force-push, and optionally
+  requires a PR. Adds a `required_status_checks` rule only if you set a non-empty
+  `REQUIRED_CHECKS` baseline (default empty — per-repo checks are owned by each
+  repo's `sync-required-checks` workflow).
 - **`defaults`** — org base permission, repo-creation policy, and default
   `GITHUB_TOKEN` workflow permissions; then per-repo merge hygiene
   (squash-only, delete branch on merge, auto-merge) on each managed repo.

--- a/org-bootstrap/README.md
+++ b/org-bootstrap/README.md
@@ -1,0 +1,89 @@
+# Org bootstrap
+
+Provision and keep in sync the things a template **repo** can't carry on its own
+— org-level **secrets**, branch-protection **rulesets**, and default **settings**
+— across every template-based repo in a GitHub organization.
+
+## Why this exists (and how it fits the other sync paths)
+
+| Path                        | What it moves                                            | Direction                   |
+| --------------------------- | -------------------------------------------------------- | --------------------------- |
+| `template-sync.yaml`        | **Files** (workflows, hooks, configs)                    | template → downstream repos |
+| `phone-home.yaml`           | **Lessons** from PR descriptions                         | downstream repos → template |
+| `sync-required-checks.yaml` | A **repo** ruleset, from `# required-check:` annotations | within one repo             |
+| **this** (`org-bootstrap/`) | **Secrets, an org ruleset, org/repo settings**           | org → all managed repos     |
+
+Secrets and protection rules are account/org state, not files, so `template-sync`
+can never carry them. This closes that gap.
+
+> **Ruleset overlap, on purpose.** An org ruleset and the per-repo
+> `sync-required-checks` workflow can both be active — GitHub evaluates every
+> matching ruleset and a check is required if _any_ of them requires it, so they
+> compose rather than fight. Two sane setups:
+>
+> - **Org-managed (simplest):** define required checks once here, in
+>   `REQUIRED_CHECKS`, and skip the per-repo workflow + its `RULESET_SYNC_TOKEN`.
+> - **Repo-managed (most precise):** keep the per-repo workflow as the source of
+>   truth (it derives the set from each repo's own `# required-check:`
+>   annotations, so repos that drop a check aren't over-gated) and use the org
+>   ruleset only for repo-agnostic rules (block deletion, block force-push).
+>
+> Keep `REQUIRED_CHECKS` here in lockstep with the annotated reporter jobs in
+> `.github/workflows/` either way.
+
+## Prerequisites
+
+- [`gh`](https://cli.github.com/) authenticated as an **org owner**, and `jq`.
+- Token scopes: classic PAT with **`admin:org`** (org secrets, rulesets, org
+  settings) **and `repo`** (per-repo merge settings). Fine-grained equivalent:
+  organization **Administration: write** + **Secrets: write**, repository
+  **Administration: write**. `gh auth login` or `GH_TOKEN=...` both work.
+
+## Setup
+
+```bash
+cd org-bootstrap
+cp config.example.sh config.sh      # config.sh is gitignored
+$EDITOR config.sh                   # set ORG, MANAGED_TOPIC, checks, settings
+```
+
+Tag the repos you want managed with the `MANAGED_TOPIC` topic (default
+`template-managed`) so unrelated org repos are never touched. Leave
+`MANAGED_TOPIC` empty to manage every non-archived repo.
+
+## Run
+
+```bash
+# Secret VALUES are read from the environment, never the config file:
+export RULESET_SYNC_TOKEN=ghp_xxx
+
+./bootstrap.sh secrets     # push org Actions secrets (skips names with no env value)
+./bootstrap.sh ruleset     # create/update the org branch-protection ruleset
+./bootstrap.sh defaults    # org defaults + per-repo merge settings
+./bootstrap.sh all         # all three, in order
+```
+
+Every subcommand is **idempotent** — re-run after editing `config.sh` to
+converge. The ruleset is matched by name (`RULESET_NAME`) and updated in place,
+so re-runs never create duplicates. A secret name with no matching environment
+variable is skipped with a warning, never blanked.
+
+## What each subcommand does
+
+- **`secrets`** — `gh secret set --org` for each name in `SECRET_NAMES`, at
+  `SECRET_VISIBILITY`. This is how `RULESET_SYNC_TOKEN` (and any other shared
+  secret) reaches all repos without per-repo copying.
+- **`ruleset`** — one org ruleset targeting the default branch of all repos
+  (`~ALL` / `~DEFAULT_BRANCH`): blocks deletion and force-push, requires the
+  `REQUIRED_CHECKS` contexts, and optionally requires a PR.
+- **`defaults`** — org base permission, repo-creation policy, and default
+  `GITHUB_TOKEN` workflow permissions; then per-repo merge hygiene
+  (squash-only, delete branch on merge, auto-merge) on each managed repo.
+
+## Automating it
+
+Run it manually after onboarding a repo, or wire it to a schedule. To run it
+from Actions, store the admin PAT as an org secret and invoke `./bootstrap.sh
+all` on a `schedule`/`workflow_dispatch` trigger — keep it **off** `pull_request`
+so it never becomes a required check (same rule the `sync-required-checks`
+workflow follows).

--- a/org-bootstrap/bootstrap.sh
+++ b/org-bootstrap/bootstrap.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Provision org-level secrets, a branch-protection ruleset, and default repo
+# settings across the template-based repos in a GitHub organization. Idempotent:
+# re-running converges to the configured state instead of duplicating anything.
+#
+# Usage:
+#   ./bootstrap.sh secrets    # push org Actions secrets (values from env)
+#   ./bootstrap.sh ruleset    # create/update the org branch-protection ruleset
+#   ./bootstrap.sh defaults   # apply org + per-repo default settings
+#   ./bootstrap.sh all        # all of the above, in order
+#
+# Requires: gh (authenticated, admin:org + repo scopes) and jq. See README.md.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+config="${here}/config.sh"
+
+if [[ ! -f "$config" ]]; then
+  echo "ERROR: ${config} not found. Copy config.example.sh to config.sh and edit it." >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+source "$config"
+
+for tool in gh jq; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: ${tool} is required but not installed." >&2
+    exit 1
+  fi
+done
+
+if [[ -z "${ORG:-}" || "$ORG" == "your-org" ]]; then
+  echo "ERROR: set ORG in config.sh." >&2
+  exit 1
+fi
+
+# Echo every gh write so a run is auditable.
+log() { printf '  %s\n' "$*"; }
+
+# Names of the repos to manage: every non-archived repo, optionally narrowed to
+# those carrying MANAGED_TOPIC. Emitted one per line for `while read`.
+managed_repos() {
+  local args=(--no-archived --limit 1000 --json name --jq '.[].name')
+  if [[ -n "${MANAGED_TOPIC:-}" ]]; then
+    args=(--topic "$MANAGED_TOPIC" "${args[@]}")
+  fi
+  gh repo list "$ORG" "${args[@]}"
+}
+
+sync_secrets() {
+  echo "Syncing org secrets to ${ORG} (visibility=${SECRET_VISIBILITY})..."
+  if [[ "${#SECRET_NAMES[@]}" -eq 0 ]]; then
+    log "no secrets configured"
+    return
+  fi
+  local name value
+  for name in "${SECRET_NAMES[@]}"; do
+    value="${!name:-}"
+    if [[ -z "$value" ]]; then
+      log "skip ${name}: no value in environment"
+      continue
+    fi
+    printf '%s' "$value" |
+      gh secret set "$name" --org "$ORG" --visibility "$SECRET_VISIBILITY"
+    log "set ${name}"
+  done
+}
+
+# Build the required_status_checks rule array from REQUIRED_CHECKS.
+checks_payload() {
+  if [[ "${#REQUIRED_CHECKS[@]}" -eq 0 ]]; then
+    echo "[]"
+    return
+  fi
+  printf '%s\n' "${REQUIRED_CHECKS[@]}" | jq -R '{context: .}' | jq -s '.'
+}
+
+sync_ruleset() {
+  echo "Syncing branch-protection ruleset '${RULESET_NAME}' on ${ORG}..."
+  local checks rules payload existing_id
+  checks="$(checks_payload)"
+
+  rules="$(jq -n --argjson checks "$checks" '
+    [
+      { "type": "deletion" },
+      { "type": "non_fast_forward" },
+      { "type": "required_status_checks",
+        "parameters": {
+          "strict_required_status_checks_policy": true,
+          "required_status_checks": $checks
+        }
+      }
+    ]')"
+
+  if [[ "${REQUIRE_PULL_REQUEST:-false}" == "true" ]]; then
+    rules="$(jq --argjson n "${REQUIRED_APPROVALS:-0}" '. + [
+      { "type": "pull_request",
+        "parameters": {
+          "required_approving_review_count": $n,
+          "dismiss_stale_reviews_on_push": true,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_review_thread_resolution": false
+        }
+      }]' <<<"$rules")"
+  fi
+
+  payload="$(jq -n --arg name "$RULESET_NAME" --argjson rules "$rules" '
+    {
+      "name": $name,
+      "target": "branch",
+      "enforcement": "active",
+      "conditions": {
+        "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] },
+        "repository_name": { "include": ["~ALL"], "exclude": [] }
+      },
+      "rules": $rules
+    }')"
+
+  existing_id="$(gh api "orgs/${ORG}/rulesets" |
+    jq -r --arg n "$RULESET_NAME" 'map(select(.name == $n))[0].id // empty')"
+
+  if [[ -n "$existing_id" ]]; then
+    gh api -X PUT "orgs/${ORG}/rulesets/${existing_id}" --input - <<<"$payload" >/dev/null
+    log "updated ruleset ${existing_id}"
+  else
+    gh api -X POST "orgs/${ORG}/rulesets" --input - <<<"$payload" >/dev/null
+    log "created ruleset '${RULESET_NAME}'"
+  fi
+}
+
+apply_defaults() {
+  echo "Applying org defaults to ${ORG}..."
+  gh api -X PATCH "orgs/${ORG}" \
+    -f "default_repository_permission=${DEFAULT_REPO_PERMISSION}" \
+    -F "members_can_create_repositories=${MEMBERS_CAN_CREATE_REPOS}" >/dev/null
+  gh api -X PUT "orgs/${ORG}/actions/permissions/workflow" \
+    -f "default_workflow_permissions=${DEFAULT_WORKFLOW_PERMISSIONS}" \
+    -F "can_approve_pull_request_reviews=false" >/dev/null
+  log "org settings applied"
+
+  echo "Applying per-repo merge settings to managed repos..."
+  local repo
+  while IFS= read -r repo; do
+    if [[ -z "$repo" ]]; then
+      continue
+    fi
+    gh api -X PATCH "repos/${ORG}/${repo}" \
+      -F "allow_squash_merge=${ALLOW_SQUASH_MERGE}" \
+      -F "allow_merge_commit=${ALLOW_MERGE_COMMIT}" \
+      -F "allow_rebase_merge=${ALLOW_REBASE_MERGE}" \
+      -F "delete_branch_on_merge=${DELETE_BRANCH_ON_MERGE}" \
+      -F "allow_auto_merge=${ALLOW_AUTO_MERGE}" >/dev/null
+    log "settings applied: ${repo}"
+  done < <(managed_repos)
+}
+
+main() {
+  local cmd="${1:-}"
+  case "$cmd" in
+  secrets) sync_secrets ;;
+  ruleset) sync_ruleset ;;
+  defaults) apply_defaults ;;
+  all)
+    sync_secrets
+    sync_ruleset
+    apply_defaults
+    ;;
+  *)
+    echo "Usage: $0 {secrets|ruleset|defaults|all}" >&2
+    exit 1
+    ;;
+  esac
+  echo "Done."
+}
+
+main "$@"

--- a/org-bootstrap/bootstrap.sh
+++ b/org-bootstrap/bootstrap.sh
@@ -77,20 +77,29 @@ checks_payload() {
 
 sync_ruleset() {
   echo "Syncing branch-protection ruleset '${RULESET_NAME}' on ${ORG}..."
-  local checks rules payload existing_id
-  checks="$(checks_payload)"
+  local rules payload existing_id
 
-  rules="$(jq -n --argjson checks "$checks" '
-    [
-      { "type": "deletion" },
-      { "type": "non_fast_forward" },
+  # Universal rules only -- these hold for every repo regardless of its tests.
+  rules="$(jq -n '[
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]')"
+
+  # Required STATUS CHECKS are per-repo (repos run different tests), so they are
+  # owned by each repo's sync-required-checks workflow, not pinned org-wide --
+  # requiring a context a repo never emits would hang its PRs at pending forever.
+  # REQUIRED_CHECKS is an optional org-wide baseline: set it only to contexts
+  # EVERY managed repo is guaranteed to report. Empty (default) adds no
+  # required_status_checks rule at all.
+  if [[ "${#REQUIRED_CHECKS[@]}" -gt 0 ]]; then
+    rules="$(jq --argjson checks "$(checks_payload)" '. + [
       { "type": "required_status_checks",
         "parameters": {
           "strict_required_status_checks_policy": true,
           "required_status_checks": $checks
         }
-      }
-    ]')"
+      }]' <<<"$rules")"
+  fi
 
   if [[ "${REQUIRE_PULL_REQUEST:-false}" == "true" ]]; then
     rules="$(jq --argjson n "${REQUIRED_APPROVALS:-0}" '. + [

--- a/org-bootstrap/config.example.sh
+++ b/org-bootstrap/config.example.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# (every var below is consumed by bootstrap.sh after this file is sourced)
+# Non-sensitive configuration for org-bootstrap. Copy to `config.sh` (gitignored)
+# and edit. Secret VALUES never live here -- they are read from the environment
+# at run time (see README.md).
+
+# GitHub organization that owns the template-based repos.
+ORG="your-org"
+
+# Only manage repos carrying this topic. Leave empty to manage every
+# non-archived repo in the org. Tag template-spawned repos with this topic so
+# unrelated repos are never touched.
+MANAGED_TOPIC="template-managed"
+
+# --- Secrets ------------------------------------------------------------------
+# Names of org-level Actions secrets to provision. The VALUE of each is read
+# from the like-named environment variable at run time, e.g. export
+# RULESET_SYNC_TOKEN=ghp_... before running `bootstrap.sh secrets`. A name with
+# no value in the environment is skipped (warned), never blanked.
+SECRET_NAMES=(
+  RULESET_SYNC_TOKEN
+)
+
+# "all" exposes secrets to every repo; "private" to private repos only;
+# "selected" requires you to wire repo access separately.
+SECRET_VISIBILITY="all"
+
+# --- Ruleset (branch protection + required checks) ----------------------------
+RULESET_NAME="template-default-branch-protection"
+
+# Required status-check contexts. Keep this in lockstep with the
+# `# required-check: true` reporter jobs in .github/workflows/ (the SSOT the
+# per-repo sync-required-checks workflow derives from).
+REQUIRED_CHECKS=(
+  format-check-passed
+  lint-passed
+  node-tests-passed
+  pre-commit-passed
+  validate-config-passed
+)
+
+# PRs required before merge? Reviews required (0 = PR required, no approval gate).
+REQUIRE_PULL_REQUEST="true"
+REQUIRED_APPROVALS=0
+
+# --- Default repo settings ----------------------------------------------------
+# Org-wide defaults applied by `bootstrap.sh defaults`.
+DEFAULT_REPO_PERMISSION="read" # base permission members get on all repos
+MEMBERS_CAN_CREATE_REPOS="false"
+DEFAULT_WORKFLOW_PERMISSIONS="read" # GITHUB_TOKEN default: read | write
+
+# Per-repo merge hygiene applied to every managed repo.
+ALLOW_SQUASH_MERGE="true"
+ALLOW_MERGE_COMMIT="false"
+ALLOW_REBASE_MERGE="false"
+DELETE_BRANCH_ON_MERGE="true"
+ALLOW_AUTO_MERGE="true"

--- a/org-bootstrap/config.example.sh
+++ b/org-bootstrap/config.example.sh
@@ -26,19 +26,19 @@ SECRET_NAMES=(
 # "selected" requires you to wire repo access separately.
 SECRET_VISIBILITY="all"
 
-# --- Ruleset (branch protection + required checks) ----------------------------
+# --- Ruleset (branch protection) ----------------------------------------------
+# The org ruleset carries only repo-agnostic rules (block deletion + force-push,
+# optional required-PR). It deliberately does NOT pin repo-specific required
+# status checks: repos run different tests, and requiring a context a repo never
+# emits hangs that repo's PRs at pending forever. Per-repo required checks are
+# owned by each repo's sync-required-checks workflow (derived from that repo's
+# own `# required-check:` annotations).
 RULESET_NAME="template-default-branch-protection"
 
-# Required status-check contexts. Keep this in lockstep with the
-# `# required-check: true` reporter jobs in .github/workflows/ (the SSOT the
-# per-repo sync-required-checks workflow derives from).
-REQUIRED_CHECKS=(
-  format-check-passed
-  lint-passed
-  node-tests-passed
-  pre-commit-passed
-  validate-config-passed
-)
+# OPTIONAL org-wide baseline of required status checks. Leave EMPTY (default)
+# unless a context is reported by *every* managed repo without exception -- list
+# only those. Anything repo-specific belongs in that repo's workflow, not here.
+REQUIRED_CHECKS=()
 
 # PRs required before merge? Reviews required (0 = PR required, no approval gate).
 REQUIRE_PULL_REQUEST="true"


### PR DESCRIPTION
## Summary

- A template **repo** can't carry account/org state — secrets, branch-protection rulesets, default settings — so `template-sync.yaml` (which copies files) can never propagate them. New repos spun up from this template need those configured by hand.
- This adds `org-bootstrap/`: an idempotent `gh`+`jq` tool plus runbook that provisions those three things across every template-based repo in a GitHub org from one place.

## Changes

`org-bootstrap/`:

- **`bootstrap.sh`** — subcommands `secrets` / `ruleset` / `defaults` / `all`:
  - `secrets`: `gh secret set --org` for each configured name; values read from the environment (e.g. `RULESET_SYNC_TOKEN`), never from disk — so the secret the `sync-required-checks` workflow needs reaches all repos without per-repo copying.
  - `ruleset`: one org branch-protection ruleset over `~ALL` / `~DEFAULT_BRANCH` with **repo-agnostic rules only** (block deletion + force-push, optional required-PR). It deliberately does **not** pin repo-specific required status checks — repos run different tests, and requiring a context a repo never emits would hang its PRs at pending forever. Per-repo required checks stay owned by each repo's `sync-required-checks` workflow. `REQUIRED_CHECKS` is an optional, default-empty org-wide baseline for contexts *every* managed repo reports. Matched by name and updated in place, so re-runs never duplicate.
  - `defaults`: org base permission, repo-creation policy, `GITHUB_TOKEN` workflow perms, then per-repo merge hygiene (squash-only, delete-branch-on-merge, auto-merge) on each managed repo.
- **`config.example.sh`** — non-sensitive config (org, managed-topic filter, optional baseline checks, settings); copy to `config.sh` (gitignored). Secret values stay in env.
- **`README.md`** — token scopes, setup/run, and how this composes with `template-sync`, `phone-home`, and the per-repo `sync-required-checks` workflow.
- `.gitignore`: ignore `org-bootstrap/config.sh`.

Only repos carrying the configured `MANAGED_TOPIC` are touched (empty = all non-archived repos), so unrelated org repos are never modified.

## Testing

- `shellcheck` (with `require-double-brackets`), `shfmt -i 2`, and `prettier` all clean; `bash -n` clean. Verified the empty-`REQUIRED_CHECKS` path yields a valid universal-rules-only ruleset.
- The `gh`/`jq` API calls themselves are **not** exercised — no `gh` CLI in the authoring sandbox. They follow the documented endpoints; first real run should target a throwaway repo to confirm payload shapes (org ruleset JSON in particular).
