### PR TITLE
feat(hooks): deterministic parallelism-nudge PostToolUse hook

### DIFF
--- a/.claude/hooks/parallelism-nudge.mjs
+++ b/.claude/hooks/parallelism-nudge.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+/**
+ * PostToolUse advisory: measure, from the session transcript, whether the
+ * current user-turn is actually using parallel execution — sub-agent
+ * delegation (Task/Agent/Workflow) or same-message tool-call batches — and
+ * splice in a one-time nudge with the concrete numbers when a long
+ * fully-serial streak is detected. This is the deterministic enforcement arm
+ * of CLAUDE.md's parallelism rule: prose is ignorable, a mid-turn count of
+ * "31 serial tool calls, 0 delegations" is not.
+ *
+ * Non-blocking by design (additionalContext, never a block): serial work can
+ * be legitimate (a chain of dependent edits), so this is friction, not a
+ * wall. It fails OPEN — any internal error lets the tool result through
+ * untouched — and nudges at most once per user-turn segment (a /tmp sentinel
+ * keyed on session + segment), so a long turn is not re-narrated per call.
+ *
+ * Dependency-free on purpose: the template ships no node_modules, so the hook
+ * must run on a bare `node` from a fresh clone.
+ */
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  openSync,
+  readSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/** Serial tool-turns (assistant messages with >=1 tool call, no delegation
+ * anywhere in the segment) after which the nudge fires. High enough that a
+ * short dependent chain (read -> edit -> test) never trips it. */
+export const SERIAL_TOOL_TURN_THRESHOLD = 15;
+
+/** Tools whose use IS parallel delegation — any one of them in the current
+ * user-turn segment proves sub-agents are engaged and silences the nudge.
+ * (`Task` is the Claude Code CLI's native name for the sub-agent tool;
+ * `Agent` is the remote harness's name for the same tool.) */
+export const DELEGATION_TOOLS = new Set(["Task", "Agent", "Workflow"]);
+
+/** Bound on how much transcript is read per invocation. A window this size
+ * always covers the current user-turn segment in practice; when it doesn't,
+ * stats are computed over the window alone, which only under-counts. */
+export const TRANSCRIPT_TAIL_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Last `maxBytes` of the file at `path`, trimmed to whole JSONL lines (the
+ * leading partial line after a mid-file start is dropped).
+ * @param {string} path
+ * @param {number} [maxBytes]
+ * @returns {string}
+ */
+export function readTranscriptTail(path, maxBytes = TRANSCRIPT_TAIL_BYTES) {
+  const fd = openSync(path, "r");
+  try {
+    const size = fstatSync(fd).size;
+    const start = Math.max(0, size - maxBytes);
+    const buf = Buffer.alloc(size - start);
+    readSync(fd, buf, 0, buf.length, start);
+    const text = buf.toString("utf8");
+    if (start === 0) return text;
+    const nl = text.indexOf("\n");
+    return nl === -1 ? "" : text.slice(nl + 1);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * The tool_use blocks of one main-thread assistant transcript line, or [] when
+ * the line is not one (wrong type, sidechain, or no tool_use content).
+ * @param {any} entry
+ * @returns {Array<{ type: string, name: string }>}
+ */
+function toolUsesOf(entry) {
+  if (typeof entry !== "object" || entry === null) return [];
+  if (entry.isSidechain === true || entry.type !== "assistant") return [];
+  const content = entry.message?.content;
+  if (!Array.isArray(content)) return [];
+  return content.filter(
+    (block) =>
+      block !== null && typeof block === "object" && block.type === "tool_use",
+  );
+}
+
+/**
+ * Parallelism stats for the transcript's CURRENT user-turn segment (all
+ * main-thread entries after the last real user prompt). One API message is
+ * written to the transcript as one line per content block, all sharing
+ * `message.id` — so a tool "turn" is a distinct assistant message id, and its
+ * batch size is the number of tool_use blocks across its lines. Sidechain
+ * (sub-agent) lines are excluded: they must not count as the main thread's own
+ * serial work. Malformed lines are skipped, never fatal.
+ * @param {string} jsonlText transcript tail, JSONL
+ * @returns {{
+ *   toolTurns: number, totalCalls: number, batchedTurns: number,
+ *   maxBatch: number, delegations: number, segmentKey: string,
+ * }}
+ */
+export function analyzeParallelism(jsonlText) {
+  /** @type {Map<string, { calls: number, delegations: number }>} */
+  let turns = new Map();
+  let segmentKey = "head";
+  for (const line of jsonlText.split("\n")) {
+    if (line.trim() === "") continue;
+    /** @type {any} */
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (typeof entry !== "object" || entry === null) continue;
+    if (
+      entry.isSidechain !== true &&
+      entry.type === "user" &&
+      !("toolUseResult" in entry)
+    ) {
+      // A real user prompt (tool results always carry toolUseResult): the
+      // measured segment restarts here.
+      turns = new Map();
+      segmentKey = typeof entry.uuid === "string" ? entry.uuid : "head";
+      continue;
+    }
+    const uses = toolUsesOf(entry);
+    if (uses.length === 0) continue;
+    const id =
+      typeof entry.message?.id === "string"
+        ? entry.message.id
+        : String(entry.uuid);
+    const turn = turns.get(id) ?? { calls: 0, delegations: 0 };
+    turn.calls += uses.length;
+    turn.delegations += uses.filter((block) =>
+      DELEGATION_TOOLS.has(block.name),
+    ).length;
+    turns.set(id, turn);
+  }
+  let totalCalls = 0;
+  let batchedTurns = 0;
+  let maxBatch = 0;
+  let delegations = 0;
+  for (const turn of turns.values()) {
+    totalCalls += turn.calls;
+    if (turn.calls >= 2) batchedTurns += 1;
+    if (turn.calls > maxBatch) maxBatch = turn.calls;
+    delegations += turn.delegations;
+  }
+  return {
+    toolTurns: turns.size,
+    totalCalls,
+    batchedTurns,
+    maxBatch,
+    delegations,
+    segmentKey,
+  };
+}
+
+/**
+ * The nudge text for `stats`, with the concrete serial count spliced in.
+ * @param {ReturnType<typeof analyzeParallelism>} stats
+ * @returns {string}
+ */
+export function nudgeMessage(stats) {
+  return (
+    `Parallelism check: ${stats.toolTurns} tool-calling turns ` +
+    `(${stats.totalCalls} tool calls) this user-turn with ZERO sub-agent ` +
+    `delegations and ${stats.batchedTurns} batched turn(s). CLAUDE.md says ` +
+    `to run independent steps in parallel: partition the remaining work ` +
+    `now, fan every independently-delegable piece out to parallel ` +
+    `sub-agents (Task/Agent) in one batch, and batch independent tool ` +
+    `calls into a single message. If ALL remaining work is genuinely ` +
+    `dependent, continue — this note is advisory and fires at most once ` +
+    `per user turn.`
+  );
+}
+
+/**
+ * Path of the once-per-user-turn-segment sentinel. Hash-keyed so arbitrary
+ * session/segment ids never form path components.
+ * @param {string} sessionId
+ * @param {string} segmentKey
+ * @param {string} dir
+ * @returns {string}
+ */
+export function nudgeSentinel(sessionId, segmentKey, dir) {
+  const key = createHash("sha256")
+    .update(`${sessionId}\n${segmentKey}`)
+    .digest("hex")
+    .slice(0, 16);
+  return join(dir, `.claude-parallelism-nudge-${key}`);
+}
+
+/**
+ * Decide the hook response for one raw PostToolUse payload: the
+ * hookSpecificOutput body carrying the nudge, or null for silence.
+ * @param {any} payload parsed hook stdin JSON
+ * @param {{
+ *   readTranscript: (path: string) => string,
+ *   alreadyNudged: (sessionId: string, segmentKey: string) => boolean,
+ *   recordNudged: (sessionId: string, segmentKey: string) => void,
+ * }} deps
+ * @returns {{ hookSpecificOutput: { hookEventName: string, additionalContext: string } } | null}
+ */
+export function judgeParallelism(payload, deps) {
+  if (typeof payload !== "object" || payload === null) return null;
+  if (payload.hook_event_name !== "PostToolUse") return null;
+  // A delegation call just happened — by definition not a serial streak.
+  if (DELEGATION_TOOLS.has(payload.tool_name)) return null;
+  const { transcript_path: transcriptPath, session_id: sessionId } = payload;
+  if (typeof transcriptPath !== "string" || typeof sessionId !== "string")
+    return null;
+  const stats = analyzeParallelism(deps.readTranscript(transcriptPath));
+  if (stats.delegations > 0 || stats.toolTurns < SERIAL_TOOL_TURN_THRESHOLD)
+    return null;
+  if (deps.alreadyNudged(sessionId, stats.segmentKey)) return null;
+  deps.recordNudged(sessionId, stats.segmentKey);
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: nudgeMessage(stats),
+    },
+  };
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    const payload = JSON.parse(await readStdin());
+    const sentinelDir = process.env.TMPDIR || "/tmp";
+    const response = judgeParallelism(payload, {
+      readTranscript: (path) => readTranscriptTail(path),
+      alreadyNudged: (sessionId, segmentKey) =>
+        existsSync(nudgeSentinel(sessionId, segmentKey, sentinelDir)),
+      recordNudged: (sessionId, segmentKey) => {
+        try {
+          writeFileSync(nudgeSentinel(sessionId, segmentKey, sentinelDir), "");
+        } catch {
+          // A read-only /tmp just means the note may repeat — never a reason to fail.
+        }
+      },
+    });
+    if (response !== null) process.stdout.write(JSON.stringify(response));
+  } catch {
+    process.exit(0); // Advisory only: never block the agent on a hook fault.
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/parallelism-nudge.mjs",
+            "timeout": 60
+          }
+        ]
+      }
     ]
   }
 }

