### PR TITLE
feat(ci): notify on post-merge and scheduled workflow failures

### DIFF
--- a/.github/scripts/ci-failure-notify.js
+++ b/.github/scripts/ci-failure-notify.js
@@ -1,0 +1,89 @@
+// @ts-check
+"use strict";
+
+const LABEL = "ci-failure";
+
+/**
+ * File (or update) a tracking issue for a failed post-merge or scheduled
+ * workflow run. One open issue per workflow name: a repeat failure adds a
+ * comment instead of a new issue.
+ *
+ * Called by the ci-failure-notify workflow via actions/github-script.
+ *
+ * @param {object} params
+ * @param {object} params.github  - Authenticated Octokit client
+ * @param {object} params.context - GitHub Actions webhook event context
+ */
+module.exports = async ({ github, context }) => {
+  const run = context.payload.workflow_run;
+  const title = `CI failure: ${run.name}`;
+
+  const failureLine = [
+    `**Run:** ${run.html_url}`,
+    `**Conclusion:** ${run.conclusion}`,
+    `**Head SHA:** ${run.head_sha}`,
+    `**Event:** ${run.event}`,
+  ].join("\n");
+
+  // issues.create silently drops labels the caller cannot create, so ensure
+  // the label exists first; a 422 "already_exists" means another run (or a
+  // human) beat us to it.
+  try {
+    await github.rest.issues.createLabel({
+      ...context.repo,
+      name: LABEL,
+      color: "b60205",
+      description: "A post-merge or scheduled workflow run failed",
+    });
+  } catch (error) {
+    const alreadyExists =
+      error.status === 422 &&
+      (error.response?.data?.errors || []).some(
+        (e) => e.code === "already_exists",
+      );
+    if (!alreadyExists) {
+      throw error;
+    }
+  }
+
+  const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+    ...context.repo,
+    state: "open",
+    labels: LABEL,
+    per_page: 100,
+  });
+  // listForRepo returns pull requests too; only real issues are dedup targets.
+  const existing = openIssues.find(
+    (issue) => !issue.pull_request && issue.title === title,
+  );
+
+  if (existing) {
+    await github.rest.issues.createComment({
+      ...context.repo,
+      issue_number: existing.number,
+      body: `Failed again.\n\n${failureLine}`,
+    });
+    console.log(`Commented on existing issue #${existing.number}`);
+    return;
+  }
+
+  const body = [
+    `The **${run.name}** workflow failed on \`${run.head_branch}\`.`,
+    "",
+    failureLine,
+    "",
+    "This issue is filed automatically for post-merge (`push`) and " +
+      "`schedule` runs only — failures on those runs have no PR to surface " +
+      "them, so without this notification they rot unnoticed. Close the " +
+      "issue once the workflow is green again; further failures while it " +
+      "stays open are added as comments.",
+  ].join("\n");
+
+  const created = await github.rest.issues.create({
+    ...context.repo,
+    title,
+    body,
+    labels: [LABEL],
+  });
+  console.log(`Created issue #${created.data.number}`);
+};

--- a/.github/workflows/ci-failure-notify.yaml
+++ b/.github/workflows/ci-failure-notify.yaml
@@ -1,0 +1,70 @@
+name: CI failure notify
+
+# Post-merge (push-to-main) and scheduled workflow failures emit no PR webhook,
+# so they rot unnoticed — releases have silently stopped for weeks downstream.
+# This workflow converts such a failure into an open issue (label: ci-failure),
+# deduplicated per workflow name: repeat failures comment on the existing issue.
+#
+# `workflow_run` has no wildcard, so `workflows:` below must name every
+# workflow in this repo with a `push:` or `schedule:` trigger (matched by the
+# workflow's `name:`). A ci-truth-serum hook (check-failure-notifier-coverage)
+# keeps this list in sync with the tree.
+# The dangerous-triggers finding targets workflows that check out or execute
+# the triggering ref's code with write credentials; this one checks out only
+# the default branch (credential-less) and gates on default-branch runs.
+on: # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    types: [completed]
+    workflows:
+      - Auto version bump and publish
+      - Format check
+      - Gitleaks Secret Scanning
+      - Hook lifecycle
+      - Lint
+      - Node tests
+      - pre-commit
+      - Weekly Security & Dependency Remediation
+      - Sync required status checks
+      - Sync from Template
+      - Validate config
+      - zizmor
+
+concurrency:
+  # Keyed per triggering workflow so failures of different workflows never
+  # queue behind each other; never cancel — a dropped notification defeats
+  # the whole point.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: File or update ci-failure issue
+    # PR-triggered failures are already visible on the PR; only failures of
+    # push/schedule runs on the default branch go unnoticed. Skipped/cancelled
+    # conclusions are not failures.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.event == 'push' ||
+       github.event.workflow_run.event == 'schedule') &&
+      github.event.workflow_run.head_branch == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      # workflow_run workflows always execute from the default branch, so a
+      # plain checkout fetches exactly the code that was vetted on main.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: File or update tracking issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const run = require('./.github/scripts/ci-failure-notify.js')
+            await run({github, context, core})

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ These run inside Claude Code sessions (local CLI or cloud), not in CI.
 | `validate-config.yaml`             | Validates `.claude/` and `.hooks/` config on every push               |
 | `dependabot-auto-merge.yaml`       | Auto-merges minor/patch Dependabot PRs after CI passes                |
 | `auto-version.yaml`                | Post-merge, publishes to npm and tags `vX.Y.Z` (non-private packages) |
