### PR TITLE
chore(ci): bump GitHub Actions off deprecated Node.js 20 runtime

### DIFF
--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -23,14 +23,14 @@ runs:
   steps:
     - name: Set up Node.js
       if: hashFiles('package.json') != ''
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
 
     - name: Install pnpm
       if: hashFiles('package.json') != ''
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Get pnpm store directory
       if: hashFiles('package.json') != ''
@@ -40,7 +40,7 @@ runs:
 
     - name: Restore pnpm cache
       if: hashFiles('package.json') != ''
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ env.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -54,7 +54,7 @@ runs:
 
     - name: Set up uv
       if: inputs.setup-python == 'true'
-      uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Restore pre-commit cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
## Summary

- `actions/setup-node`, `pnpm/action-setup`, `actions/cache` (including the `restore` sub-action), and `astral-sh/setup-uv` were pinned to versions whose `action.yml` still declares `using: node20`, which GitHub now surfaces as a deprecation warning in workflow run logs across most workflows (they all go through `setup-base-env`).
- Bumped each to its latest major release (`setup-node` v4 → v6.4.0, `action-setup` v4 → v6.0.9, `cache`/`cache/restore` v4 → v6.1.0, `setup-uv` v3 → v8.2.0 — matching the SHA already used elsewhere in `zizmor.yaml`), all confirmed to declare `using: node24` in their `action.yml`.
- Verified each new SHA resolves to the exact commit tagged by its release (byte-identical `action.yml`) and that none of the majors changed the `with:` inputs already used in this repo (`node-version`/`registry-url`, `path`/`key`/`restore-keys`, `enable-cache`/`cache-dependency-glob`).

## Test plan

- [x] Confirmed each pinned SHA's `action.yml` matches its release tag and declares `using: node24`
- [x] Confirmed no `with:` input changes needed (inputs used are stable across the version bumps)
- [ ] CI on this PR (pre-commit, lint, node-tests, etc.) exercises the updated `setup-base-env` composite action end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01XCFNscMb3r3FzMoX8YPVZw)_