### PR TITLE
fix(release): cap automated version bumps at minor and pin release push to GITHUB_TOKEN

### DIFF
--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -51,15 +51,20 @@ fi
 # line) — only these are checked for type prefixes, so prose in a commit
 # body that happens to start with `feat:` can't inflate the bump. $2: full
 # messages (`%B`), scanned only for BREAKING CHANGE footers. Rules, per
-# Conventional Commits:
-# - any `type!:` / `type(scope)!:` subject or `BREAKING CHANGE:` footer -> major
+# Conventional Commits — with MAJOR bumps deliberately never chosen automatically:
+# - any `type!:` / `type(scope)!:` subject or `BREAKING CHANGE:` footer -> minor
+#   (capped, not major). An automated push to main must never jump a major
+#   version: a single stray `!` in a routine commit would otherwise leap the whole
+#   line (e.g. 5.x -> 6.0). A real major release is a deliberate, manual act (bump
+#   package.json + tag/publish by hand). The breaking change still ships as a minor.
 # - else any `feat:` / `feat(scope):` subject -> minor
 # - else (including commits with no conventional prefix at all) -> patch
 determine_bump() {
   local subjects="$1" full_messages="$2"
   if grep -Eq '^[a-zA-Z]+(\([^)]*\))?!:' <<<"$subjects" ||
     grep -Eq '^BREAKING[- ]CHANGE:' <<<"$full_messages"; then
-    echo "major"
+    log "Breaking-change marker detected, but automated MAJOR bumps are disabled — capping at 'minor'. Cut a major release by hand if one is intended."
+    echo "minor"
   elif grep -Eq '^feat(\([^)]*\))?:' <<<"$subjects"; then
     echo "minor"
   else
@@ -229,16 +234,19 @@ fi
 # Parse version components
 IFS='.' read -r MAJOR MINOR PATCH_NUM <<<"$CURRENT_VERSION"
 
-# Calculate new version
+# Calculate new version. determine_bump never returns "major" (automated major
+# bumps are disabled), so there is no major arm; the `*)` default fails loud if an
+# unexpected value ever reaches here rather than silently leaving NEW_VERSION unset.
 case $BUMP in
-major)
-  NEW_VERSION="$((MAJOR + 1)).0.0"
-  ;;
 minor)
   NEW_VERSION="${MAJOR}.$((MINOR + 1)).0"
   ;;
 patch)
   NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH_NUM + 1))"
+  ;;
+*)
+  log "Error: unexpected bump level '$BUMP' (expected 'minor' or 'patch'). Refusing to guess a version."
+  exit 1
   ;;
 esac
 

--- a/.github/workflows/auto-version.yaml
+++ b/.github/workflows/auto-version.yaml
@@ -37,13 +37,18 @@ jobs:
     steps:
       - name: Checkout
         # Credentials stay persisted: version-bump.sh pushes the release-docs
-        # commit and the vX.Y.Z tag with them. A PAT lets the tag push clear any
-        # tag protection; falls back to GITHUB_TOKEN.
+        # commit and the vX.Y.Z tag with them as github-actions[bot]. The
+        # workflow's `contents: write` authorizes that bot to push to the default
+        # branch and tags of its own repo — do NOT swap in a cross-account PAT
+        # (e.g. TEMPLATE_SYNC_TOKEN, minted for a different owner), which the
+        # remote rejects with a 403 and silently strands every release: npm is
+        # published but the docs commit and tag never land, so the next run
+        # re-reads the climbing npm version and bumps again.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.2 # zizmor: ignore[artipacked]
         with:
           # Need full history so `git describe`/`git log` can find the last tag.
           fetch-depth: 0
-          token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env

