### PR TITLE
build(deps): bump ci-truth-serum to pick up branch-ruleset disambiguation fix

### DIFF
--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install the apply tool (ci-truth-serum)
         # Pin to the same ci-truth-serum commit the pre-commit hook uses so the
         # lint and the apply step share one parser version.
-        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@e438c361e232fa2f69ab36ff9a29a1e639e0c5a7"
+        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@1314a61e16854aa43da3612989c86533a5667b30"
 
       - name: Sync required status checks
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,7 +70,7 @@ repos:
   # and global-stdio-swap Python lints. Tier aggregates over per-check ids so a
   # check added upstream to a tier applies here with no config change.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: e438c361e232fa2f69ab36ff9a29a1e639e0c5a7 # main
+    rev: 1314a61e16854aa43da3612989c86533a5667b30 # main
     hooks:
       - id: check-tier1
       - id: check-tier2


### PR DESCRIPTION
Bumps the pinned ci-truth-serum rev from `e438c361` to the merged `1314a61` (both the `.pre-commit-config.yaml` pin and the `sync-required-checks.yaml` pip pin) so the template — and everything synced from it — picks up the branch-ruleset disambiguation fix from ci-truth-serum [#35](https://github.com/AlexanderMattTurner/ci-truth-serum/pull/35).

`find_branch_ruleset` now narrows to the sole `source_type == "Repository"` ruleset when a repo is covered by both its own and an inherited org-level branch ruleset, instead of failing with "Expected exactly one branch ruleset … found 2". Both pins move together to avoid a skew between the sync tool and the pre-commit hooks. The bump also pulls other accumulated ci-truth-serum changes; CI will surface anything needing attention.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGE731B9SzBXvHC59CnGEk)_