### PR TITLE
ci(claude): add @claude responder to auto-resolve template-sync conflicts

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -74,4 +74,5 @@ jobs:
         uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          model: claude-sonnet-4-6
           github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,0 +1,77 @@
+name: Claude
+
+# General-purpose @claude responder. Fires whenever someone mentions @claude in
+# an issue, a PR/issue comment, or a PR review, and hands the request to
+# claude-code-action, which acts on it (answers, edits code, resolves conflicts)
+# and pushes to the branch.
+#
+# WHY THIS EXISTS — template-sync linkage:
+#   template-sync.yaml opens a sync PR and, when a sync hits merge conflicts,
+#   posts an "@claude Resolve this..." comment (see request-claude-resolve.sh).
+#   Without a listener, that comment lands in the void, so a human has to
+#   remember to open a Claude session and resolve the conflicts by hand. This
+#   workflow IS that listener — it turns the existing @claude comment into a
+#   hands-off resolution, leaving only human review + merge.
+#
+#   IMPORTANT — comment author matters: GitHub does NOT deliver issue_comment
+#   events for comments authored by GITHUB_TOKEN (the github-actions[bot]); it's
+#   a recursion guard. So for sync auto-resolution to fire, template-sync.yaml's
+#   @claude comment must be posted by a real identity — set the
+#   TEMPLATE_SYNC_TOKEN secret (a fine-grained PAT) so it doesn't fall back to
+#   github.token. The sync flow already needs TEMPLATE_SYNC_TOKEN for its PR to
+#   trigger downstream CI, so this is the same existing requirement.
+#
+# AUTH — two credentials, both already documented in the README secrets table:
+#   - Model side: ANTHROPIC_API_KEY authenticates the Anthropic API call. This is
+#     the same secret the security-vulnerability-scan workflow already uses; the
+#     GitHub App does not cover it.
+#   - GitHub side: github_token is TEMPLATE_SYNC_TOKEN (a fine-grained PAT) when
+#     set, falling back to GITHUB_TOKEN. The PAT matters because commits pushed
+#     under GITHUB_TOKEN are suppressed by the recursion guard above and will NOT
+#     re-trigger CI on the PR; a PAT-authored push does. Same pattern as
+#     template-sync / phone-home / auto-version.
+#
+# SETUP (per downstream repo, one time): install the Claude GitHub App
+# (https://github.com/apps/claude) and set ANTHROPIC_API_KEY (plus
+# TEMPLATE_SYNC_TOKEN for CI re-triggering). Access is gated by
+# claude-code-action's built-in check — it only acts for commenters with write
+# access, so a drive-by "@claude" from an outsider is ignored.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+concurrency:
+  # Serialize per issue/PR so overlapping @claude mentions don't race on the same
+  # branch; never cancel an in-flight resolution (it may be mid-push).
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Respond to @claude
+        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Template sync is painful downstream because resolving merge conflicts means **manually opening a Claude session** every time. The root cause: `template-sync.yaml` already posts an `@claude Resolve this...` comment on the sync PR (via `request-claude-resolve.sh`), but **nothing was listening for that mention** — there was no `issue_comment`-triggered responder anywhere in `.github/workflows/`.
- The README already documents a `claude.yaml` responder (workflow table, file tree, and secrets table all reference it), but the file itself was missing. This restores it.
- With the responder in place, a conflicting sync becomes hands-off: sync opens the PR → posts `@claude` → this workflow runs `claude-code-action` to resolve conflicts and push to the branch → you just review and merge.

## Changes

- Add `.github/workflows/claude.yaml` — a general `@claude` responder triggered on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues`, gated on the body/title containing `@claude`.
- **Auth reuses only already-documented secrets** (no new setup): `ANTHROPIC_API_KEY` for the model, and `github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}` for GitHub — the same token pattern as `template-sync` / `phone-home` / `auto-version`.
- Pinned `anthropics/claude-code-action` to the same commit SHA already used by `security-vulnerability-scan.yaml` (`428971d…` / v1.0.157), and pinned `model: claude-sonnet-4-6` (matching that workflow) to satisfy the `check-extras` lint that forbids an implicit default-Opus model.
- Per-thread `concurrency` group keyed by issue/PR number with `cancel-in-progress: false`, so overlapping mentions don't race on the branch and an in-flight resolution is never killed mid-push.

## Two failure modes the header comment documents

- **Comment author matters.** GitHub suppresses `issue_comment` events for comments authored by `GITHUB_TOKEN` (recursion guard). So sync auto-resolution only fires when `template-sync.yaml`'s `@claude` comment is posted under a real identity — i.e. when `TEMPLATE_SYNC_TOKEN` is set (which the sync flow already requires for its PR to trigger CI). Same existing requirement, now called out explicitly.
- **CI re-triggering.** Commits pushed under `GITHUB_TOKEN` don't re-trigger workflows. Using `TEMPLATE_SYNC_TOKEN` (a fine-grained PAT) for `github_token` means Claude's pushed conflict resolution actually re-runs CI on the PR.

## Testing

- Pre-commit hooks (prettier, actionlint, zizmor, `check-extras`) pass locally and in CI; all 18 CI checks green.
- Verified no SSOT/contract test enumerates the workflow set — `tests/test_version_sync.py` only pins version strings in `zizmor.yaml`, `pre-commit.yaml`, and `sync-required-checks.yaml`, none of which this touches.
- Confirmed README consistency: the workflow table, file tree, and secrets table already describe this file and list `ANTHROPIC_API_KEY` + `TEMPLATE_SYNC_TOKEN` as the required secrets, so no README change is needed.