### PR TITLE
ci(workflows): require deterministic zero-API gates

### DIFF
--- a/.github/workflows/decide-reusable.yaml
+++ b/.github/workflows/decide-reusable.yaml
@@ -1,0 +1,42 @@
+name: decide
+
+# Reusable path gate. A caller invokes this as a `decide` job and gates its work
+# jobs on `needs.decide.outputs.run == 'true'`. Because the decide job itself has
+# no `paths:` filter it ALWAYS runs, so the caller's `if: always()` reporter
+# always receives a conclusion — unlike a native `pull_request: paths:` filter,
+# which skips the whole workflow and strands a required check at "Expected —
+# Waiting". On non-pull_request events (e.g. push to main) the gate is always
+# open, so nothing is path-filtered there.
+
+on:
+  workflow_call:
+    inputs:
+      filters:
+        description: dorny/paths-filter filter spec (YAML). `run` is 'true' when any group matches.
+        required: true
+        type: string
+    outputs:
+      run:
+        description: "'true' if any configured path changed, or the event is not a pull_request."
+        value: ${{ jobs.decide.outputs.run }}
+
+permissions:
+  contents: read
+  pull-requests: read # dorny/paths-filter lists a PR's changed files via the API
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # On a pull_request, open the gate iff paths-filter reported at least one
+    # matched group (`changes` is the JSON array of matched filter names, `[]`
+    # when none). On any other event the filter step is skipped (its outputs are
+    # empty) and the gate is unconditionally open.
+    outputs:
+      run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.changes != '[]' }}
+    steps:
+      - id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          filters: ${{ inputs.filters }}

--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  gitleaks:
+  gitleaks: # required-check: true
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -6,29 +6,7 @@ name: Hook lifecycle
 on:
   push:
     branches: ["main"]
-    paths:
-      - ".claude/hooks/**"
-      - ".hooks/**"
-      - "setup.sh"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".pre-commit-config.yaml"
-      - ".github/scripts/run-hook-lifecycle.sh"
-      - ".github/workflows/hook-lifecycle.yaml"
-  pull_request: # not-required-check: single advisory job, path-gated, no required reporter
-    paths:
-      - ".claude/hooks/**"
-      - ".hooks/**"
-      - "setup.sh"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".pre-commit-config.yaml"
-      - ".github/scripts/run-hook-lifecycle.sh"
-      - ".github/workflows/hook-lifecycle.yaml"
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -38,7 +16,28 @@ permissions:
   contents: read
 
 jobs:
+  decide:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/decide-reusable.yaml
+    with:
+      filters: |
+        run:
+          - '.claude/hooks/**'
+          - '.hooks/**'
+          - 'setup.sh'
+          - 'package.json'
+          - 'pnpm-lock.yaml'
+          - 'pyproject.toml'
+          - 'uv.lock'
+          - '.pre-commit-config.yaml'
+          - '.github/scripts/run-hook-lifecycle.sh'
+          - '.github/workflows/hook-lifecycle.yaml'
+
   hook-lifecycle:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -53,3 +52,13 @@ jobs:
 
       - name: Run hook lifecycle
         run: bash .github/scripts/run-hook-lifecycle.sh
+
+  hook-lifecycle-passed: # required-check: true
+    if: always()
+    needs: [decide, hook-lifecycle]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if any required job did not pass
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -5,11 +5,7 @@ name: zizmor
 on:
   push:
     branches: ["main"]
-    paths:
-      - ".github/**"
-  pull_request: # not-required-check: single advisory job, path-gated, no required reporter
-    paths:
-      - ".github/**"
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -19,7 +15,19 @@ permissions:
   contents: read
 
 jobs:
+  decide:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/decide-reusable.yaml
+    with:
+      filters: |
+        run:
+          - '.github/**'
+
   zizmor:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -31,3 +39,13 @@ jobs:
 
       - name: Run zizmor
         run: uvx zizmor==1.25.2 .github/
+
+  zizmor-passed: # required-check: true
+    if: always()
+    needs: [decide, zizmor]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if any required job did not pass
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Summary

Makes three deterministic, no-API CI gates into stable Required status checks using ci-truth-serum's `# required-check:` annotation system.

- **gitleaks.yaml** (Tier 1, marker-only): already runs on every PR with no `paths:` filter, so its single job can be required directly. Added `# required-check: true` to the `gitleaks` job key.
- **zizmor.yaml** and **hook-lifecycle.yaml** (Tier 2, restructured): both carried a `pull_request: paths:` filter and were opted out via `# not-required-check` — a required check with a PR-trigger paths filter hangs forever at "Expected — Waiting". Restructured each into the `decide` job + `always()` reporter shape: the `paths:` lists move into a `decide` reusable-workflow filter, the work job gains `needs: decide` / `if: needs.decide.outputs.run == 'true'`, and a `-passed` reporter (marked `# required-check: true`) always runs and fails only if a needed job failed or was cancelled. This lets the check be required without ever hanging on irrelevant PRs.
- Added **decide-reusable.yaml** (shared by both restructured workflows).

Work-job `runs-on`, timeouts, and all pinned action SHAs are unchanged.

## Verification

All five ci-truth-serum workflow lints pass, plus YAML parse:

```
check_always_reporter    exit=0
check_required_reporter  exit=0
check_pr_paths           exit=0
check_static_concurrency exit=0
check_concurrency        exit=0
yaml ok
```