+| `ci-failure-notify.yaml`           | Files a `ci-failure` issue when a post-merge or scheduled run fails   |
 
 #### Required checks & branch protection
 


### PR DESCRIPTION
# feat(ci): notify on post-merge and scheduled workflow failures

## Motivation

Failures of post-merge (push-to-main) and scheduled workflow runs emit no PR webhook, so nothing pings anyone and they rot unnoticed — releases have silently stopped for weeks in downstream repos. This converts such a failure into an open, labeled issue that someone actually sees.

## What it does

New `.github/workflows/ci-failure-notify.yaml` + `.github/scripts/ci-failure-notify.js`:

- Triggers on `workflow_run` (`types: [completed]`). `workflow_run` has **no wildcard**, so `workflows:` must explicitly name every workflow with a `push:` or `schedule:` trigger (matched by `name:`). A `check-failure-notifier-coverage` hook landing separately in ci-truth-serum keeps this list synced with the tree.
- Job-level gate: acts only when `conclusion == 'failure'` AND the triggering event is `push` or `schedule` AND `head_branch` is the default branch. PR failures are already visible on the PR; skipped/cancelled are not failures.
- Action: finds an OPEN issue labeled `ci-failure` titled exactly `CI failure: <workflow name>` and comments (run URL, conclusion, head SHA, event); otherwise creates it. Dedup = one open issue per workflow name. The script ensures the `ci-failure` label exists first (`createLabel`, tolerating 422 `already_exists`) since `issues.create` silently drops labels it can't attach.
- All untrusted data (workflow names, SHAs) flows through `context.payload` inside `actions/github-script` — no `run:` block interpolates event fields.
- Hardening: top-level `permissions: contents: read` with job-level `issues: write`; SHA-pinned `actions/checkout` (v7.0.0, `sparse-checkout: .github/scripts`, `persist-credentials: false`) and `actions/github-script` (v9) matching the repo's existing pins; `timeout-minutes: 5`; concurrency keyed per triggering-workflow name with `cancel-in-progress: false` (never a required check). zizmor's `dangerous-triggers` finding is suppressed inline with a justification: the code checked out is the default branch's own (workflow_run runs from the default branch by definition), credential-less, with minimal permissions.

## Covered workflows (every `push:`/`schedule:`-triggered workflow in the tree)

| Workflow file | `name:` | Trigger |
| --- | --- | --- |
| `auto-version.yaml` | Auto version bump and publish | push |
| `format-check.yaml` | Format check | push |
| `gitleaks.yaml` | Gitleaks Secret Scanning | push |
| `hook-lifecycle.yaml` | Hook lifecycle | push |
| `lint.yaml` | Lint | push |
| `node-tests.yaml` | Node tests | push |
| `pre-commit.yaml` | pre-commit | push |
| `security-vulnerability-scan.yaml` | Weekly Security & Dependency Remediation | schedule |
| `sync-required-checks.yaml` | Sync required status checks | push |
| `template-sync.yaml` | Sync from Template | schedule |
| `validate-config.yaml` | Validate config | push |
| `zizmor.yaml` | zizmor | push |

Not covered (no `push:`/`schedule:` trigger): `claude.yaml`, `decide-reusable.yaml`, `dependabot-auto-merge.yaml`, `phone-home.yaml`, and the notifier itself.

Also adds one row to the README's workflows table.

## Validation

- YAML parses; `node --check` passes on the script.
- `pre-commit run` on the changed files: check-yaml, ci-truth-serum tier1/tier2/extras, validate-config, prettier — all pass. zizmor passes offline (`--no-online-audits`; its online advisories audit 403s through this sandbox's proxy). shellcheck/shfmt/actionlint hook environments could not install locally (binary downloads 403 through the proxy) — CI re-runs the full suite.
- `uv run pytest tests/test_version_sync.py tests/test_validate_config.py` — 13 passed.

## Decisions made

- **zizmor `dangerous-triggers` suppression**: zizmor flags any `workflow_run` trigger as high-severity by default. Suppressed inline with a comment explaining why this instance is safe (default-branch checkout, `persist-credentials: false`, minimal permissions). The alternative — no suppression — would permanently red the required zizmor check.
- **Repeat-failure comments say only "Failed again" plus the run facts** rather than trying to diff against the prior failure; anything richer belongs in the linked run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AGE731B9SzBXvHC59CnGEk)_