### PR TITLE
fix(ci): wrap template-sync.sh in main() to survive self-sync

### DIFF
--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -22,307 +22,319 @@
 
 set -euo pipefail
 
-SYNC_PATHS="${SYNC_PATHS:-}"
-EXCLUDE_PATHS="${EXCLUDE_PATHS:-}"
-: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+# Wrap all logic in main(), called as the final line. bash reads a running
+# script incrementally from disk, not all at once — this script overwrites
+# its own file when SYNC_PATHS includes the directory it lives in, so any
+# top-level statement below the self-overwrite would read shifted bytes.
+# Deferring everything behind main() forces bash to parse through this
+# file's closing brace and the trailing `main "$@"` call before executing
+# any of it.
+main() {
 
-# Allow tests to point at alternative temp dirs.
-WORK_DIR="${TEMPLATE_SYNC_WORK_DIR:-/tmp}"
-CONFLICT_FILES="$WORK_DIR/conflict_files.txt"
-CONFLICT_REPORT="$WORK_DIR/conflict_report.md"
-DELETED_FILES="$WORK_DIR/deleted_files.txt"
-AUTO_MERGED_FILES="$WORK_DIR/auto_merged_files.txt"
-PREV_TEMPLATE_FILES="$WORK_DIR/prev_template_files.txt"
+  SYNC_PATHS="${SYNC_PATHS:-}"
+  EXCLUDE_PATHS="${EXCLUDE_PATHS:-}"
+  : "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
 
-: >"$CONFLICT_FILES"
-: >"$CONFLICT_REPORT"
-: >"$DELETED_FILES"
-: >"$AUTO_MERGED_FILES"
+  # Allow tests to point at alternative temp dirs.
+  WORK_DIR="${TEMPLATE_SYNC_WORK_DIR:-/tmp}"
+  CONFLICT_FILES="$WORK_DIR/conflict_files.txt"
+  CONFLICT_REPORT="$WORK_DIR/conflict_report.md"
+  DELETED_FILES="$WORK_DIR/deleted_files.txt"
+  AUTO_MERGED_FILES="$WORK_DIR/auto_merged_files.txt"
+  PREV_TEMPLATE_FILES="$WORK_DIR/prev_template_files.txt"
 
-is_excluded() {
-  local candidate="$1" exclude
-  for exclude in $EXCLUDE_PATHS; do
-    [[ "$candidate" = "$exclude" ]] && return 0
-  done
-  return 1
-}
+  : >"$CONFLICT_FILES"
+  : >"$CONFLICT_REPORT"
+  : >"$DELETED_FILES"
+  : >"$AUTO_MERGED_FILES"
 
-# Generate a random sentinel suffix. Prefers /proc/sys/kernel/random/uuid
-# (always present on Linux runners and inside containers) but falls back to
-# `uuidgen` or $RANDOM so the script works in stripped-down environments.
-random_token() {
-  if [[ -r /proc/sys/kernel/random/uuid ]]; then
-    cat /proc/sys/kernel/random/uuid
-  elif command -v uuidgen >/dev/null 2>&1; then
-    uuidgen
-  else
-    printf '%s_%s_%s' "$$" "$RANDOM" "$RANDOM"
-  fi
-}
+  is_excluded() {
+    local candidate="$1" exclude
+    for exclude in $EXCLUDE_PATHS; do
+      [[ "$candidate" = "$exclude" ]] && return 0
+    done
+    return 1
+  }
 
-# Emit a multi-line GITHUB_OUTPUT block using a random-suffixed sentinel so
-# user-controlled content can't accidentally terminate the block early.
-emit_multiline_output() {
-  local key="$1" content="$2" sentinel
-  sentinel="EOF_$(random_token)"
+  # Generate a random sentinel suffix. Prefers /proc/sys/kernel/random/uuid
+  # (always present on Linux runners and inside containers) but falls back to
+  # `uuidgen` or $RANDOM so the script works in stripped-down environments.
+  random_token() {
+    if [[ -r /proc/sys/kernel/random/uuid ]]; then
+      cat /proc/sys/kernel/random/uuid
+    elif command -v uuidgen >/dev/null 2>&1; then
+      uuidgen
+    else
+      printf '%s_%s_%s' "$$" "$RANDOM" "$RANDOM"
+    fi
+  }
+
+  # Emit a multi-line GITHUB_OUTPUT block using a random-suffixed sentinel so
+  # user-controlled content can't accidentally terminate the block early.
+  emit_multiline_output() {
+    local key="$1" content="$2" sentinel
+    sentinel="EOF_$(random_token)"
+    {
+      echo "${key}<<${sentinel}"
+      printf '%s\n' "$content"
+      echo "$sentinel"
+    } >>"$GITHUB_OUTPUT"
+  }
+
+  #############################################
+  # Version tracking
+  #############################################
+
+  TEMPLATE_SHA=$(git -C _template rev-parse HEAD)
+  TEMPLATE_SHA_SHORT="${TEMPLATE_SHA:0:7}"
   {
-    echo "${key}<<${sentinel}"
-    printf '%s\n' "$content"
-    echo "$sentinel"
+    echo "template_sha=$TEMPLATE_SHA"
+    echo "template_sha_short=$TEMPLATE_SHA_SHORT"
   } >>"$GITHUB_OUTPUT"
-}
 
-#############################################
-# Version tracking
-#############################################
-
-TEMPLATE_SHA=$(git -C _template rev-parse HEAD)
-TEMPLATE_SHA_SHORT="${TEMPLATE_SHA:0:7}"
-{
-  echo "template_sha=$TEMPLATE_SHA"
-  echo "template_sha_short=$TEMPLATE_SHA_SHORT"
-} >>"$GITHUB_OUTPUT"
-
-PREV_SHA=""
-if [[ -f .template-version ]]; then
-  PREV_SHA=$(cat .template-version)
-  echo "Previous template version: $PREV_SHA"
-else
-  echo "No previous template version found (first sync)"
-fi
-echo "Current template version: $TEMPLATE_SHA"
-
-if [[ -n "$PREV_SHA" ]] && [[ "$PREV_SHA" != "$TEMPLATE_SHA" ]]; then
-  if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
-    CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA")
+  PREV_SHA=""
+  if [[ -f .template-version ]]; then
+    PREV_SHA=$(cat .template-version)
+    echo "Previous template version: $PREV_SHA"
   else
-    echo "::warning::Previous template SHA $PREV_SHA not found in template history (likely rewritten by force-push or rebase)"
-    CHANGELOG="Previous SHA \`$PREV_SHA\` no longer exists in template history (force-push/rebase). Showing last 20 commits instead:"$'\n'
-    CHANGELOG+=$(git -C _template log --oneline -20 "$TEMPLATE_SHA")
+    echo "No previous template version found (first sync)"
   fi
-  [[ -n "$CHANGELOG" ]] && emit_multiline_output "changelog" "$CHANGELOG"
-fi
+  echo "Current template version: $TEMPLATE_SHA"
 
-echo "$TEMPLATE_SHA" >.template-version
-
-#############################################
-# File processing
-#############################################
-
-# Resolve a single file's sync outcome using a 3-way merge strategy:
-#
-#   base     = the file at PREV_SHA in the template (last known common ancestor)
-#   local    = the current file in the child repo
-#   template = the file at HEAD in the template
-#
-# Decision tree:
-#   1. File is new in template → copy it in.
-#   2. Files are already identical → no-op.
-#   3. No merge base (first sync or lost history) → apply template, record conflict.
-#   4. Template is unchanged since base → local diverged alone; keep local.
-#   5. Local is unchanged since base → template advanced alone; adopt template.
-#   6. Both sides changed → attempt a 3-way merge:
-#      a. Clean merge → write merged result.
-#      b. Conflict → write conflict markers for Claude to resolve.
-process_file() {
-  local rel_path="$1"
-  local template_file="_template/$rel_path"
-
-  local parent_dir
-  parent_dir=$(dirname "$rel_path")
-  [[ "$parent_dir" != "." ]] && mkdir -p "$parent_dir"
-
-  # Case 1: new file in template.
-  if [[ ! -f "$rel_path" ]]; then
-    cp "$template_file" "$rel_path"
-    echo "Added: $rel_path"
-    return
+  if [[ -n "$PREV_SHA" ]] && [[ "$PREV_SHA" != "$TEMPLATE_SHA" ]]; then
+    if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
+      CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA")
+    else
+      echo "::warning::Previous template SHA $PREV_SHA not found in template history (likely rewritten by force-push or rebase)"
+      CHANGELOG="Previous SHA \`$PREV_SHA\` no longer exists in template history (force-push/rebase). Showing last 20 commits instead:"$'\n'
+      CHANGELOG+=$(git -C _template log --oneline -20 "$TEMPLATE_SHA")
+    fi
+    [[ -n "$CHANGELOG" ]] && emit_multiline_output "changelog" "$CHANGELOG"
   fi
 
-  # Case 2: already identical.
-  if diff -q "$rel_path" "$template_file" >/dev/null 2>&1; then
-    return
-  fi
+  echo "$TEMPLATE_SHA" >.template-version
 
-  # Case 3: no merge base — first sync or history unavailable.
-  if [[ -z "$PREV_SHA" ]]; then
-    record_no_base_conflict "$rel_path" "$template_file"
-    return
-  fi
+  #############################################
+  # File processing
+  #############################################
 
-  local safe_name
-  safe_name=$(echo "$rel_path" | tr '/' '_')
-  local base_file="$WORK_DIR/merge_base_${safe_name}"
+  # Resolve a single file's sync outcome using a 3-way merge strategy:
+  #
+  #   base     = the file at PREV_SHA in the template (last known common ancestor)
+  #   local    = the current file in the child repo
+  #   template = the file at HEAD in the template
+  #
+  # Decision tree:
+  #   1. File is new in template → copy it in.
+  #   2. Files are already identical → no-op.
+  #   3. No merge base (first sync or lost history) → apply template, record conflict.
+  #   4. Template is unchanged since base → local diverged alone; keep local.
+  #   5. Local is unchanged since base → template advanced alone; adopt template.
+  #   6. Both sides changed → attempt a 3-way merge:
+  #      a. Clean merge → write merged result.
+  #      b. Conflict → write conflict markers for Claude to resolve.
+  process_file() {
+    local rel_path="$1"
+    local template_file="_template/$rel_path"
 
-  if ! git -C _template show "${PREV_SHA}:${rel_path}" >"$base_file" 2>/dev/null; then
-    rm -f "$base_file"
-    record_no_base_conflict "$rel_path" "$template_file"
-    return
-  fi
+    local parent_dir
+    parent_dir=$(dirname "$rel_path")
+    [[ "$parent_dir" != "." ]] && mkdir -p "$parent_dir"
 
-  # Case 4: template unchanged since base — local diverged alone; keep local.
-  if diff -q "$base_file" "$template_file" >/dev/null 2>&1; then
-    echo "Unchanged in template: $rel_path (keeping local version)"
-    rm -f "$base_file"
-    return
-  fi
+    # Case 1: new file in template.
+    if [[ ! -f "$rel_path" ]]; then
+      cp "$template_file" "$rel_path"
+      echo "Added: $rel_path"
+      return
+    fi
 
-  # Case 5: local unchanged since base — template advanced alone; adopt it.
-  if diff -q "$base_file" "$rel_path" >/dev/null 2>&1; then
-    cp "$template_file" "$rel_path"
-    echo "Updated: $rel_path (local was unmodified)"
-    rm -f "$base_file"
-    return
-  fi
+    # Case 2: already identical.
+    if diff -q "$rel_path" "$template_file" >/dev/null 2>&1; then
+      return
+    fi
 
-  # Case 6: both sides changed — attempt a 3-way merge.
-  local merge_result="$WORK_DIR/merge_result_${safe_name}"
-  cp "$rel_path" "$merge_result"
+    # Case 3: no merge base — first sync or history unavailable.
+    if [[ -z "$PREV_SHA" ]]; then
+      record_no_base_conflict "$rel_path" "$template_file"
+      return
+    fi
 
-  if git merge-file -L "local" -L "base" -L "template" \
-    "$merge_result" "$base_file" "$template_file" 2>/dev/null; then
+    local safe_name
+    safe_name=$(echo "$rel_path" | tr '/' '_')
+    local base_file="$WORK_DIR/merge_base_${safe_name}"
+
+    if ! git -C _template show "${PREV_SHA}:${rel_path}" >"$base_file" 2>/dev/null; then
+      rm -f "$base_file"
+      record_no_base_conflict "$rel_path" "$template_file"
+      return
+    fi
+
+    # Case 4: template unchanged since base — local diverged alone; keep local.
+    if diff -q "$base_file" "$template_file" >/dev/null 2>&1; then
+      echo "Unchanged in template: $rel_path (keeping local version)"
+      rm -f "$base_file"
+      return
+    fi
+
+    # Case 5: local unchanged since base — template advanced alone; adopt it.
+    if diff -q "$base_file" "$rel_path" >/dev/null 2>&1; then
+      cp "$template_file" "$rel_path"
+      echo "Updated: $rel_path (local was unmodified)"
+      rm -f "$base_file"
+      return
+    fi
+
+    # Case 6: both sides changed — attempt a 3-way merge.
+    local merge_result="$WORK_DIR/merge_result_${safe_name}"
+    cp "$rel_path" "$merge_result"
+
+    if git merge-file -L "local" -L "base" -L "template" \
+      "$merge_result" "$base_file" "$template_file" 2>/dev/null; then
+      cp "$merge_result" "$rel_path"
+      echo "Auto-merged: $rel_path (clean 3-way merge)"
+      echo "$rel_path" >>"$AUTO_MERGED_FILES"
+      rm -f "$base_file" "$merge_result"
+      return
+    fi
+
+    # Case 6b: conflict markers produced — keep them for Claude to resolve.
     cp "$merge_result" "$rel_path"
-    echo "Auto-merged: $rel_path (clean 3-way merge)"
-    echo "$rel_path" >>"$AUTO_MERGED_FILES"
+    echo "CONFLICT (merge markers): $rel_path"
+    echo "$rel_path" >>"$CONFLICT_FILES"
+    {
+      echo "### \`$rel_path\`"
+      echo ""
+      echo "3-way merge produced **conflict markers** (\`<<<<<<<\`/\`=======\`/\`>>>>>>>\`)."
+      echo "Resolve them: keep local customizations, adopt template improvements."
+      echo ""
+      echo "<details>"
+      echo "<summary>View file with conflict markers</summary>"
+      echo ""
+      echo "\`\`\`"
+      head -500 "$rel_path"
+      echo "\`\`\`"
+      echo "</details>"
+      echo ""
+    } >>"$CONFLICT_REPORT"
     rm -f "$base_file" "$merge_result"
-    return
-  fi
+  }
 
-  # Case 6b: conflict markers produced — keep them for Claude to resolve.
-  cp "$merge_result" "$rel_path"
-  echo "CONFLICT (merge markers): $rel_path"
-  echo "$rel_path" >>"$CONFLICT_FILES"
-  {
-    echo "### \`$rel_path\`"
-    echo ""
-    echo "3-way merge produced **conflict markers** (\`<<<<<<<\`/\`=======\`/\`>>>>>>>\`)."
-    echo "Resolve them: keep local customizations, adopt template improvements."
-    echo ""
-    echo "<details>"
-    echo "<summary>View file with conflict markers</summary>"
-    echo ""
-    echo "\`\`\`"
-    head -500 "$rel_path"
-    echo "\`\`\`"
-    echo "</details>"
-    echo ""
-  } >>"$CONFLICT_REPORT"
-  rm -f "$base_file" "$merge_result"
-}
+  record_no_base_conflict() {
+    local rel_path="$1" template_file="$2"
+    echo "CONFLICT (no base): $rel_path"
+    echo "$rel_path" >>"$CONFLICT_FILES"
+    {
+      echo "### \`$rel_path\`"
+      echo ""
+      echo "No merge base available (first sync or file history unavailable)."
+      echo "Template version has been applied. Restore any important local customizations."
+      echo ""
+      echo "<details>"
+      echo "<summary>Diff (old local → new template)</summary>"
+      echo ""
+      echo "\`\`\`diff"
+      # diff exits 0 (identical) or 1 (differs); anything higher is a real error.
+      # Capture into a variable so truncating with `head` can't SIGPIPE the diff.
+      diff_rc=0
+      diff_out=$(diff -u "$rel_path" "$template_file") || diff_rc=$?
+      [[ "${diff_rc:-0}" -le 1 ]] || exit "${diff_rc}"
+      head -500 <<<"$diff_out"
+      echo "\`\`\`"
+      echo "</details>"
+      echo ""
+    } >>"$CONFLICT_REPORT"
+    cp "$template_file" "$rel_path"
+  }
 
-record_no_base_conflict() {
-  local rel_path="$1" template_file="$2"
-  echo "CONFLICT (no base): $rel_path"
-  echo "$rel_path" >>"$CONFLICT_FILES"
-  {
-    echo "### \`$rel_path\`"
-    echo ""
-    echo "No merge base available (first sync or file history unavailable)."
-    echo "Template version has been applied. Restore any important local customizations."
-    echo ""
-    echo "<details>"
-    echo "<summary>Diff (old local → new template)</summary>"
-    echo ""
-    echo "\`\`\`diff"
-    # diff exits 0 (identical) or 1 (differs); anything higher is a real error.
-    # Capture into a variable so truncating with `head` can't SIGPIPE the diff.
-    diff_rc=0
-    diff_out=$(diff -u "$rel_path" "$template_file") || diff_rc=$?
-    [[ "${diff_rc:-0}" -le 1 ]] || exit "${diff_rc}"
-    head -500 <<<"$diff_out"
-    echo "\`\`\`"
-    echo "</details>"
-    echo ""
-  } >>"$CONFLICT_REPORT"
-  cp "$template_file" "$rel_path"
-}
+  #############################################
+  # Detect deleted files + process sync paths
+  #############################################
 
-#############################################
-# Detect deleted files + process sync paths
-#############################################
-
-# A path is "deleted" only if it existed in the template at PREV_SHA but no
-# longer exists at the current template HEAD. This avoids false positives for
-# project-specific files that were never in the template.
-if [[ -n "$PREV_SHA" ]]; then
-  if ! git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES"; then
-    : >"$PREV_TEMPLATE_FILES" # PREV_SHA not in template history; treat as no prior files
-  fi
-fi
-
-for path in $SYNC_PATHS; do
-  is_excluded "$path" && continue
-
+  # A path is "deleted" only if it existed in the template at PREV_SHA but no
+  # longer exists at the current template HEAD. This avoids false positives for
+  # project-specific files that were never in the template.
   if [[ -n "$PREV_SHA" ]]; then
-    while IFS= read -r prev_file; do
-      case "$prev_file" in "$path" | "$path/"*) ;; *) continue ;; esac
-      is_excluded "$prev_file" && continue
-      if [[ ! -f "_template/$prev_file" ]]; then
-        echo "DELETED in template: $prev_file"
-        echo "$prev_file" >>"$DELETED_FILES"
-      fi
-    done <"$PREV_TEMPLATE_FILES"
+    if ! git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES"; then
+      : >"$PREV_TEMPLATE_FILES" # PREV_SHA not in template history; treat as no prior files
+    fi
   fi
 
