### PR TITLE
build(deps): bump ci-truth-serum pin

### DIFF
--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install the apply tool (ci-truth-serum)
         # Pin to the same ci-truth-serum commit the pre-commit hook uses so the
         # lint and the apply step share one parser version.
-        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@421e708a4fa98df667c708fdb4c43570ab620bb6"
+        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@e438c361e232fa2f69ab36ff9a29a1e639e0c5a7"
 
       - name: Sync required status checks
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
   # and global-stdio-swap Python lints. Tier aggregates over per-check ids so a
   # check added upstream to a tier applies here with no config change.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 421e708a4fa98df667c708fdb4c43570ab620bb6 # newest (no tag cut yet)
+    rev: e438c361e232fa2f69ab36ff9a29a1e639e0c5a7 # main
     hooks:
       - id: check-tier1
       - id: check-tier2


### PR DESCRIPTION
Bumps the ci-truth-serum pre-commit/ruleset-sync pin to pick up the fix where `sync_required_checks` bootstraps a `required_status_checks` rule when the branch ruleset lacks one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5F6hSjCtKT7hk5Fgg5ZAo)_