### PR TITLE
feat(skills): add critique-and-improve phase to explore-plan

### DIFF
--- a/.claude/skills/explore-plan/SKILL.md
+++ b/.claude/skills/explore-plan/SKILL.md
@@ -2,16 +2,16 @@
 # prettier-ignore
 name: explore-plan
 description: >
-  Drives the Explore -> Plan -> Review -> Verify discipline for non-trivial, multi-file work before
+  Drives the Explore -> Plan -> Critique -> Review -> Verify discipline for non-trivial, multi-file work before
   any code is written. Activate when the user asks to "plan this", "scope this out", "figure out how
   to do X", "explore the codebase first", or is starting a change that touches several files or an
-  unfamiliar area. Enforces a written plan and real verification instead of trusting a success claim.
+  unfamiliar area. Enforces a self-critiqued written plan and real verification instead of trusting a success claim.
 ---
 
 # Explore / Plan Skill
 
 For non-trivial work, exact context beats approximation and a written plan beats diving in. This
-skill codifies the four-phase loop. Skip it for trivial edits (typos, single-line tweaks)—say so.
+skill codifies the five-phase loop. Skip it for trivial edits (typos, single-line tweaks)—say so.
 
 ## 1. Explore (read-only)
 
@@ -39,13 +39,24 @@ review/verify must see the prior step's result first. Only reach for the `Workfl
 user has explicitly opted into multi-agent orchestration (see its tool description)—otherwise use
 direct parallel `Agent` calls in a single message.
 
-## 3. Review (fresh, unbiased)
+## 3. Critique and improve (self, before any fresh eyes)
+
+Before handing the plan to a reviewer—or executing it—reread the draft as a hostile reviewer of
+someone else's work. Hunt for: premises the exploration didn't actually verify, missing files or
+edge cases, steps that reinvent an existing utility, success criteria you couldn't test, hidden
+ordering dependencies between steps, and scope creep beyond the request. State each finding in one
+line, fix the plan, then re-critique the fix (fixes introduce their own gaps). Repeat until a full
+pass finds nothing, capped at ~3 passes—the same fixed-point discipline as `CLAUDE.md`'s
+Self-Critique Loop, applied to the plan instead of the code. A plan that hasn't survived its own
+critique wastes the reviewer's pass on defects you could have caught yourself.
+
+## 4. Review (fresh, unbiased)
 
 Have the plan—and later the diff—reviewed with no implementation bias. Use the `peer-review`
 skill, which drives the read-only `code-reviewer` subagent. A reviewer that did not write the plan
 catches assumptions the author cannot see.
 
-## 4. Verify (never trust a success claim)
+## 5. Verify (never trust a success claim)
 
 **Never accept “it works” without evidence.** Before declaring done, produce real output: run the
 tests, run the app and observe behavior, capture a screenshot for UI changes, or paste the real
@@ -62,8 +73,10 @@ you cannot exercise the feature, say so explicitly rather than claiming success.
    real middleware files and cites them.
 2. Writes a plan: which middleware to add, where config lives, which existing `RedisClient` helper to
    reuse, which tests to add.
-3. Runs `peer-review` on the plan—reviewer notes the plan misses the health-check path; fixes it.
-4. After implementing, verifies by hitting the endpoint until throttled and pasting the 429 response.
+3. Self-critiques the plan to a fixed point—first pass finds it never chose where the limiter's
+   counters live; fixes it, and the next pass finds nothing.
+4. Runs `peer-review` on the plan—reviewer notes the plan misses the health-check path; fixes it.
+5. After implementing, verifies by hitting the endpoint until throttled and pasting the 429 response.
 
 ### Example 2: Unfamiliar bug
 


### PR DESCRIPTION
## Summary

- Adds an explicit **Critique and improve** phase to the `explore-plan` skill, between Plan and Review: reread the draft plan as a hostile reviewer (unverified premises, missing files/edge cases, reinvented utilities, untestable success criteria, hidden ordering dependencies, scope creep), fix each finding, and re-critique to a fixed point (~3-pass cap) before any fresh-eyes review or execution.
- Renumbers the loop to five phases and updates the frontmatter description, intro, and Example 1 to match. The template-specific "parallelize before executing" subsection under Plan is untouched.

## Changes

- `.claude/skills/explore-plan/SKILL.md`: new `## 3. Critique and improve` section; Review/Verify renumbered to 4/5; description now reads Explore -> Plan -> Critique -> Review -> Verify; Example 1 gains a self-critique step.

## Testing

- Skill re-loaded in a live session; the updated description registers correctly. Docs-only change with no runtime surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjG6igFL4JaG3eJKZBjigE)_