-  if [[ ! -e "_template/$path" ]]; then
-    echo "Warning: $path not found in template, skipping"
-    continue
+  for path in $SYNC_PATHS; do
+    is_excluded "$path" && continue
+
+    if [[ -n "$PREV_SHA" ]]; then
+      while IFS= read -r prev_file; do
+        case "$prev_file" in "$path" | "$path/"*) ;; *) continue ;; esac
+        is_excluded "$prev_file" && continue
+        if [[ ! -f "_template/$prev_file" ]]; then
+          echo "DELETED in template: $prev_file"
+          echo "$prev_file" >>"$DELETED_FILES"
+        fi
+      done <"$PREV_TEMPLATE_FILES"
+    fi
+
+    if [[ ! -e "_template/$path" ]]; then
+      echo "Warning: $path not found in template, skipping"
+      continue
+    fi
+
+    if [[ -d "_template/$path" ]]; then
+      while IFS= read -r template_file; do
+        rel_path="${template_file#_template/}"
+        is_excluded "$rel_path" && continue
+        process_file "$rel_path"
+      done < <(find "_template/$path" -type f)
+    else
+      process_file "$path"
+    fi
+  done
+
+  rm -rf _template
+
+  #############################################
+  # Set outputs
+  #############################################
+
+  if [[ -s "$AUTO_MERGED_FILES" ]]; then
+    auto_merged=$(tr '\n' ' ' <"$AUTO_MERGED_FILES")
+    echo "auto_merged_files=$auto_merged" >>"$GITHUB_OUTPUT"
   fi
 