--- a/scripts/version-bump.test.mjs
+++ b/scripts/version-bump.test.mjs
@@ -1,0 +1,138 @@
+import { strict as assert } from "node:assert";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const LIVE_SCRIPT = join(REPO_ROOT, ".github", "scripts", "version-bump.sh");
+const AUTO_VERSION_YAML = join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "auto-version.yaml",
+);
+
+// --- Bug B: the release push rides GITHUB_TOKEN, never a cross-account PAT ---
+// The release-docs commit and vX.Y.Z tag are pushed with the credentials the
+// checkout persists. A cross-account PAT (TEMPLATE_SYNC_TOKEN, minted for a
+// different owner) is rejected 403 by this repo's remote, stranding every
+// release: npm publishes but the tag never lands, so the next run re-reads the
+// climbing npm version and bumps again. The push MUST ride GITHUB_TOKEN, whose
+// `contents: write` authorizes github-actions[bot] on its own repo.
+
+test("auto-version.yaml runs the .github/scripts release script", () => {
+  const yaml = readFileSync(AUTO_VERSION_YAML, "utf8");
+  const invocations = [...yaml.matchAll(/bash\s+(\S*version-bump\.sh)/g)].map(
+    (m) => m[1],
+  );
+  assert.deepEqual(
+    invocations,
+    [".github/scripts/version-bump.sh"],
+    "the workflow must run one, and only the .github/scripts, version-bump.sh",
+  );
+  assert.ok(existsSync(LIVE_SCRIPT), "the invoked script must exist on disk");
+});
+
+test("the release checkout pins GITHUB_TOKEN, never a cross-account PAT", () => {
+  const yaml = readFileSync(AUTO_VERSION_YAML, "utf8");
+  const tokenLines = yaml
+    .split("\n")
+    .filter((l) => /^\s*token:/.test(l))
+    .map((l) => l.trim());
+  assert.deepEqual(
+    tokenLines,
+    ["token: ${{ secrets.GITHUB_TOKEN }}"],
+    "the checkout must pin GITHUB_TOKEN, not a fallback to a cross-account PAT",
+  );
+});
+
+// --- Bug A: automated major bumps are disabled ----------------------------
+// A breaking-change marker (`type!:` subject or `BREAKING CHANGE:` footer) must
+// be CAPPED at a minor bump, never a major one: a stray `!` in a routine commit
+// must not leap the whole version line. The npm stub reports the package at
+// 5.0.0 and answers the `pkg@<version>` existence probe with success, so each
+// run stops at the "already exists" guard BEFORE any publish/push — nothing
+// leaves the sandbox.
+const NPM_AT_5_STUB =
+  'if [[ "$2" == *@* ]]; then exit 0; else echo "5.0.0"; fi';
+
+/** Build a throwaway git repo tagged v0.0.0 at HEAD, plus a stubbed `npm`. */
+function makeSandbox(npmStubBody) {
+  const dir = mkdtempSync(join(tmpdir(), "vbump-"));
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "sandbox-pkg", version: "0.0.0" }) + "\n",
+  );
+  const binDir = join(dir, "stub-bin");
+  mkdirSync(binDir);
+  const npmStub = join(binDir, "npm");
+  writeFileSync(npmStub, `#!/usr/bin/env bash\n${npmStubBody}\n`);
+  chmodSync(npmStub, 0o755);
+
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+  git("init", "-q");
+  git("config", "user.email", "t@t.test");
+  git("config", "user.name", "t");
+  git("commit", "-q", "--allow-empty", "-m", "chore: seed");
+  git("tag", "v0.0.0");
+  return { dir, binDir };
+}
+
+/** Run the live script in `dir`; return {status, stderr, stdout}. */
+function runScript(dir, binDir) {
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+  delete env.ANTHROPIC_API_KEY;
+  delete env.GITHUB_OUTPUT;
+  const res = spawnSync("bash", [LIVE_SCRIPT], {
+    cwd: dir,
+    env,
+    encoding: "utf8",
+  });
+  assert.equal(res.error, undefined, "failed to spawn the release script");
+  return { status: res.status, stderr: res.stderr, stdout: res.stdout };
+}
+
+for (const { name, subject, body } of [
+  {
+    name: "a `type!:` subject",
+    subject: "feat(api)!: drop the legacy field",
+    body: "",
+  },
+  {
+    name: "a `BREAKING CHANGE:` footer",
+    subject: "refactor(core): rework the seam",
+    body: "\n\nBREAKING CHANGE: the exported signature changed",
+  },
+]) {
+  test(`${name} is capped at a minor bump, never a major one`, () => {
+    const { dir, binDir } = makeSandbox(NPM_AT_5_STUB);
+    try {
+      const git = (...args) =>
+        execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+      // A breaking-change commit past the v0.0.0 tag — the exact input that used
+      // to decide a major bump (5.x -> 6.0).
+      git("commit", "-q", "--allow-empty", "-m", subject + body);
+      const { status, stderr } = runScript(dir, binDir);
+      assert.equal(status, 0, stderr);
+      assert.match(stderr, /Conventional Commits bump level: minor/);
+      assert.match(stderr, /New version: 5\.1\.0/);
+      assert.doesNotMatch(stderr, /bump level: major/);
+      assert.doesNotMatch(stderr, /New version: 6\./);
+      assert.match(stderr, /automated MAJOR bumps are disabled/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}


### PR DESCRIPTION
This is the **source** template that propagates `auto-version.yaml` + `version-bump.sh` to downstream repos, so fixing it here stops future propagation of two coupled release-automation defects. (Existing downstream copies are fixed in their own PRs — template-sync does not retro-fix them.)

## Bug A — automated MAJOR bumps
`determine_bump()` mapped any Conventional-Commits breaking marker (`type!:` / `type(scope)!:` subject, or a `BREAKING CHANGE:` footer) to `echo "major"`. A single stray `!` in a routine commit then jumped the whole major version line automatically.

**Fix:** cap breaking markers at a **minor** bump (log the cap, `echo "minor"`). In the version-calc `case`, the now-dead `major)` arm is deleted and a `*)` default logs an error and `exit 1` — failing loud instead of leaving `NEW_VERSION` unset if an unexpected bump level ever reaches it. A real major release stays a deliberate manual act.

## Bug B — cross-account PAT hijacks the release push → 403
The release checkout persisted `token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}`. `TEMPLATE_SYNC_TOKEN` is a PAT minted for a **different** account than the repo owner; once set it took over the release-docs commit + `vX.Y.Z` tag push, which the remote rejects with 403. npm would publish, but the `docs: release` commit and tag never landed — so the next run re-read the ever-climbing npm version and bumped again (a self-reinforcing runaway).

**Fix:** pin the checkout to `token: ${{ secrets.GITHUB_TOKEN }}`. `GITHUB_TOKEN` + `contents: write` is the correct actor for a repo pushing to its own `main`/tags.

## Test
Adds `scripts/version-bump.test.mjs` (node:test) guarding both bugs:
- drives the real `version-bump.sh` in a throwaway git repo with `npm` stubbed at 5.0.0; a `type!:` subject **and** a `BREAKING CHANGE:` footer each assert bump level `minor` / `New version: 5.1.0` (never `major` / `6.x`) and the cap message;
- asserts the `auto-version.yaml` checkout token line is exactly `${{ secrets.GITHUB_TOKEN }}`.

The behavioral test uses its own non-private sandbox `package.json`, so it exercises the bump logic even though this template is `private`. This guard propagates to downstream repos on the next template-sync.

## Decisions made
- **The test does not run in this repo's own CI** (the template ships a placeholder `test` script; it's `private` and never publishes). It's carried here so it propagates to downstream repos that do run `node --test`, where it actively guards the fix. Kept at `scripts/version-bump.test.mjs` to match the recursive `node --test` discovery downstreams use.
- **The checkout action pin (`@…` v6.0.2) is left unchanged** — bumping the action version is out of scope for this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGE731B9SzBXvHC59CnGEk)_