### PR TITLE
ci: enable path-gate-deps and notifier-coverage lints

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -57,7 +57,8 @@ webi_install_if_missing() {
     # shebang check below, and a version-pinned $pkg instead.
     # pin-exempt: webi.sh bootstrap is generated per-request, no stable digest
     if curl --proto '=https' -fsSL "https://webi.sh/$pkg" -o "$installer" 2>/dev/null; then
-      if head -n 1 "$installer" | grep -q '^#!'; then
+      first_line="$(head -n 1 "$installer")"
+      if grep -q '^#!' <<<"$first_line"; then
         sh "$installer" >/dev/null 2>&1 || warn "Failed to install $cmd"
       else
         warn "Installer for $cmd is not a shell script (missing shebang) — skipping"

--- a/.github/scripts/check-token-scope.sh
+++ b/.github/scripts/check-token-scope.sh
@@ -19,9 +19,10 @@ if ! HEADERS=$(curl --proto '=https' -sSf -I -H "Authorization: token $TOKEN" \
   exit 1
 fi
 
-if echo "$HEADERS" | grep -qi '^x-oauth-scopes:'; then
+if grep -qi '^x-oauth-scopes:' <<<"$HEADERS"; then
   SCOPES=$(echo "$HEADERS" | grep -i '^x-oauth-scopes:' | sed 's/^[^:]*: //' | tr -d '\r\n')
-  if echo "$SCOPES" | tr ',' '\n' | sed 's/^ *//' | grep -qx 'workflow'; then
+  scope_list="$(tr ',' '\n' <<<"$SCOPES" | sed 's/^ *//')"
+  if grep -qx 'workflow' <<<"$scope_list"; then
     echo "Classic PAT has 'workflow' scope."
   else
     echo "::error::Classic TEMPLATE_SYNC_TOKEN lacks the 'workflow' scope, which GitHub requires to push changes to .github/workflows/ files. Add the 'workflow' scope to your PAT at https://github.com/settings/tokens and update the TEMPLATE_SYNC_TOKEN repository secret."

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -33,6 +33,7 @@ jobs:
           - 'uv.lock'
           - '.pre-commit-config.yaml'
           - '.github/scripts/run-hook-lifecycle.sh'
+          - '.github/actions/setup-base-env/**'
           - '.github/workflows/hook-lifecycle.yaml'
 
   hook-lifecycle:

--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install the apply tool (ci-truth-serum)
         # Pin to the same ci-truth-serum commit the pre-commit hook uses so the
         # lint and the apply step share one parser version.
-        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@1314a61e16854aa43da3612989c86533a5667b30"
+        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@ea23549db2d54ebd4391c34f817364db97aeeabe"
 
       - name: Sync required status checks
         env:

--- a/.hooks/lint-skills.sh
+++ b/.hooks/lint-skills.sh
@@ -37,7 +37,8 @@ for file in "$@"; do
   [[ "$grandparent" != "skills" || "$basename_file" != "SKILL.md" ]] && continue
 
   # Check for YAML frontmatter opening delimiter
-  if ! head -1 "$file" | grep -q '^---$'; then
+  first_line="$(head -1 "$file")"
+  if ! grep -q '^---$' <<<"$first_line"; then
     echo "ERROR: $file missing YAML frontmatter (must start with ---)" >&2
     errors=$((errors + 1))
     continue

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,11 +70,31 @@ repos:
   # and global-stdio-swap Python lints. Tier aggregates over per-check ids so a
   # check added upstream to a tier applies here with no config change.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: 1314a61e16854aa43da3612989c86533a5667b30 # main
+    rev: ea23549db2d54ebd4391c34f817364db97aeeabe # main
     hooks:
       - id: check-tier1
+      # check-path-gate-deps and check-failure-notifier-coverage are Tier 2
+      # members but are listed explicitly below (the notifier check needs
+      # --require-notifier, which the aggregate can't pass), so skip them here to
+      # avoid running each twice.
       - id: check-tier2
+        args:
+          [
+            --skip,
+            check_path_gate_deps,
+            --skip,
+            check_failure_notifier_coverage,
+          ]
       - id: check-extras
+      # A gated job whose decide filters omit a composite/script dependency fails
+      # open — the job skips exactly when that dependency changes and the reporter
+      # goes green.
+      - id: check-path-gate-deps
+      # The notifier's workflow_run list is a derived copy of the tree's
+      # push/schedule workflows; --require-notifier fails loud if this repo's
+      # ci-failure-notify.yaml is ever deleted or its list drifts.
+      - id: check-failure-notifier-coverage
+        args: [--require-notifier]
 
   - repo: local
     hooks:


### PR DESCRIPTION
## What

Enable the two new ci-truth-serum Tier 2 workflow-lint hooks and fix what they flag:

- **`check-path-gate-deps`** — fails when a `decide`-gated job depends on a file the decide `filters:` don't cover (the fail-open silent-green class).
- **`check-failure-notifier-coverage`** — verifies `ci-failure-notify.yaml`'s `on.workflow_run.workflows:` list equals the set of push/schedule workflow names.

## Changes

- Bump the ci-truth-serum pin from `1314a61` to `ea23549db2d54ebd4391c34f817364db97aeeabe` in **both** `.pre-commit-config.yaml` (`rev:`) and `.github/workflows/sync-required-checks.yaml` (`pip install … @<sha>`), kept in lockstep so the lint and the ruleset-apply step share one parser version.
- Enable both hooks in `.pre-commit-config.yaml`. Both are Tier 2 members, so they're `--skip`ped from the `check-tier2` aggregate and listed explicitly instead — the notifier check needs `--require-notifier` (which the aggregate can't pass), so listing both explicitly keeps each running exactly once with the correct args.
- Fix the one real gap `check-path-gate-deps` caught (below).

## Decisions made

- **`check-path-gate-deps` caught a real fail-open in `hook-lifecycle.yaml`.** Its gated `hook-lifecycle` job runs `uses: ./.github/actions/setup-base-env`, but the `decide` job's `filters:` did not list that composite action. A PR changing only `.github/actions/setup-base-env/**` would set `run == 'false'`, skip the job, and let the `always()` reporter go green without ever running the hook lifecycle against the changed setup action. Fixed by adding `.github/actions/setup-base-env/**` to the decide filters (adding paths only widens the gate — safe, no risk of over-skipping).
- **`check-failure-notifier-coverage --require-notifier` reported clean** — `ci-failure-notify.yaml`'s `workflows:` list already exactly matches the tree's push/schedule workflows. `--require-notifier` is passed so a future deletion of the notifier (or drift in its list) fails loud instead of silently passing.
- **Both hooks listed explicitly + `--skip`ped from `check-tier2`** rather than relying on the aggregate. Alternative considered: leave them in the aggregate and only override the notifier's args — but the aggregate can't pass `--require-notifier`, and running the notifier check twice (once weak via the aggregate, once strict) is redundant. Skipping both from the aggregate keeps each hook running once with its intended args and makes the enablement auditable in the config.

## Verification

Both hooks run clean locally against this repo's workflows (via the merged ci-truth-serum source):

- `check_path_gate_deps` → exit 0 (after the filter fix; failed before, naming `hook-lifecycle.yaml` / `setup-base-env`).
- `check_failure_notifier_coverage --require-notifier` → exit 0.
- `run_tier 2 --skip check_path_gate_deps --skip check_failure_notifier_coverage` → exit 0.

No `changelog.d` in this repo; releases derive from Conventional Commits, so no changelog fragment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGE731B9SzBXvHC59CnGEk)_