### PR TITLE
docs: consider parallelizing research/implementation before executing a plan

### DIFF
--- a/.claude/skills/explore-plan/SKILL.md
+++ b/.claude/skills/explore-plan/SKILL.md
@@ -26,6 +26,18 @@ Before multi-file changes, write an explicit plan: the problem, the approach, th
 touch, and the existing helpers/patterns to reuse (search for them—do not invent new code when a
 utility already exists). A written plan is reviewable and catches wrong premises before they cost edits.
 
+### Before executing: parallelize where independent
+
+Once the plan lists concrete files/steps, check whether any of them are independent before
+running them serially. Independent research (tracing unrelated modules, checking multiple call
+sites) fans out to parallel `Explore` agents. Independent implementation (edits to separate files
+with no shared state or ordering dependency) can run as parallel `Agent` calls—use
+`isolation: "worktree"` if they'd otherwise touch the same files concurrently. Steps stay serial
+when one depends on another's output (e.g., a schema change before the code that reads it) or when
+review/verify must see the prior step's result first. Only reach for the `Workflow` tool when the
+user has explicitly opted into multi-agent orchestration (see its tool description)—otherwise use
+direct parallel `Agent` calls in a single message.
+
 ## 3. Review (fresh, unbiased)
 
 Have the plan—and later the diff—reviewed with no implementation bias. Use the `peer-review`

--- a/.claude/skills/explore-plan/SKILL.md
+++ b/.claude/skills/explore-plan/SKILL.md
@@ -28,6 +28,7 @@ utility already exists). A written plan is reviewable and catches wrong premises
 
 ### Before executing: parallelize where independent
 
+This isn't limited to the planning step—apply it to executing any plan (see `CLAUDE.md`).
 Once the plan lists concrete files/steps, check whether any of them are independent before
 running them serially. Independent research (tracing unrelated modules, checking multiple call
 sites) fans out to parallel `Explore` agents. Independent implementation (edits to separate files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 - No running commentary or filler—don’t narrate tool use, restate my request, or recap after each step. Just do the work.
 - Save all explanation for the END: a short overview of what changed and how it fits, plus anything I need to run/use it. Proportional to the change.
 - Be direct. Flag real risks once; skip caveats I didn’t ask for. Don’t claim it works unless you ran it or read the code.
+- **Before executing any plan—mine or one already written—check which steps are independent and run those in parallel instead of serially.** This applies whether the step is research (parallel `Explore`/read-only agents) or implementation (parallel `Agent` calls across separate files, using `isolation: "worktree"` if they'd otherwise collide). Keep steps serial only when one genuinely depends on another's output, or when a review/verify gate must see the prior step's result first.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Adds guidance so the agent checks, before executing any plan, whether its research or implementation steps are independent and can run in parallel instead of serially
- Added both in `CLAUDE.md` (Working style)—so it applies to executing any plan, not just ones written via the `explore-plan` skill—and in the `explore-plan` skill itself, which cross-references it
- Clarifies when steps must stay serial (output dependencies, review/verify ordering) and when to reach for parallel `Explore`/`Agent` calls vs. the `Workflow` tool (only on explicit user opt-in)

## Test plan

- [x] `.hooks/lint-skills.sh` ran via pre-commit hook and passed
- N/A — docs-only change to instructions files, no runtime behavior to exercise