-  if [[ -d "_template/$path" ]]; then
-    while IFS= read -r template_file; do
-      rel_path="${template_file#_template/}"
-      is_excluded "$rel_path" && continue
-      process_file "$rel_path"
-    done < <(find "_template/$path" -type f)
+  if [[ -s "$CONFLICT_FILES" ]]; then
+    conflicts=$(tr '\n' ' ' <"$CONFLICT_FILES")
+    {
+      echo "has_conflicts=true"
+      echo "conflict_files=$conflicts"
+    } >>"$GITHUB_OUTPUT"
+    emit_multiline_output "conflict_report" "$(cat "$CONFLICT_REPORT")"
+    echo "Template updates available for: $conflicts" >.template-sync-conflicts
   else
-    process_file "$path"
+    echo "has_conflicts=false" >>"$GITHUB_OUTPUT"
+    rm -f .template-sync-conflicts
   fi
-done
 
-rm -rf _template
+  if [[ -s "$DELETED_FILES" ]]; then
+    deleted=$(tr '\n' ' ' <"$DELETED_FILES")
+    {
+      echo "has_deletions=true"
+      echo "deleted_files=$deleted"
+    } >>"$GITHUB_OUTPUT"
+  else
+    echo "has_deletions=false" >>"$GITHUB_OUTPUT"
+  fi
 
