### PR TITLE
ci(workflows): rename RULESET_SYNC_TOKEN to RULESET_SYNC_TOKEN_ORG

### DIFF
--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -10,7 +10,7 @@ name: Sync required status checks
 #
 # Runs only post-merge on main (and on demand). It mutates branch protection, so
 # it needs a token with `administration: write`; the stock GITHUB_TOKEN cannot
-# edit rulesets. Provide it as the RULESET_SYNC_TOKEN secret — the job fails loud
+# edit rulesets. Provide it as the RULESET_SYNC_TOKEN_ORG secret — the job fails loud
 # if it is absent. Not a required check itself (no pull_request trigger).
 on:
   push:
@@ -53,7 +53,7 @@ jobs:
 
       - name: Sync required status checks
         env:
-          GH_TOKEN: ${{ secrets.RULESET_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.RULESET_SYNC_TOKEN_ORG }}
           REPO: ${{ github.repository }}
           CHECK_ONLY: ${{ inputs.check-only }}
         run: |


### PR DESCRIPTION
## Summary
- Renamed the secret `RULESET_SYNC_TOKEN` to `RULESET_SYNC_TOKEN_ORG` in `sync-required-checks.yaml`, reflecting that it's an org-level secret shared across repos rather than a per-repo one.

## Test plan
- [x] `git grep RULESET_SYNC_TOKEN` finds only the new `RULESET_SYNC_TOKEN_ORG` name.
- [ ] Ensure the org-level `RULESET_SYNC_TOKEN_ORG` secret is configured before the next push to `main` triggers `sync-required-checks.yaml`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VKBpYnRptkgkfpkMhmwExb)_