### PR TITLE
ci: add lychee offline internal-link check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,17 @@ repos:
         args: [--fix]
       - id: ruff-format
 
+  # Fail on an internal Markdown link that points at a missing repo-relative
+  # file (link rot from a moved or renamed target). `--offline` resolves only
+  # local file links and skips every http(s)/mailto link, so the check is
+  # deterministic and never flakes on a slow or unreachable external site.
+  - repo: https://github.com/lycheeverse/lychee
+    rev: lychee-v0.24.2
+    hooks:
+      - id: lychee
+        args: [--offline, --no-progress]
+        types: [markdown]
+
   # Honesty + identity CI lints: catch a green check that hides a failed
   # command (pipefail/|| true/2>/dev/null), a path-filtered required check that
   # hangs forever, or a mutable base-image/download pin. Tier 2 adds the


### PR DESCRIPTION
## What

Adds the [lychee](https://github.com/lycheeverse/lychee) link checker as a pre-commit hook, scoped to Markdown and run in `--offline` mode: it fails when an internal Markdown link points at a repo-relative file that does not exist (link rot from a moved or renamed target).

```yaml
- repo: https://github.com/lycheeverse/lychee
  rev: lychee-v0.24.2
  hooks:
    - id: lychee
      args: [--offline, --no-progress]
      types: [markdown]
```

## Why

This is the "reference existence" / internal-link check we wanted, delivered off-the-shelf instead of porting a bespoke Python script. `--offline` skips every `http(s)`/`mailto` link and resolves only local file links, so the check is deterministic and never flakes on a slow or unreachable external site. It runs locally via the existing `.hooks/pre-commit` and in CI via the existing `pre-commit.yaml` (`pre-commit run --all-files`) — no new workflow needed.

The `lychee` hook (`language: script`) auto-installs its own binary, so no `session-setup.sh` provisioning is added. Pinned by release tag, matching the convention for the other pinned-release hooks in this file (SHA pinning here is reserved for the main-tracking `ci-truth-serum`).

## Verification

Scanned every tracked `*.md` in the repo for broken internal links across inline, reference-style, and HTML `href`/`src` forms before wiring the hook: **0 broken**. CI's real lychee run is the authoritative gate.

## Decisions made

- **Off-the-shelf (lychee) over porting a custom checker.** The sibling `claude-guard` repo has a bespoke `check-internal-links.py`, but it exists to encode repo-specific base resolution (`changelog.d/`/`.github/` links resolve against the repo root because fragments get assembled into a root `CHANGELOG.md`) that this template does not have. With no such wrinkle here, lychee's default file-relative resolution is a correct, lower-maintenance fit. Under the alternative (porting the Python), we'd own ~110 lines and a test for no added correctness.
- **Committed with `--no-verify`.** The local pre-commit run would clone the new `lycheeverse/lychee` hook repo, which a repo-scoped web-session proxy 403s (it authorizes only in-scope repos). CI runs the hook on clean network. Known limitation: in a web session behind that proxy, the hook's binary auto-install may 403 and fall back to `--no-verify`; CI remains the authoritative enforcement, consistent with how other rev-pinned hooks already behave here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SV9g3tmU1buDUsNzWTmtRw)_