-#############################################
-# Set outputs
-#############################################
+  if git diff --quiet && [[ -z "$(git ls-files --others --exclude-standard)" ]]; then
+    echo "has_changes=false" >>"$GITHUB_OUTPUT"
+  else
+    changed_paths=$({
+      git diff --name-only
+      git ls-files --others --exclude-standard
+    } | tr '\n' ' ')
+    {
+      echo "has_changes=true"
+      echo "changed_paths=$changed_paths"
+    } >>"$GITHUB_OUTPUT"
+  fi
+}
 
-if [[ -s "$AUTO_MERGED_FILES" ]]; then
-  auto_merged=$(tr '\n' ' ' <"$AUTO_MERGED_FILES")
-  echo "auto_merged_files=$auto_merged" >>"$GITHUB_OUTPUT"
-fi
-
-if [[ -s "$CONFLICT_FILES" ]]; then
-  conflicts=$(tr '\n' ' ' <"$CONFLICT_FILES")
-  {
-    echo "has_conflicts=true"
-    echo "conflict_files=$conflicts"
-  } >>"$GITHUB_OUTPUT"
-  emit_multiline_output "conflict_report" "$(cat "$CONFLICT_REPORT")"
-  echo "Template updates available for: $conflicts" >.template-sync-conflicts
-else
-  echo "has_conflicts=false" >>"$GITHUB_OUTPUT"
-  rm -f .template-sync-conflicts
-fi
-
-if [[ -s "$DELETED_FILES" ]]; then
-  deleted=$(tr '\n' ' ' <"$DELETED_FILES")
-  {
-    echo "has_deletions=true"
-    echo "deleted_files=$deleted"
-  } >>"$GITHUB_OUTPUT"
-else
-  echo "has_deletions=false" >>"$GITHUB_OUTPUT"
-fi
-
-if git diff --quiet && [[ -z "$(git ls-files --others --exclude-standard)" ]]; then
-  echo "has_changes=false" >>"$GITHUB_OUTPUT"
-else
-  changed_paths=$({
-    git diff --name-only
-    git ls-files --others --exclude-standard
-  } | tr '\n' ' ')
-  {
-    echo "has_changes=true"
-    echo "changed_paths=$changed_paths"
-  } >>"$GITHUB_OUTPUT"
-fi
+main "$@"


### PR DESCRIPTION
## Summary
- `template-sync.sh` syncs itself into downstream repos (it lives under `.github/scripts/`, which is a synced path), so a downstream run overwrites the very file bash is currently executing
- bash reads a running script incrementally from disk rather than all at once, so once the self-overwrite happens, any remaining top-level statement can read shifted bytes and crash on an unrelated line
- Wrapped all logic in `main()`, called as the file's final line — this forces bash to parse through the closing brace and the trailing `main "$@"` call before executing anything, so the self-overwrite can no longer corrupt an in-flight read
- This bug originates in the template (confirmed via phone-home issue #249, filed after a downstream repo hit and fixed the same bug in its own synced copy)

## Test plan
- [x] `bash -n` / `shellcheck` / `shfmt -i 2 -w` — clean
- [x] `git diff -w` confirms the only non-whitespace change is the `main()` wrapper (no logic drift)
- [x] Manually reproduced the exact self-overwrite path (`SYNC_PATHS=".github/scripts"` syncing a template repo's newer `template-sync.sh` over a downstream copy of itself, case "template advanced alone; adopt it") — script ran to completion without corruption

Closes #249.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGoKWFnakX37B8hdoFhCRj)_