### PR TITLE
fix(hooks): shell-quote values written into the sourced env file

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -17,6 +17,25 @@ warn() {
 }
 is_root() { [[ "$(id -u)" = "0" ]]; }
 
+# Append `export NAME=VALUE` to CLAUDE_ENV_FILE with VALUE shell-quoted via
+# bash's @Q operator. Interpolating a value straight into a double-quoted
+# string (e.g. "export X=\"$val\"") is not escaping it — a value containing a
+# `"` or `$` becomes arbitrary code in whatever later sources this file.
+emit_export() {
+  local name="$1" value="$2"
+  [[ -n "${CLAUDE_ENV_FILE:-}" ]] || return 0
+  echo "export $name=${value@Q}" >>"$CLAUDE_ENV_FILE"
+}
+
+# Append `export PATH=<quoted dir>:$PATH` — like emit_export, but $PATH must
+# stay unexpanded so it resolves against whatever PATH is active when the
+# file is later sourced, not the PATH at generation time.
+emit_path_prepend() {
+  local dir="$1"
+  [[ -n "${CLAUDE_ENV_FILE:-}" ]] || return 0
+  echo "export PATH=${dir@Q}:\$PATH" >>"$CLAUDE_ENV_FILE"
+}
+
 # Install a command via uv if missing
 uv_install_if_missing() {
   local cmd="$1" pkg="${2:-$1}"
@@ -88,9 +107,7 @@ _check_hook_syntax
 #######################################
 
 export PATH="$HOME/.local/bin:$PATH"
-if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
-  echo "export PATH=\"\$HOME/.local/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
-fi
+emit_path_prepend "$HOME/.local/bin"
 
 #######################################
 # Tool installation (optional - warn on failure)
@@ -151,9 +168,7 @@ if [[ -z "${GH_REPO:-}" ]]; then
     GH_REPO="${BASH_REMATCH[1]}"
     GH_REPO="${GH_REPO%.git}"
     export GH_REPO
-    if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
-      echo "export GH_REPO=\"$GH_REPO\"" >>"$CLAUDE_ENV_FILE"
-    fi
+    emit_export GH_REPO "$GH_REPO"
   fi
 fi
 
@@ -207,9 +222,7 @@ if [[ -f "$PROJECT_DIR/uv.lock" ]] && command -v uv &>/dev/null; then
   # Add .venv/bin to PATH so Python tools are available to hooks
   if [[ -d "$PROJECT_DIR/.venv/bin" ]]; then
     export PATH="$PROJECT_DIR/.venv/bin:$PATH"
-    if [[ -n "${CLAUDE_ENV_FILE:-}" ]]; then
-      echo "export PATH=\"$PROJECT_DIR/.venv/bin:\$PATH\"" >>"$CLAUDE_ENV_FILE"
-    fi
+    emit_path_prepend "$PROJECT_DIR/.venv/bin"
   fi
 fi
 

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -92,7 +92,14 @@ def test_gh_repo_extraction(
     if expected is None:
         assert exports == [], f"expected no GH_REPO export, got: {exports}"
     else:
-        assert exports == [f'export GH_REPO="{expected}"']
+        assert len(exports) == 1, f"expected exactly one GH_REPO export, got: {exports}"
+        sourced = subprocess.run(
+            ["bash", "-c", f"{exports[0]}; printf '%s' \"$GH_REPO\""],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert sourced.stdout == expected
 
 
 def test_preserves_pre_set_gh_repo(sandbox: Path) -> None:


### PR DESCRIPTION
## Summary
- `session-setup.sh` interpolated `GH_REPO` and `$PROJECT_DIR/.venv/bin` straight into a double-quoted `export ...` line appended to `$CLAUDE_ENV_FILE`, which is sourced later in the session
- Double-quoting a value in a generated shell line isn't escaping it — a value containing a `"` or `$` would execute as code when the file is sourced
- Added `emit_export` (quotes a value via bash's `${var@Q}`) and `emit_path_prepend` (quotes the directory but leaves the trailing `$PATH` unexpanded so it resolves at source-time, not generation-time), and routed all three call sites through them

## Test plan
- [x] `bash -n .claude/hooks/session-setup.sh`
- [x] Verified `${var@Q}` output for values containing `"` and `/` manually
- [x] Reviewed diff for behavior parity (PATH-prepend semantics preserved)

Closes #287 (the escaping lesson; the symlink-resolver and `set -e` arithmetic lessons in that issue don't apply — no hand-rolled `readlink -f` or bare `(( expr ))` exists in this repo).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGoKWFnakX37B8hdoFhCRj)_