### PR TITLE
fix(ci): compare workflow_dispatch dry-run as boolean, not string

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -119,7 +119,7 @@ jobs:
         run: bash .github/scripts/template-sync.sh
 
       - name: Show diff (dry run)
-        if: inputs.dry-run == 'true' && steps.sync.outputs.has_changes == 'true'
+        if: inputs.dry-run == true && steps.sync.outputs.has_changes == 'true'
         env:
           HAS_CONFLICTS: ${{ steps.sync.outputs.has_conflicts }}
           HAS_DELETIONS: ${{ steps.sync.outputs.has_deletions }}
@@ -128,7 +128,7 @@ jobs:
         run: bash .github/scripts/show-sync-diff.sh
 
       - name: Create Pull Request
-        if: inputs.dry-run != 'true' && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
+        if: inputs.dry-run != true && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
@@ -177,7 +177,7 @@ jobs:
           labels: ${{ steps.sync.outputs.has_conflicts == 'true' && 'template-sync,needs-conflict-resolution' || 'template-sync' }}
 
       - name: Request Claude to resolve conflicts
-        if: inputs.dry-run != 'true' && (steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true') && steps.create-pr.outputs.pull-request-number
+        if: inputs.dry-run != true && (steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true') && steps.create-pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || github.token }}
           HAS_CONFLICTS: ${{ steps.sync.outputs.has_conflicts }}


### PR DESCRIPTION
## What

`template-sync.yaml`'s `dry-run` step conditions now compare `inputs.dry-run == true` / `!= true` instead of `== 'true'` / `!= 'true'`.

## Why

The workflow declares `inputs.dry-run` as `type: boolean`, so GitHub Actions exposes it as an actual boolean in the `inputs` context (unlike `github.event.inputs.*`, which is always a string). Comparing a boolean to the string literal `'true'` triggers GitHub's expression-language type coercion for mismatched types, which never evaluates true — so a `dry-run: true` dispatch silently fell through to the real `Create Pull Request` step and opened a genuine PR instead of just showing a diff.

Found via `alexander-turner/.dotfiles`, which had patched this locally in its synced copy and flagged it in `CLAUDE.md` as a "local customization to fold upstream." Folding it here means every consuming repo's next sync picks up the real fix instead of carrying a silent local patch.

## Verification

No existing test exercises `dry-run` specifically (the workflow-level `if:` condition isn't unit-testable the way `template-sync.sh` is); verified by inspection of GitHub's documented boolean/string coercion behavior and the diff being a pure `== true`/`!= true` swap with no other logic change. YAML validated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoRiQhvXwwux8gMwGz36Y2)_