--- a/.github/scripts/validate-config.sh
+++ b/.github/scripts/validate-config.sh
@@ -58,6 +58,11 @@ for f in .hooks/* .claude/hooks/*; do
       error "$f has a python syntax error: $py_err"
     fi
     ;;
+  *.mjs | *.cjs | *.js)
+    if ! node_err=$(node --check "$f" 2>&1); then
+      error "$f has a JavaScript syntax error: $node_err"
+    fi
+    ;;
   *)
     if ! bash_err=$(bash -n "$f" 2>&1); then
       error "$f has a bash syntax error: $bash_err"

--- a/README.md
+++ b/README.md
@@ -58,21 +58,22 @@ A GitHub template that makes [Claude Code](https://docs.anthropic.com/en/docs/cl
 
 These run inside Claude Code sessions (local CLI or cloud), not in CI.
 
-| Hook           | What it does                                                              |
-| -------------- | ------------------------------------------------------------------------- |
-| `SessionStart` | Installs tools (shfmt, shellcheck), configures git, installs dependencies |
-| `PreToolUse`   | Runs build/lint/typecheck/tests before `git push` or `gh pr create`       |
+| Hook           | What it does                                                                                                              |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `SessionStart` | Installs tools (shfmt, shellcheck), configures git, installs dependencies                                                 |
+| `PreToolUse`   | Runs build/lint/typecheck/tests before `git push` or `gh pr create`                                                       |
+| `PostToolUse`  | Nudges once per turn (with the counts) when work runs serially instead of using parallel sub-agents or batched tool calls |
 
 ### Claude Skills (`.claude/skills/`)
 
-| Skill                  | What it does                                                                    |
-| ---------------------- | ------------------------------------------------------------------------------- |
-| `pr-creation`          | Self-critique workflow before PR submission, then watches CI and fixes failures |
-| `update-pr`            | Updates an existing PR with new changes and optionally revises the description  |
-| `conventional-commits` | Guides Claude through properly formatted commits with secret detection          |
-| `markdown-block`       | Outputs content in a fenced code block so users can copy raw markdown           |
-| `peer-review`          | Runs the read-only `code-reviewer` agent on the diff, then triages and fixes    |
-| `explore-plan`         | Enforces the Explore → Plan → Review → Verify discipline for non-trivial work   |
+| Skill                  | What it does                                                                             |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| `pr-creation`          | Self-critique workflow before PR submission, then watches CI and fixes failures          |
+| `update-pr`            | Updates an existing PR with new changes and optionally revises the description           |
+| `conventional-commits` | Guides Claude through properly formatted commits with secret detection                   |
+| `markdown-block`       | Outputs content in a fenced code block so users can copy raw markdown                    |
+| `peer-review`          | Runs the read-only `code-reviewer` agent on the diff, then triages and fixes             |
+| `explore-plan`         | Enforces the Explore → Plan → Critique → Review → Verify discipline for non-trivial work |
 
 ### Claude Subagents (`.claude/agents/`)
 
@@ -82,24 +83,29 @@ These run inside Claude Code sessions (local CLI or cloud), not in CI.
 
 ### GitHub Actions (`.github/workflows/`)
 
-| Workflow                           | What it does                                                          |
-| ---------------------------------- | --------------------------------------------------------------------- |
-| `claude.yaml`                      | Responds to `@claude` mentions in issues and PR comments              |
-| `template-sync.yaml`               | Daily sync from template repo with 3-way merge and conflict detection |
-| `phone-home.yaml`                  | Propagates “Lessons Learned” from merged PRs back to the template     |
-| `security-vulnerability-scan.yaml` | Weekly security sweep—collects alerts, opens a rollup fix PR          |
-| `node-tests.yaml`                  | Runs `pnpm test` (skips gracefully if unconfigured)                   |
-| `lint.yaml`                        | Runs `pnpm lint` and `pnpm check` (skips gracefully if unconfigured)  |
-| `format-check.yaml`                | Checks Prettier formatting                                            |
-| `pre-commit.yaml`                  | Runs pre-commit hooks in CI                                           |
-| `validate-config.yaml`             | Validates `.claude/` and `.hooks/` config on every push               |
-| `dependabot-auto-merge.yaml`       | Auto-merges minor/patch Dependabot PRs after CI passes                |
-| `auto-version.yaml`                | Post-merge, publishes to npm and tags `vX.Y.Z` (non-private packages) |
-| `ci-failure-notify.yaml`           | Files a `ci-failure` issue when a post-merge or scheduled run fails   |
+| Workflow                           | What it does                                                                                          |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `claude.yaml`                      | Responds to `@claude` mentions in issues and PR comments                                              |
+| `template-sync.yaml`               | Daily sync from template repo with 3-way merge and conflict detection                                 |
+| `phone-home.yaml`                  | Propagates “Lessons Learned” from merged PRs back to the template                                     |
+| `security-vulnerability-scan.yaml` | Weekly security sweep—collects alerts, opens a rollup fix PR                                          |
+| `node-tests.yaml`                  | Runs `pnpm test` (skips gracefully if unconfigured)                                                   |
+| `lint.yaml`                        | Runs `pnpm lint` and `pnpm check` (skips gracefully if unconfigured)                                  |
+| `format-check.yaml`                | Checks Prettier formatting                                                                            |
+| `pre-commit.yaml`                  | Runs pre-commit hooks in CI                                                                           |
+| `validate-config.yaml`             | Validates `.claude/` and `.hooks/` config on every push                                               |
+| `dependabot-auto-merge.yaml`       | Auto-merges minor/patch Dependabot PRs after CI passes                                                |
+| `auto-version.yaml`                | Post-merge, publishes to npm and tags `vX.Y.Z` (non-private packages)                                 |
+| `ci-failure-notify.yaml`           | Files a `ci-failure` issue when a post-merge or scheduled run fails                                   |
+| `gitleaks.yaml`                    | Scans for committed secrets (PR diff, full history on main); PR-gating                                |
+| `zizmor.yaml`                      | Security-audits workflows/actions with zizmor; PR-gating                                              |
+| `hook-lifecycle.yaml`              | Runs the full Claude hook lifecycle on a clean checkout so a broken hook is caught in CI; PR-gating   |
+| `build-publish-notify.yaml`        | Pushes a phone alert (ntfy) when a build/publish run fails outside a PR (opt-in via `GH_NTFY_*`)      |
+| `sync-required-checks.yaml`        | Post-merge, syncs branch-protection required checks to the workflows' `# required-check:` annotations |
 
 #### Required checks & branch protection
 
-Each PR-gating workflow (`format-check`, `lint`, `node-tests`, `pre-commit`, `validate-config`) ends with an `if: always()` summary job—`format-check-passed`, `lint-passed`, `node-tests-passed`, `pre-commit-passed`, `validate-config-passed`—that `needs:` the real job(s) and passes only when they all succeed (or skip). **Mark these `*-passed` jobs as Required in branch protection, not the underlying jobs.** A job that is cancelled or skipped never reports a status to GitHub, so a directly-Required job can leave a PR stuck “pending” forever; the always-running summary job (`if: always()` plus a `contains(needs.*.result, …)` guard) reports a definitive pass/fail instead.
+Each PR-gating workflow (`format-check`, `lint`, `node-tests`, `pre-commit`, `validate-config`, `gitleaks`, `zizmor`, `hook-lifecycle`) ends with an `if: always()` summary job—`format-check-passed`, `lint-passed`, `node-tests-passed`, `pre-commit-passed`, `validate-config-passed`, `gitleaks-passed`, `zizmor-passed`, `hook-lifecycle-passed`—that `needs:` the real job(s) and passes only when they all succeed (or skip). **Mark these `*-passed` jobs as Required in branch protection, not the underlying jobs.** (`sync-required-checks.yaml` keeps that set in step with the workflows' `# required-check:` annotations automatically, if you grant it a token.) A job that is cancelled or skipped never reports a status to GitHub, so a directly-Required job can leave a PR stuck “pending” forever; the always-running summary job (`if: always()` plus a `contains(needs.*.result, …)` guard) reports a definitive pass/fail instead.
 
 > **Caveat:** the summary job only helps when its workflow runs at all. `lint`, `node-tests`, and `validate-config` use `paths` filters, so on a PR that doesn’t touch their paths the _entire_ workflow (summary job included) is skipped and posts nothing. If you mark those `*-passed` checks Required, drop the workflow’s `paths` filter (let the job run and short-circuit internally) so the gate always reports.
 
@@ -136,6 +142,8 @@ The `env` block in `.claude/settings.json` sets defaults tuned for long-running 
 | `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` | Disables autoupdater/telemetry/error reporting (CI- and web-safe)      |
 
 See the [Claude Code environment variables reference](https://code.claude.com/docs/en/env-vars) for the full list.
+
+The same file's `permissions.deny` block blocks Claude from reading secret files (`**/.env`, `**/.env.*`, `**/*.pem`, `**/*.key`) so credentials can't be surfaced into a session transcript.
 
 ## How the Pieces Fit Together
 
@@ -175,11 +183,13 @@ Changes arrive as a PR for you to review. The sync uses a 3-way merge that prese
 
 Repository **settings and secrets are never copied** when you create a repo from a template or when `template-sync` runs—both only move files. So each consuming repo configures these once. The workflows read:
 
-| Secret                | Used by                                                 | Required?                             |
-| --------------------- | ------------------------------------------------------- | ------------------------------------- |
-| `ANTHROPIC_API_KEY`   | `claude`, `security-vulnerability-scan`, `auto-version` | For Claude-backed workflows           |
-| `TEMPLATE_SYNC_TOKEN` | `template-sync`, `phone-home`, `auto-version`           | Optional—falls back to `GITHUB_TOKEN` |
-| `PUSH_TOKEN`          | `security-vulnerability-scan`                           | Optional—falls back to `GITHUB_TOKEN` |
+| Secret                | Used by                                                 | Required?                                                        |
+| --------------------- | ------------------------------------------------------- | ---------------------------------------------------------------- |
+| `ANTHROPIC_API_KEY`   | `claude`, `security-vulnerability-scan`, `auto-version` | For Claude-backed workflows                                      |
+| `TEMPLATE_SYNC_TOKEN` | `template-sync`, `phone-home`, `auto-version`           | Optional—falls back to `GITHUB_TOKEN`                            |
+| `PUSH_TOKEN`          | `security-vulnerability-scan`                           | Optional—falls back to `GITHUB_TOKEN`                            |
+| `GH_NTFY_SUBJECT`     | `build-publish-notify`                                  | Optional—enables the ntfy failure alert (a no-op if unset)       |
+| `GH_NTFY_URL`         | `build-publish-notify`                                  | Optional—targets a self-hosted ntfy server (defaults to ntfy.sh) |
 
 `TEMPLATE_SYNC_TOKEN` should be a **fine-grained PAT** (it lets sync/release PRs touch workflow files and clear tag protection, which `GITHUB_TOKEN` can’t):
 

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -158,6 +158,12 @@ def run_session_setup(
             "CLAUDE_PROJECT_DIR": str(sandbox),
             "CLAUDE_ENV_FILE": str(env_file),
             "GH_TOKEN": "fake",
+            # Ignore ambient host git config: a Claude Code web session
+            # installs a global url.insteadOf rewrite that makes
+            # `git remote get-url` return a proxy URL for a plain
+            # github.com remote, flipping the GH_REPO cases.
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
         }
     )
     if extra_env:

--- a/tests/test_parallelism_nudge.py
+++ b/tests/test_parallelism_nudge.py
@@ -42,7 +42,9 @@ def _serial_transcript(turns: int, extra_lines: list[str] | None = None) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _run_hook(transcript: Path, tmp_dir: Path, session: str = "sess") -> subprocess.CompletedProcess:
+def _run_hook(
+    transcript: Path, tmp_dir: Path, session: str = "sess"
+) -> subprocess.CompletedProcess:
     payload = {
         "hook_event_name": "PostToolUse",
         "tool_name": "Bash",
@@ -67,7 +69,9 @@ def test_nudges_on_serial_streak_then_sentinel_silences(tmp_path: Path) -> None:
     assert first.returncode == 0
     body = json.loads(first.stdout)["hookSpecificOutput"]
     assert body["hookEventName"] == "PostToolUse"
-    assert f"{SERIAL_TOOL_TURN_THRESHOLD} tool-calling turns" in body["additionalContext"]
+    assert (
+        f"{SERIAL_TOOL_TURN_THRESHOLD} tool-calling turns" in body["additionalContext"]
+    )
     second = _run_hook(transcript, tmp_path)
     assert second.returncode == 0
     assert second.stdout == ""

--- a/tests/test_parallelism_nudge.py
+++ b/tests/test_parallelism_nudge.py
@@ -1,0 +1,111 @@
+"""End-to-end tests for .claude/hooks/parallelism-nudge.mjs.
+
+Each test drives the real hook as a subprocess with a real transcript file on
+disk and asserts the observable outcome: the hookSpecificOutput JSON on stdout
+(or silence), the exit code, and the once-per-segment sentinel behavior.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "parallelism-nudge.mjs"
+
+SERIAL_TOOL_TURN_THRESHOLD = 15
+
+
+def _prompt_line(uuid: str = "u1") -> str:
+    return json.dumps(
+        {"type": "user", "uuid": uuid, "message": {"role": "user", "content": "go"}}
+    )
+
+
+def _tool_line(msg_id: str, name: str) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "uuid": f"a-{msg_id}",
+            "message": {
+                "role": "assistant",
+                "id": msg_id,
+                "content": [{"type": "tool_use", "name": name, "input": {}}],
+            },
+        }
+    )
+
+
+def _serial_transcript(turns: int, extra_lines: list[str] | None = None) -> str:
+    lines = [_prompt_line("seg")]
+    lines += [_tool_line(f"m{i}", "Bash") for i in range(turns)]
+    lines += extra_lines or []
+    return "\n".join(lines) + "\n"
+
+
+def _run_hook(transcript: Path, tmp_dir: Path, session: str = "sess") -> subprocess.CompletedProcess:
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "true"},
+        "tool_response": "ok",
+        "session_id": session,
+        "transcript_path": str(transcript),
+    }
+    return subprocess.run(
+        ["node", str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(tmp_dir)},
+    )
+
+
+def test_nudges_on_serial_streak_then_sentinel_silences(tmp_path: Path) -> None:
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(_serial_transcript(SERIAL_TOOL_TURN_THRESHOLD))
+    first = _run_hook(transcript, tmp_path)
+    assert first.returncode == 0
+    body = json.loads(first.stdout)["hookSpecificOutput"]
+    assert body["hookEventName"] == "PostToolUse"
+    assert f"{SERIAL_TOOL_TURN_THRESHOLD} tool-calling turns" in body["additionalContext"]
+    second = _run_hook(transcript, tmp_path)
+    assert second.returncode == 0
+    assert second.stdout == ""
+
+
+def test_silent_below_threshold(tmp_path: Path) -> None:
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(_serial_transcript(SERIAL_TOOL_TURN_THRESHOLD - 1))
+    result = _run_hook(transcript, tmp_path)
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_delegation_in_segment_silences(tmp_path: Path) -> None:
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        _serial_transcript(
+            SERIAL_TOOL_TURN_THRESHOLD, extra_lines=[_tool_line("mT", "Task")]
+        )
+    )
+    result = _run_hook(transcript, tmp_path)
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_fails_open_on_missing_transcript(tmp_path: Path) -> None:
+    result = _run_hook(tmp_path / "missing.jsonl", tmp_path)
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_fails_open_on_malformed_stdin(tmp_path: Path) -> None:
+    result = subprocess.run(
+        ["node", str(HOOK)],
+        input="not json {",
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(tmp_path)},
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -109,16 +109,55 @@ def test_fails_when_settings_json_is_malformed(tmp_path: Path, copy_script) -> N
     assert (result.stdout + result.stderr).count("could not be parsed") == 2
 
 
-def test_rejects_hook_with_syntax_error(tmp_path: Path, copy_script) -> None:
-    """Hook scripts with bash syntax errors must be caught with a useful message."""
+@pytest.mark.parametrize(
+    "rel_path, body, expected_substring",
+    [
+        # unclosed [[ is a bash syntax error
+        (".hooks/bad.sh", "#!/usr/bin/env bash\nif [[\n", "has a bash syntax error"),
+        # bare `def` with no name is a python syntax error
+        (
+            ".claude/hooks/bad.py",
+            "#!/usr/bin/env python3\ndef\n",
+            "has a python syntax error",
+        ),
+        # a JSDoc comment with `(` is fine for node but chokes bash -n; the
+        # validator must pick node --check for a .mjs hook, not bash.
+        (
+            ".claude/hooks/bad.mjs",
+            "#!/usr/bin/env node\nexport const x = (\n",
+            "has a JavaScript syntax error",
+        ),
+    ],
+    ids=["bash", "python", "mjs"],
+)
+def test_rejects_hook_with_syntax_error(
+    tmp_path: Path, copy_script, rel_path: str, body: str, expected_substring: str
+) -> None:
+    """Each interpreter arm catches a syntax error in its own language with a
+    useful message — a Node (.mjs) hook is checked with node, not bash -n."""
     write_settings(tmp_path, {"hooks": {}})
-    path = tmp_path / ".hooks" / "bad.sh"
+    path = tmp_path / rel_path
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text("#!/usr/bin/env bash\nif [[\n")  # unclosed [[ is a syntax error
+    path.write_text(body)
     path.chmod(0o755)
     result = run_validator(tmp_path, copy_script)
     assert result.returncode == 1
-    assert "has a bash syntax error" in result.stdout + result.stderr
+    assert expected_substring in result.stdout + result.stderr
+
+
+def test_accepts_valid_mjs_hook(tmp_path: Path, copy_script) -> None:
+    """A syntactically valid .mjs hook (JSDoc comments and all) passes — the
+    regression guard for parallelism-nudge.mjs tripping the bash arm."""
+    write_settings(tmp_path, {"hooks": {}})
+    path = tmp_path / ".claude" / "hooks" / "ok.mjs"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "#!/usr/bin/env node\n/** doc (Task/Agent) */\nexport const x = 1;\n"
+    )
+    path.chmod(0o755)
+    result = run_validator(tmp_path, copy_script)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "All checks passed" in result.stdout
 
 
 def _pretooluse_settings(cmd: str) -> dict:


### PR DESCRIPTION
## Summary

- Adds a **deterministic parallelism check**: a new advisory PostToolUse hook, `.claude/hooks/parallelism-nudge.mjs`, that measures actual sub-agent delegation and tool-call batching from the session transcript and splices a one-time `additionalContext` nudge — with the concrete numbers — into the agent's stream when the current user-turn has run **15+ tool-calling turns with zero delegations** (Task/Agent/Workflow). CLAUDE.md's "run independent steps in parallel" rule is prose the agent can ignore; a mid-turn count of "15 serial tool calls, 0 delegations" is not.
- Fixes an environment-sensitivity bug in the `session-setup.sh` tests: in a Claude Code web session a global `url.insteadOf` rewrite makes `git remote get-url` return a proxy URL for a plain `github.com` remote, flipping the `GH_REPO` extraction cases. The test helper now runs with `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pointed at `/dev/null`.
- Fixes `validate-config.sh` to dispatch the hook syntax check by interpreter: it previously checked every non-`.py` hook with `bash -n`, so the new `.mjs` Node hook failed as a "bash syntax error" on its JSDoc. Adds a `.mjs`/`.cjs`/`.js` arm using `node --check`.
- Documents the new hook and several previously-undocumented features in the README (see below).

## Changes

- `.claude/hooks/parallelism-nudge.mjs` — dependency-free (runs on bare `node` from a fresh clone). Parses the transcript tail (8 MiB bound) over the current user-turn segment (entries after the last real user prompt; sidechain lines excluded); groups tool "turns" by `message.id` so same-message batches count as parallelism; advisory-only and fail-open; at most one nudge per user-turn segment via a hash-keyed `/tmp` sentinel.
- `.claude/settings.json` — wires the hook into `PostToolUse`.
- `.github/scripts/validate-config.sh` + `tests/test_validate_config.py` — interpreter-dispatched syntax check (bash/python/js), covered member-by-member plus a valid-`.mjs` regression case.
- `tests/test_parallelism_nudge.py` — end-to-end subprocess tests (nudge fires at threshold, sentinel silences the second run, delegation in segment silences, below-threshold silent, fail-open on missing transcript and malformed stdin).
- `tests/test_claude_hooks.py` — git-config isolation in `run_session_setup`.
- `README.md` — documents the `PostToolUse` nudge row; the `gitleaks`, `zizmor`, `hook-lifecycle`, `build-publish-notify`, and `sync-required-checks` workflows (with their required-check and `GH_NTFY_*` secret wiring); the `permissions.deny` secret-read guard; and corrects the `explore-plan` phase list.

## Testing

- `uv run --extra dev pytest tests/` — 91 passed
- `bash .github/scripts/validate-config.sh` passes with the `.mjs` hook present; `node --check` / `bash -n` behavior verified directly
- Prettier + ruff clean

## Decisions made

- **Dependency-free variant**: the downstream `agent-glovebox` version of this hook (sibling PR AlexanderMattTurner/agent-glovebox#2204) routes through its `agent-control-plane-core` boundary; the template ships no `node_modules`, so this variant emits the native `hookSpecificOutput` body directly.
- **Advisory, never a block**: serial work can be legitimate (dependent edit chains), so this is friction with concrete numbers, not a wall.
- **Trigger = zero delegations despite 15+ tool turns**; the threshold is high enough that a read → edit → test chain never trips it.