### PR TITLE
ci: adopt full ci-truth-serum extras tier, bump pin, drift-guard it

### DIFF
--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install the apply tool (ci-truth-serum)
         # Pin to the same ci-truth-serum commit the pre-commit hook uses so the
         # lint and the apply step share one parser version.
-        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@55b3c2af0b83f77f15eba92aac743bdf8ff254be"
+        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@421e708a4fa98df667c708fdb4c43570ab620bb6"
 
       - name: Sync required status checks
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,14 +65,16 @@ repos:
   # hangs forever, or a mutable base-image/download pin. Tier 2 adds the
   # required-check-shape lints this template's workflows already follow
   # (classified always() reporters, explicit concurrency, externalized run
-  # blocks). check-claude-model enforces an explicit --model on the
-  # claude-code-action steps this template ships.
+  # blocks). Extras adds check-claude-model (explicit --model on the
+  # claude-code-action steps this template ships) plus the unnamed-regex-group
+  # and global-stdio-swap Python lints. Tier aggregates over per-check ids so a
+  # check added upstream to a tier applies here with no config change.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 55b3c2af0b83f77f15eba92aac743bdf8ff254be # newest (no tag cut yet)
+    rev: 421e708a4fa98df667c708fdb4c43570ab620bb6 # newest (no tag cut yet)
     hooks:
       - id: check-tier1
       - id: check-tier2
-      - id: check-claude-model
+      - id: check-extras
 
   - repo: local
     hooks:

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -17,6 +17,13 @@ hooks behave differently from CI:
     - .pre-commit-config.yaml          (default_language_version: python:)
     - .github/workflows/pre-commit.yaml (actions/setup-python python-version:)
 
+  ci-truth-serum (the workflow-honesty lints and their ruleset apply tool):
+    - .pre-commit-config.yaml          (rev: <sha> on the ci-truth-serum repo)
+    - .github/workflows/sync-required-checks.yaml (pip install git+...@<sha>)
+    A mismatch means the lint that classifies required-check annotations and
+    the tool that applies them to the branch ruleset parse with different
+    versions.
+
 This test is the machine-checkable form of the "keep in sync" comments in
 session-setup.sh and .pre-commit-config.yaml. Each case is checked
 independently so a failure names the exact file pair that drifted.
@@ -33,6 +40,9 @@ PRE_COMMIT_CFG = REPO_ROOT / ".pre-commit-config.yaml"
 ZIZMOR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "zizmor.yaml"
 PYTHON_VERSION_FILE = REPO_ROOT / ".python-version"
 PRE_COMMIT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pre-commit.yaml"
+SYNC_REQUIRED_CHECKS_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "sync-required-checks.yaml"
+)
 
 
 def _search(pattern: str, path: Path, *, flags: int = 0) -> str:
@@ -85,10 +95,22 @@ def _python_pins() -> dict[str, str]:
     }
 
 
+def _ci_truth_serum_pins() -> dict[str, str]:
+    return {
+        ".pre-commit-config.yaml": _search(
+            r"alexander-turner/ci-truth-serum\s+rev:\s+(\S+)", PRE_COMMIT_CFG
+        ),
+        "sync-required-checks.yaml": _search(
+            r"ci-truth-serum @ git\+https://github\.com/alexander-turner/ci-truth-serum@(\S+)\"",
+            SYNC_REQUIRED_CHECKS_WORKFLOW,
+        ),
+    }
+
+
 @pytest.mark.parametrize(
     "pins_fn",
-    [_ruff_pins, _zizmor_pins, _python_pins],
-    ids=["ruff", "zizmor", "python"],
+    [_ruff_pins, _zizmor_pins, _python_pins, _ci_truth_serum_pins],
+    ids=["ruff", "zizmor", "python", "ci-truth-serum"],
 )
 def test_version_pins_agree(pins_fn) -> None:
     pins = pins_fn()


### PR DESCRIPTION
## Summary

Brings the template's ci-truth-serum consumption up to the full doctrine claude-guard follows, so every downstream repo inherits it:

- **Enable the `check-extras` aggregate** in place of the lone `check-claude-model` id. This adds the unnamed-regex-group and global-stdio-swap Python lints, and — because it's a tier aggregate — any check added to Extras upstream applies here with no config change. (Verified: extras passes on the current tree.)
- **Bump the pinned ci-truth-serum rev** to current upstream main (`421e708`), picking up the multiline exit-suppression fix, Dockerfile `ADD <url>` pinning, and the `${{ always() }}` reporter-shape fix. Verified tier1/tier2/extras all pass against this tree at the new rev.
- **Drift-guard the pin pair**: `test_version_sync.py` now asserts the `.pre-commit-config.yaml` `rev:` and `sync-required-checks.yaml`'s `pip install git+…@<sha>` agree, so the annotation lint and the ruleset apply tool can never parse with different versions. Confirmed red on a deliberately mismatched pin, green when synced.

## Verification

- `pytest tests/test_version_sync.py` — 4 passed (including the new `ci-truth-serum` case; mutation-checked red/green).
- Tier 1, Tier 2, and Extras run clean against this tree at the bumped rev.

---
_Generated by [Claude Code](https://claude.ai/code/session_0155o9xwLdCM8K8RWx54btuq)_