### PR TITLE
docs(claude): front-load questions, run multi-item tasks to completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,14 @@
 - Be direct. Flag real risks once; skip caveats I didn’t ask for. Don’t claim it works unless you ran it or read the code.
 - **Before executing any plan—mine or one already written—check which steps are independent and run those in parallel instead of serially.** This applies whether the step is research (parallel `Explore`/read-only agents) or implementation (parallel `Agent` calls across separate files, using `isolation: "worktree"` if they'd otherwise collide). Keep steps serial only when one genuinely depends on another's output, or when a review/verify gate must see the prior step's result first.
 
+## Autonomy: front-load questions, then run to completion
+
+- **Concentrate questions at the start.** Before beginning a multi-item task (multiple PRs, findings, files), resolve every clarifying question in one batch up front—scope, priorities, decision authority. Once work begins, no further questions.
+- **Never checkpoint mid-run.** Complete every item in the agreed queue without asking "should I continue?" or "move on to the next one?"—the answer is always yes. Stop mid-task only for a destructive/irreversible action or a genuine scope change the user must decide.
+- **Mid-run decisions are logged, not asked.** When a reversible design choice surfaces after work has begun, pick a sensible default, keep going, and record it under a `## Decisions made` heading in the PR description: what came up, the default chosen, and what would change under the alternative. The user reviews decisions asynchronously in the PR, not live in chat.
+- **Maintain a status checklist.** For multi-item tasks, post the item list at the start (in chat or the PR description) and tick items off as they complete—that is the supervision surface for a user running parallel sessions.
+- **Silent turns on non-actionable events.** A webhook/notification wake-up that needs no action (duplicate event, superseded-SHA cancellation, CI still running) gets no reply—end the turn with no text. Never post "all clear" / "nothing to do."
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Parallel web sessions were stalling every ~15 minutes: mid-run "should I move on to the next PR?" checkpoints, mid-task clarifying questions, and "all clear" replies to non-actionable webhook events. This adds an **Autonomy** section to CLAUDE.md that restructures where questions surface:

- **Front-load questions**: batch all clarifying questions before a multi-item task starts; none afterward.
- **No mid-run checkpoints**: complete the whole agreed queue; stop only for destructive actions or genuine scope changes.
- **Async decision log**: mid-run reversible design choices get a sensible default plus a `## Decisions made` entry in the PR description for asynchronous review — instead of a blocking question.
- **Status checklist**: post the item list at start and tick items off, so parallel sessions are supervisable at a glance.
- **Silent no-op turns**: non-actionable webhook/notification wake-ups end with no text (no more "all clear").

## Changes

- `CLAUDE.md`: new `## Autonomy: front-load questions, then run to completion` section after Working style.

## Tests / verification

Docs-only; no code paths. Markdown passes the repo's pre-commit hooks (commit succeeded through them).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pym4XEXt1XH7SGW3gSHGo1)_