### PR TITLE
fix(hooks): fail loudly when pre-push-check.sh can't run ruff

### DIFF
--- a/.claude/hooks/pre-push-check.sh
+++ b/.claude/hooks/pre-push-check.sh
@@ -35,10 +35,15 @@ fi
 
 # Python checks
 if [[ -f pyproject.toml ]] || [[ -f uv.lock ]]; then
-  RUFF_CMD=(ruff check .)
-  [[ -f uv.lock ]] && exists uv && RUFF_CMD=(uv run ruff check .)
-
-  { exists ruff || { [[ -f uv.lock ]] && exists uv; }; } && run_check "ruff" "${RUFF_CMD[@]}"
+  if [[ -f uv.lock ]] && exists uv; then
+    run_check "ruff" uv run ruff check .
+  elif exists ruff; then
+    run_check "ruff" ruff check .
+  else
+    echo "=== ruff FAILED ===" >&2
+    echo "Neither ruff nor uv (with uv.lock) is available to run Python checks." >&2
+    FAILED=1
+  fi
 fi
 
 exit $FAILED

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -12,6 +13,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SESSION_SETUP = REPO_ROOT / ".claude" / "hooks" / "session-setup.sh"
 SAFE_LAUNCH_PARSE = REPO_ROOT / ".claude" / "hooks" / "safe-launch-parse.py"
 SAFE_LAUNCH = REPO_ROOT / ".claude" / "hooks" / "safe-launch.sh"
+PRE_PUSH_CHECK = REPO_ROOT / ".claude" / "hooks" / "pre-push-check.sh"
+LIB_CHECKS = REPO_ROOT / ".claude" / "hooks" / "lib-checks.sh"
 
 
 def _run_parser_raw(
@@ -301,6 +304,86 @@ def test_safe_launch_degraded_path_allows_real_self_repair(
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == ""
     assert "allowing self-repair edit" in result.stderr
+
+
+@pytest.fixture
+def pre_push_sandbox(tmp_path: Path) -> Path:
+    """Project dir containing a copy of pre-push-check.sh and lib-checks.sh."""
+    hooks_dir = tmp_path / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    for src in (PRE_PUSH_CHECK, LIB_CHECKS):
+        dst = hooks_dir / src.name
+        dst.write_bytes(src.read_bytes())
+        dst.chmod(0o755)
+    return tmp_path
+
+
+def _minimal_path(tmp_path: Path) -> str:
+    """A PATH exposing only `dirname` (needed by pre-push-check.sh itself),
+    so jq/ruff/uv are guaranteed absent regardless of what's installed on
+    the host."""
+    bin_dir = tmp_path / "minimal-bin"
+    bin_dir.mkdir(exist_ok=True)
+    found = shutil.which("dirname")
+    assert found
+    (bin_dir / "dirname").symlink_to(found)
+    return str(bin_dir)
+
+
+def _run_pre_push_check(project_dir: Path, path: str) -> subprocess.CompletedProcess:
+    launcher = project_dir / ".claude" / "hooks" / "pre-push-check.sh"
+    bash = shutil.which("bash")
+    assert bash
+    env = dict(os.environ)
+    env["PATH"] = path
+    return subprocess.run(
+        [bash, str(launcher)],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_pre_push_check_fails_loudly_when_jq_missing(
+    pre_push_sandbox: Path,
+) -> None:
+    """A configured package.json with no `jq` on PATH must fail the check,
+    not silently skip all Node checks (there's no way to tell what's
+    configured without jq)."""
+    (pre_push_sandbox / "package.json").write_text('{"scripts": {}}')
+    result = _run_pre_push_check(pre_push_sandbox, _minimal_path(pre_push_sandbox))
+    assert result.returncode == 1
+    assert "jq is required" in result.stderr
+
+
+def test_pre_push_check_fails_loudly_when_ruff_and_uv_missing(
+    pre_push_sandbox: Path,
+) -> None:
+    """A Python project with neither `ruff` nor `uv` on PATH must fail the
+    check, not silently skip the ruff check."""
+    (pre_push_sandbox / "pyproject.toml").write_text("")
+    result = _run_pre_push_check(pre_push_sandbox, _minimal_path(pre_push_sandbox))
+    assert result.returncode == 1
+    assert "Neither ruff nor uv" in result.stderr
+
+
+def test_pre_push_check_runs_ruff_when_available(
+    pre_push_sandbox: Path,
+) -> None:
+    """A Python project with `ruff` on PATH must actually invoke it with the
+    exact expected argv (catches quoting/word-splitting regressions in the
+    argv-based run_check)."""
+    (pre_push_sandbox / "pyproject.toml").write_text("")
+    path = _minimal_path(pre_push_sandbox)
+    bin_dir = Path(path)
+    marker = pre_push_sandbox / "ruff-invoked-with-args.txt"
+    fake_ruff = bin_dir / "ruff"
+    fake_ruff.write_text(f'#!/bin/bash\nprintf "%s\\n" "$@" > "{marker}"\n')
+    fake_ruff.chmod(0o755)
+    result = _run_pre_push_check(pre_push_sandbox, path)
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text().splitlines() == ["check", "."]
 
 
 def test_preserves_pre_set_gh_repo(sandbox: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #368 (now merged), addressing review feedback caught in the compress-critique-fix loop before that PR closed:

- `pre-push-check.sh` hardened Node-check detection (fail loudly when `jq` is missing) but left the Python/ruff branch silently skipping the check when neither `ruff` nor `uv` (+ `uv.lock`) was available — the same class of silent-skip bug, just on the other language path.
- The ruff-command-selection logic duplicated its own availability condition (checked once to pick the command, again to decide whether to run it).

## Changes

- `.claude/hooks/pre-push-check.sh`: the Python checks block now fails loudly (non-zero exit, clear stderr message) when it can't determine how to run `ruff`, instead of silently exiting 0. Collapsed the duplicated `uv`/`ruff` availability check into a single if/elif that both selects the command and decides whether to run it.
- `tests/test_claude_hooks.py`: added coverage for `pre-push-check.sh` directly (not previously tested) — the new jq-missing and ruff-missing fail-loud paths, plus a positive test that runs a stub `ruff` and asserts on its exact invoked argv (`check .`), to catch quoting/word-splitting regressions in the argv-based `run_check`.

## Testing

- `uv run pytest tests/` — all pass except the same pre-existing, unrelated failure noted in #368 (`test_gh_repo_extraction[github-https]`, a sandbox git-config artifact).
- `bash .github/scripts/validate-config.sh` — passes.
- Manually verified all three `pre-push-check.sh` branches (jq missing, ruff/uv missing, ruff available) against a real shell before adding the pytest coverage.


---
_Generated by [Claude Code](https://claude.ai/code/session_017kanPLvQSH98yaXavH1pGj)_