### PR TITLE
fix(setup): install Node deps with corepack-routed pnpm

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,8 +9,13 @@ echo "Setting up Claude automation template..."
 git config core.hooksPath .hooks
 
 if [[ -f package.json ]]; then
-  # Install pnpm if not available
-  if ! command -v pnpm &>/dev/null; then
+  # Route through corepack so the pnpm version actually used matches the
+  # "packageManager" pin in package.json — a bare `pnpm` on PATH (e.g. from
+  # `npm install -g pnpm`) bypasses that pin and can rewrite the lockfile
+  # into an off-version format.
+  if command -v corepack &>/dev/null; then
+    corepack enable
+  else
     echo "Installing pnpm..."
     npm install -g pnpm
   fi


### PR DESCRIPTION
## Summary
- `setup.sh` fell back to `npm install -g pnpm` when pnpm wasn't found, then ran `pnpm install` against that bare binary
- A bare pnpm on PATH bypasses the `packageManager: "pnpm@11.8.0"` pin in `package.json`, so installs can silently drift to whatever pnpm version happens to be globally installed and rewrite the lockfile in an off-version format
- Route through `corepack enable` instead, which honors the pin

## Test plan
- [x] `bash -n setup.sh`
- [x] Reviewed diff — only the pnpm-install branch changed

Closes #294.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGoKWFnakX37B8hdoFhCRj)_