### PR TITLE
fix(template-sync): leave child symlinks untouched during sync

### DIFF
--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -139,6 +139,26 @@ main() {
 
     local parent_dir
     parent_dir=$(dirname "$rel_path")
+
+    # Case 0: the child deliberately made this path — or an ancestor directory —
+    # a symlink (e.g. a dotfiles repo pointing .claude/settings.json or
+    # .claude/hooks/ at another repo it clones at runtime). Never write it: cp
+    # through a dangling link errors out, through a live one it escapes into the
+    # link target, and mkdir -p on a symlinked directory fails outright. Leave
+    # the local structure alone; checked before the mkdir below.
+    if [[ -L "$rel_path" ]]; then
+      echo "Skipping symlink: $rel_path (local structure preserved)"
+      return
+    fi
+    local ancestor="$parent_dir"
+    while [[ "$ancestor" != "." && "$ancestor" != "/" && -n "$ancestor" ]]; do
+      if [[ -L "$ancestor" ]]; then
+        echo "Skipping under symlinked dir: $rel_path ($ancestor is a symlink)"
+        return
+      fi
+      ancestor=$(dirname "$ancestor")
+    done
+
     [[ "$parent_dir" != "." ]] && mkdir -p "$parent_dir"
 
     # Case 1: new file in template.

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -319,6 +319,56 @@ def test_writes_template_version_with_trailing_newline(workdir: Path) -> None:
     assert (child / ".template-version").read_text() == f"{sha}\n"
 
 
+def test_symlink_in_child_is_left_untouched(workdir: Path) -> None:
+    """A child path that is a symlink (e.g. a dotfiles repo pointing
+    .claude/settings.json into a repo it clones at runtime) must be preserved,
+    not overwritten. A dangling symlink previously crashed `cp`; a live one
+    would clobber the link target instead of the link."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "a.txt", "template content\n")
+    commit_all(template)
+
+    # Child has config/a.txt as a *dangling* symlink into a sibling repo that
+    # does not exist in this checkout.
+    (child / "config").mkdir(parents=True, exist_ok=True)
+    (child / "config" / "a.txt").symlink_to("../../other-repo/a.txt")
+    commit_all(child)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    link = child / "config" / "a.txt"
+    assert link.is_symlink()
+    assert os.readlink(link) == "../../other-repo/a.txt"
+    assert "Skipping symlink: config/a.txt" in result.stdout
+    outputs = parse_outputs(output_file)
+    assert outputs["has_conflicts"] == "false"
+
+
+def test_symlinked_directory_in_child_is_left_untouched(workdir: Path) -> None:
+    """When the child made a whole directory a (dangling) symlink, files the
+    template wants to write inside it must be skipped — mkdir -p on a symlinked
+    dir fails outright, and writing through it would escape into the link
+    target. Mirrors a dotfiles repo whose .claude/hooks -> ../claude-guard/hooks."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "nested" / "a.txt", "template content\n")
+    commit_all(template)
+
+    (child / "config").mkdir(parents=True, exist_ok=True)
+    (child / "config" / "nested").symlink_to("../../other-repo/nested")
+    commit_all(child)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    assert (child / "config" / "nested").is_symlink()
+    assert "Skipping under symlinked dir: config/nested/a.txt" in result.stdout
+    outputs = parse_outputs(output_file)
+    assert outputs["has_conflicts"] == "false"
+
+
 def test_fails_loudly_without_github_output(workdir: Path) -> None:
     """Missing GITHUB_OUTPUT should fail loudly, not silently write to /dev/null."""
     template = workdir / "template"


### PR DESCRIPTION
## What

`template-sync.sh`'s `process_file` now skips any synced path that the child repo has deliberately made a symlink — either the file itself or any ancestor directory.

## Why

A downstream repo can point a synced path at another repo it clones at runtime. `.dotfiles`, for example, symlinks `.claude/settings.json`, `.claude/README.md`, and `.claude/hooks/` into the `claude-guard` repo it clones during `setup.bash`. During a sync those links are **dangling** (the sibling repo isn't checked out in the sync runner), and the old code:

- `cp`'d through the dangling file symlink → `cp: not writing through dangling symlink` and the whole sync aborted; and
- ran `mkdir -p` on the symlinked `.claude/hooks/` directory → `mkdir: cannot create directory: File exists`, also aborting.

Through a *live* symlink it was arguably worse: the copy would escape into the link target and clobber the other repo's files instead of the child's.

The child symlinked those paths on purpose, so the sync should leave them alone — consistent with the existing "keep local customizations" philosophy.

## How

At the top of `process_file` (before the `mkdir`):

- skip when `rel_path` itself is a symlink;
- walk the parent-directory chain and skip when any ancestor is a symlink.

## Tests

Two regression tests in `test_template_sync.py`:

- `test_symlink_in_child_is_left_untouched` — a dangling file symlink is preserved, no conflict, sync exits 0. (Verified it fails on the pre-fix script with the exact `cp: not writing through dangling symlink` error.)
- `test_symlinked_directory_in_child_is_left_untouched` — a symlinked directory has its would-be children skipped rather than crashing `mkdir`.

Full `test_template_sync.py` suite passes (14 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoRiQhvXwwux8gMwGz36Y2)_