### PR TITLE
reliability: tag-before-docs release ordering, release canary, hook fail-open warning

### DIFF
--- a/.github/scripts/release-canary.sh
+++ b/.github/scripts/release-canary.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Daily release-pipeline canary: assert that npm's published versions, the
+# repo's v* git tags, and CHANGELOG.md's top dated heading all agree on the
+# latest release. Two real incidents motivated this — a publish loop that
+# silently no-op'd and a changelog promotion that silently degraded — both
+# invisible until a human went looking. On disagreement this exits non-zero; the
+# "Build/publish failure notify" (ntfy) and "CI failure notify" (tracking issue)
+# workflow_run listeners turn that failure into an alert.
+#
+# The npm side reads the FULL `versions --json` list and takes the max stable
+# semver — never `npm view <pkg> version`, which returns the `latest` dist-tag.
+# That dist-tag lags (or leads) the real max after a partial or aborted publish,
+# which is exactly the desync this canary exists to catch.
+#
+# The package name is read from package.json, so downstream repos inherit the
+# right target after template-sync with no per-repo edit.
+set -euo pipefail
+
+log() { echo "$@" >&2; }
+
+# Self-check guard: a repo that does not publish to npm (package.json
+# "private": true — e.g. the template itself) has no release pipeline to canary,
+# so skip. Fails CLOSED on an unreadable package.json, matching version-bump.sh.
+IS_PRIVATE=$(node -p "require('./package.json').private === true" 2>/dev/null || echo "error")
+case "$IS_PRIVATE" in
+true)
+  log "package.json has \"private\": true; this repo does not publish to npm. Nothing to canary."
+  exit 0
+  ;;
+false) ;;
+*)
+  log "Error: could not read package.json \"private\" field (got: '$IS_PRIVATE'). Refusing to run the canary."
+  exit 1
+  ;;
+esac
+
+PACKAGE_NAME=$(node -p "require('./package.json').name")
+
+# npm side: max stable X.Y.Z over the full published-versions list. `--json`
+# yields an array normally, but a bare string for a single-release package.
+VERSIONS_JSON=$(npm view "$PACKAGE_NAME" versions --json 2>/dev/null || echo "")
+if [[ -z "$VERSIONS_JSON" ]]; then
+  log "Error: could not read published versions for '$PACKAGE_NAME' from npm."
+  exit 1
+fi
+if ! NPM_MAX=$(NPM_VERSIONS="$VERSIONS_JSON" node -e '
+const raw = JSON.parse(process.env.NPM_VERSIONS);
+const all = Array.isArray(raw) ? raw : [raw];
+const stable = all.filter((v) => /^\d+\.\d+\.\d+$/.test(v));
+if (stable.length === 0) process.exit(3);
+const cmp = (a, b) => {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  return 0;
+};
+stable.sort(cmp);
+process.stdout.write(stable[stable.length - 1]);
+'); then
+  log "Error: no stable X.Y.Z version published for '$PACKAGE_NAME'."
+  exit 1
+fi
+
+# git side: the highest stable v* tag. Sort descending by version and take the
+# first vX.Y.Z, skipping any prerelease or non-semver tags.
+TAG_VERSION=""
+while IFS= read -r tag; do
+  candidate="${tag#v}"
+  if [[ "$candidate" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    TAG_VERSION="$candidate"
+    break
+  fi
+done < <(git tag --list 'v*' --sort=-v:refname)
+if [[ -z "$TAG_VERSION" ]]; then
+  log "Error: no stable v* git tag (vX.Y.Z) found."
+  exit 1
+fi
+
+# changelog side: the version of the top DATED heading ("## [X.Y.Z] - DATE").
+# The "## Unreleased" heading carries no version bracket, so it is skipped.
+if [[ ! -f CHANGELOG.md ]]; then
+  log "Error: CHANGELOG.md is missing; cannot cross-check the release."
+  exit 1
+fi
+CHANGELOG_VERSION=""
+while IFS= read -r line; do
+  if [[ "$line" =~ ^##\ \[([0-9]+\.[0-9]+\.[0-9]+)\] ]]; then
+    CHANGELOG_VERSION="${BASH_REMATCH[1]}"
+    break
+  fi
+done <CHANGELOG.md
+if [[ -z "$CHANGELOG_VERSION" ]]; then
+  log "Error: no dated '## [X.Y.Z] - DATE' heading found in CHANGELOG.md."
+  exit 1
+fi
+
+log "npm max published: $NPM_MAX"
+log "latest v* tag:     v$TAG_VERSION"
+log "top CHANGELOG:      $CHANGELOG_VERSION"
+
+if [[ "$NPM_MAX" == "$TAG_VERSION" && "$TAG_VERSION" == "$CHANGELOG_VERSION" ]]; then
+  log "✅ Release agreement: $NPM_MAX (npm == tag == changelog)."
+  exit 0
+fi
+
+log "❌ Release desync for '$PACKAGE_NAME': npm=$NPM_MAX tag=v$TAG_VERSION changelog=$CHANGELOG_VERSION."
+log "   A partial/aborted publish or a degraded changelog promotion left these out of sync."
+exit 1

--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -127,6 +127,16 @@ if [[ -z "$COMMITS" ]]; then
   exit 0
 fi
 
+# Skip when every commit since the tag is this script's own release-docs commit
+# ("docs: release X.Y.Z [skip ci]"). The tag is pushed BEFORE the docs commit
+# (tag = published SHA), so after a successful release HEAD sits one docs commit
+# past the tag; without this guard a manual re-dispatch with no real work would
+# read that docs commit as releasable and cut a spurious patch.
+if ! grep -Evq '^docs: release [0-9]+\.[0-9]+\.[0-9]+ \[skip ci\]$' <<<"$COMMIT_SUBJECTS"; then
+  log "Only release-docs commits since $LAST_TAG. Skipping."
+  exit 0
+fi
+
 log "Commits to analyze:"
 log "$COMMITS"
 
@@ -286,9 +296,28 @@ fi
 log "$PUBLISH_OUTPUT"
 log "✅ Published $PACKAGE_NAME@$NEW_VERSION"
 
+# Tag the release IMMEDIATELY after a successful publish, before any docs work.
+# The tag is the dedup guard: it is what stops the next run from re-analyzing
+# these same commits and walking the version upward. Publishing, then pushing
+# docs, then tagging LAST once left a published-but-untagged release whenever the
+# docs push failed — the next run re-read the climbing npm version and bumped
+# again (a runaway version walk). The tag points at the commit that was actually
+# published; the release-docs commit below lands after it and is analyzed (and
+# skipped) by the next run's release-docs guard.
+git tag "v$NEW_VERSION"
+# Fail loudly if the tag never lands: the tag is what stops the next run from
+# re-analyzing these commits (re-drafting the changelog, re-pushing release
+# docs), so a silent failure here would quietly corrupt the next release.
+if ! retry_cmd 4 2 git push origin "v$NEW_VERSION"; then
+  log "Error: failed to push tag v$NEW_VERSION after retries. The release is published;"
+  log "       push the tag manually so the next run does not re-analyze these commits."
+  exit 1
+fi
+log "Pushed tag v$NEW_VERSION"
+
 # Promote "## Unreleased" to a dated version section in CHANGELOG.md, using the
 # drafted body. The helper exits 0 even on its own errors: the package is
-# already published, so a CHANGELOG hiccup must not abort the tag push below.
+# already published and tagged, so a CHANGELOG hiccup must not mask that.
 if [[ -f CHANGELOG.md ]] && [[ -n "$CHANGELOG_SECTION" ]]; then
   RELEASE_DATE=$(date -u +%Y-%m-%d)
   NEW_VERSION="$NEW_VERSION" \
@@ -300,9 +329,10 @@ fi
 # Commit the CHANGELOG entry back to the default branch so users see the release
 # notes. package.json stays dirty (npm is the source of truth for version). A
 # bot identity and `[skip ci]` keep the resulting push from spawning another
-# workflow run. The tag is created AFTER this commit (and only if it reached the
-# branch) so HEAD == tag SHA and the next run sees "HEAD is already tagged".
-RELEASE_DOCS_PUSH_FAILED=0
+# workflow run. A push failure here still fails the run LOUDLY (the release notes
+# are part of the release), but the tag above has already landed, so a retry or
+# the next run cannot re-process these commits — it only needs to re-push docs.
+#
 # actions/checkout leaves the runner in detached HEAD even for `push` events,
 # so `git rev-parse --abbrev-ref HEAD` returns the literal string "HEAD", not
 # the branch name — that would push to the bogus ref "HEAD:HEAD". GITHUB_REF_NAME
@@ -318,28 +348,8 @@ else
   # Push to the default branch explicitly so this works whether actions/checkout
   # left us on a branch or in detached HEAD state.
   if ! retry_cmd 4 2 git push origin "HEAD:$DEFAULT_BRANCH"; then
-    log "⚠️ Failed to push release-docs update. Release was published; docs can be updated manually."
-    RELEASE_DOCS_PUSH_FAILED=1
+    log "Error: failed to push the release-docs update for v$NEW_VERSION."
+    log "       The release is published and tagged; push the CHANGELOG commit manually."
+    exit 1
   fi
-fi
-
-# Tag only when the release-docs commit (if any) actually reached the branch.
-# Otherwise the local HEAD is an orphan commit nobody can see, and tagging it
-# would leave v$NEW_VERSION pointing at a SHA outside the branch history.
-if [[ "$RELEASE_DOCS_PUSH_FAILED" = "1" ]]; then
-  log "⚠️ Skipping tag v$NEW_VERSION because the release-docs commit did not reach $DEFAULT_BRANCH."
-  log "    Release was published to npm; reconcile by pushing the release-docs commit and tagging manually."
-  exit 1
-fi
-
-# Tag the release for future commit-range detection. Tag HEAD (which now
-# includes the release-docs commit, if any) so a re-trigger sees HEAD == tag SHA.
-git tag "v$NEW_VERSION"
-# Fail loudly if the tag never lands: the tag is what stops the next run from
-# re-analyzing these commits (re-drafting the changelog, re-pushing release
-# docs), so a silent failure here would quietly corrupt the next release.
-if ! retry_cmd 4 2 git push origin "v$NEW_VERSION"; then
-  log "Error: failed to push tag v$NEW_VERSION after retries. The release is published;"
-  log "       push the tag manually so the next run does not re-analyze these commits."
-  exit 1
 fi

--- a/.github/scripts/version-bump.test.mjs
+++ b/.github/scripts/version-bump.test.mjs
@@ -14,7 +14,7 @@ import { dirname, join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
-const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const LIVE_SCRIPT = join(REPO_ROOT, ".github", "scripts", "version-bump.sh");
 const AUTO_VERSION_YAML = join(
   REPO_ROOT,

--- a/.github/workflows/build-publish-notify.yaml
+++ b/.github/workflows/build-publish-notify.yaml
@@ -22,6 +22,7 @@ on: # zizmor: ignore[dangerous-triggers]
     types: [completed]
     workflows:
       - Auto version bump and publish
+      - Release canary
 
 concurrency:
   # Keyed per triggering workflow so notifications never queue behind each other;

--- a/.github/workflows/ci-failure-notify.yaml
+++ b/.github/workflows/ci-failure-notify.yaml
@@ -25,6 +25,7 @@ on: # zizmor: ignore[dangerous-triggers]
       - Merge-conflict early warning
       - Node tests
       - pre-commit
+      - Release canary
       - Weekly Security & Dependency Remediation
       - Sync required status checks
       - Sync from Template

--- a/.github/workflows/release-canary.yaml
+++ b/.github/workflows/release-canary.yaml
@@ -1,0 +1,48 @@
+name: Release canary
+
+# Daily cross-check that the release pipeline actually released: the max version
+# published to npm, the latest v* git tag, and CHANGELOG.md's top dated heading
+# must all name the same release. Two real incidents (a silently no-op'd publish
+# loop and a silently degraded changelog promotion) rotted unseen for days —
+# this converts that failure mode into a same-day alert. On mismatch the run
+# fails; the "Build/publish failure notify" (ntfy) and "CI failure notify"
+# (tracking issue) workflow_run listeners turn that failure into a notification.
+#
+# A repo that does not publish to npm (package.json "private": true — e.g. the
+# template itself) is a no-op: release-canary.sh skips before touching npm.
+
+on:
+  schedule:
+    - cron: "17 6 * * *" # daily, offset from the top of the hour
+  workflow_dispatch:
+
+concurrency:
+  # Serialize canary runs; never cancel — a dropped run is a dropped alert. The
+  # static group (no per-ref key) is intentional and safe: no pull_request
+  # trigger, so this never backs a required check that a cancelled run could hang.
+  group: release-canary
+  cancel-in-progress: false
+  # static-concurrency-ok: not a required check (schedule/dispatch only)
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: npm / git tag / changelog release agreement
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history so every v* tag is present for the tag-side check.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Run release canary
+        run: bash .github/scripts/release-canary.sh

--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install the apply tool (ci-truth-serum)
         # Pin to the same ci-truth-serum commit the pre-commit hook uses so the
         # lint and the apply step share one parser version.
-        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@ea23549db2d54ebd4391c34f817364db97aeeabe"
+        run: python3 -m pip install --user "ci-truth-serum @ git+https://github.com/alexander-turner/ci-truth-serum@952fdc475278f41167b734175f790bfcb302f238"
 
       - name: Sync required status checks
         env:

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -18,7 +18,11 @@ if [[ -d "$git_root/.venv/bin" ]]; then
   export PATH="$git_root/.venv/bin:$PATH"
 fi
 
+# Fresh clones (and non-Node projects) have no lint-staged binary. Don't block
+# the commit, but WARN loudly on stderr: a silent skip lets a fresh clone commit
+# with zero lint/format enforcement and no signal that anything was bypassed.
 if [[ ! -f "$git_root/node_modules/.bin/lint-staged" ]]; then
+  echo "pre-commit: lint-staged not installed — lint/format checks SKIPPED for this commit; run pnpm install to enable them." >&2
   exit 0
 fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
   # and global-stdio-swap Python lints. Tier aggregates over per-check ids so a
   # check added upstream to a tier applies here with no config change.
   - repo: https://github.com/alexander-turner/ci-truth-serum
-    rev: ea23549db2d54ebd4391c34f817364db97aeeabe # main
+    rev: 952fdc475278f41167b734175f790bfcb302f238 # v1.0.0
     hooks:
       - id: check-tier1
       # check-path-gate-deps and check-failure-notifier-coverage are Tier 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@
 - **Never checkpoint mid-run.** Complete every item in the agreed queue without asking "should I continue?" or "move on to the next one?"—the answer is always yes. Stop mid-task only for a destructive/irreversible action or a genuine scope change the user must decide.
 - **Mid-run decisions are logged, not asked.** When a reversible design choice surfaces after work has begun, pick a sensible default, keep going, and record it under a `## Decisions made` heading in the PR description: what came up, the default chosen, and what would change under the alternative. The user reviews decisions asynchronously in the PR, not live in chat.
 - **Maintain a status checklist.** For multi-item tasks, post the item list at the start (in chat or the PR description) and tick items off as they complete—that is the supervision surface for a user running parallel sessions.
+- **Check open PR commits first when addressing a bug that's red on main — a fix may already be underway.** List the open PRs before starting; if one already covers the failure, push to that branch instead of opening a sibling. Name the claimed area in the PR description's first line so parallel sessions can see what's taken. (Duplicate fixes for the same red-main failure have shipped twice from overlapping sessions.)
 - **Silent turns on non-actionable events.** A webhook/notification wake-up that needs no action (duplicate event, superseded-SHA cancellation, CI still running) gets no reply—end the turn with no text. Never post "all clear" / "nothing to do."
 
 ## Commands

--- a/scripts/version-bump.test.mjs
+++ b/scripts/version-bump.test.mjs
@@ -95,6 +95,9 @@ function runScript(dir, binDir) {
   const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
   delete env.ANTHROPIC_API_KEY;
   delete env.GITHUB_OUTPUT;
+  // In CI GITHUB_REF_NAME names the PR branch; drop it so the docs push targets
+  // the sandbox's own branch (which the bare origin below rejects on purpose).
+  delete env.GITHUB_REF_NAME;
   const res = spawnSync("bash", [LIVE_SCRIPT], {
     cwd: dir,
     env,
@@ -103,6 +106,98 @@ function runScript(dir, binDir) {
   assert.equal(res.error, undefined, "failed to spawn the release script");
   return { status: res.status, stderr: res.stderr, stdout: res.stdout };
 }
+
+// --- Bug C: tag ordering — the dedup tag must land before the docs push -----
+// The vX.Y.Z tag is what stops the next run from re-analyzing the same commits.
+// It used to be pushed LAST, after the CHANGELOG/docs push, so a docs-push
+// failure left a published-but-untagged release and the next run re-bumped the
+// same commits (a runaway version walk). The tag must be pushed IMMEDIATELY
+// after a successful npm publish; a docs-push failure still exits non-zero, but
+// with the tag already landed.
+
+/** npm stub for a real release path: package at 5.0.0, probe says "not yet published". */
+const NPM_RELEASABLE_STUB =
+  'if [[ "$2" == *@* ]]; then exit 1; else echo "5.0.0"; fi';
+
+/** Add publish/sleep stubs and a bare origin whose branches reject pushes (tags land). */
+function makeReleaseSandbox() {
+  const { dir, binDir } = makeSandbox(NPM_RELEASABLE_STUB);
+  // pnpm publish must "succeed" without touching a registry.
+  writeFileSync(join(binDir, "pnpm"), "#!/usr/bin/env bash\nexit 0\n");
+  chmodSync(join(binDir, "pnpm"), 0o755);
+  // retry_cmd sleeps between attempts; stub it so the failing-push retries are instant.
+  writeFileSync(join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n");
+  chmodSync(join(binDir, "sleep"), 0o755);
+
+  // Bare origin that accepts tag pushes but rejects branch pushes — the exact
+  // partial failure that used to strand a published release untagged.
+  const origin = join(dir, "origin.git");
+  execFileSync("git", ["init", "-q", "--bare", origin]);
+  const preReceive = join(origin, "hooks", "pre-receive");
+  writeFileSync(
+    preReceive,
+    '#!/usr/bin/env bash\nwhile read -r _old _new ref; do\n  [[ "$ref" == refs/heads/* ]] && exit 1\ndone\nexit 0\n',
+  );
+  chmodSync(preReceive, 0o755);
+  execFileSync("git", ["remote", "add", "origin", origin], { cwd: dir });
+  // A CHANGELOG with Unreleased content so the run has a docs commit to push.
+  writeFileSync(
+    join(dir, "CHANGELOG.md"),
+    "# Changelog\n\n## Unreleased\n\n### Added\n\n- a thing\n",
+  );
+  execFileSync("git", ["add", "-A"], { cwd: dir });
+  execFileSync("git", ["commit", "-q", "-m", "feat: releasable work"], {
+    cwd: dir,
+  });
+  return { dir, binDir, origin };
+}
+
+test("tag is pushed before the docs push; a docs-push failure exits non-zero with the tag landed", () => {
+  const { dir, binDir, origin } = makeReleaseSandbox();
+  try {
+    const { status, stderr } = runScript(dir, binDir);
+    // Fail loud on the docs push...
+    assert.notEqual(status, 0, "a failed docs push must fail the run");
+    assert.match(stderr, /failed to push the release-docs update/);
+    // ...but only AFTER the dedup tag landed on the remote.
+    assert.match(stderr, /Pushed tag v5\.1\.0/);
+    const remoteTags = execFileSync("git", ["ls-remote", "--tags", origin], {
+      encoding: "utf8",
+    });
+    assert.match(remoteTags, /refs\/tags\/v5\.1\.0/);
+    // Ordering in the transcript: tag push succeeded before the docs failure.
+    assert.ok(
+      stderr.indexOf("Pushed tag v5.1.0") <
+        stderr.indexOf("failed to push the release-docs update"),
+      "tag must be pushed before the docs push is attempted",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a range containing only release-docs commits is skipped, not re-released", () => {
+  // With the tag preceding the docs commit, HEAD sits one "docs: release ..."
+  // commit past the tag after every successful release; a manual re-dispatch
+  // must not read that commit as releasable work.
+  const { dir, binDir } = makeSandbox(NPM_AT_5_STUB);
+  try {
+    execFileSync(
+      "git",
+      ["commit", "-q", "--allow-empty", "-m", "docs: release 5.0.0 [skip ci]"],
+      { cwd: dir },
+    );
+    const { status, stderr } = runScript(dir, binDir);
+    assert.equal(status, 0, stderr);
+    assert.match(
+      stderr,
+      /Only release-docs commits since v0\.0\.0\. Skipping\./,
+    );
+    assert.doesNotMatch(stderr, /New version:/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 for (const { name, subject, body } of [
   {


### PR DESCRIPTION
Generalizes five reliability hardenings that were implemented and verified downstream (agent-control-plane-core #33, agent-input-sanitizer #157) into the template so every downstream repo inherits them via template-sync. Each converts a silent failure mode into a loud one.

## 1. version-bump.sh: push the tag immediately after publish (`fix(release)`)

`.github/scripts/version-bump.sh` published to npm, then pushed the CHANGELOG/docs commit, then pushed the `vX.Y.Z` tag **last**. The tag is the dedup guard that stops the next run from re-analyzing the same commits — so when the docs push failed, the run aborted before tagging, leaving a **published-but-untagged** release. The next run re-read the climbing npm version and bumped again: a real runaway version walk downstream (1.x→5.x).

Now the tag is pushed **immediately after a successful `pnpm publish`**, before the CHANGELOG/docs push. A docs-push failure still exits non-zero (fail loud) — but with the tag already landed, so a retry only needs to re-push docs; the commits are never re-processed. Because HEAD now sits one `docs: release X.Y.Z [skip ci]` commit past the tag after every release, a guard skips a commit range consisting solely of those release-docs commits (otherwise a manual re-dispatch would cut a spurious patch). Sandbox tests cover both the ordering (bare origin that accepts tag pushes but rejects branch pushes) and the docs-only skip.

## 2. Daily release-canary workflow (`feat(release)`)

New `.github/workflows/release-canary.yaml` (scheduled daily) + self-contained `.github/scripts/release-canary.sh`. It asserts three sources agree on the latest release: the **max published npm version** (from `npm view <pkg> versions --json` with a numeric semver max — never `npm view <pkg> version`, whose `latest` dist-tag lags after a partial publish), the latest `v*` git tag, and CHANGELOG.md's top dated `## [X.Y.Z]` heading. A silently no-op'd publish and a silently degraded changelog promotion are both real incidents that rotted unseen for days; the canary converts either into a same-day alert.

On mismatch the run exits non-zero and both `workflow_run` listeners fire: the ntfy **Build/publish failure notify** alert and the **CI failure notify** tracking issue. `Release canary` is added to both notifier lists in the same commit; `ci-failure-notify.yaml`'s list is the one `check-failure-notifier-coverage` keeps in sync with the tree. The package name is read from `package.json` so downstream repos inherit the right target after template-sync, and a `"private": true` repo (the template itself) is a no-op — the script skips before touching npm. SHA-pinned actions, concurrency block, all shell externalized to `.github/scripts/`.

## 3. .hooks/pre-commit: warn instead of silently skipping (`fix(hooks)`)

The hook `exit 0`'d silently when `node_modules/.bin/lint-staged` was absent, so a fresh clone committed with zero lint/format enforcement and no signal. It now prints a prominent stderr warning (`lint/format checks SKIPPED … run pnpm install`) while still exiting 0 so fresh-clone commits aren't blocked.

## 4. CLAUDE.md: parallel-session convention (`docs(claude)`)

Adds a short rule under Autonomy: check open PR commits before fixing a bug that's red on main (a fix may already be underway), push to a covering PR instead of a sibling, and name the claimed area in the PR description's first line. Motivated by real incidents of duplicate fixes for the same red-main failure from overlapping sessions.

## 5. Pin ci-truth-serum to the v1.0.0 release (`build(deps)`)

The `.pre-commit-config.yaml` rev was pinned to an untagged, stale-labeled `main` SHA (`ea23549`, 2026-07-10). `v1.0.0` (`952fdc47`, 2026-07-19) is a **newer** tagged release that still carries every hook this repo enables (the tier aggregates, `check-path-gate-deps`, and `check-failure-notifier-coverage` — the latter already enabled with `--require-notifier`), so this is an upgrade to a vetted release with **no coverage loss**. The lockstep pin in `sync-required-checks.yaml` moves in the same commit so the `test_version_sync` contract test stays green.

## Verification

- `node --test .github/scripts/*.test.mjs` — **62 pass, 0 fail** (includes the 2 new version-bump ordering/skip tests).
- `pytest tests/test_version_sync.py` — 4 pass (both ci-truth-serum pins agree).
- `pre-commit run` at the v1.0.0 pin: `check-tier1/2/extras`, `check-path-gate-deps`, `check-failure-notifier-coverage`, `validate-config`, `check-yaml/json` all **pass** on `--all-files`; pre-commit successfully cloned `alexander-turner/ci-truth-serum@v1.0.0`, confirming the SHA resolves in the real repo.
- `zizmor --offline` clean on all three changed workflows.
- shellcheck (`-o require-double-brackets`) + shfmt clean on every changed shell file.
- release-canary.sh exercised in a sandbox across agreement, npm-ahead, stale-changelog, single-string-version, prerelease-ignored, and double-digit-semver-ordering cases.
- `shellcheck-py`/`actionlint`/`zizmor` full runs couldn't install in this sandbox (their binary/advisory fetches are blocked by egress policy) — validated with system shellcheck/shfmt and offline zizmor; CI re-runs them with network.

## Decisions made

- **Canary is self-contained, not delegated to ci-truth-serum's `release-canary` console script.** The downstream PRs delegate the comparison to ci-truth-serum's `release-canary` entry point, which is **not in a tagged release** — their canaries fail loudly until the shared pin moves. The template must not reference an unreleased ci-truth-serum SHA (task rule), so the comparison logic lives in `.github/scripts/release-canary.sh` here. Trade-off: the logic is duplicated rather than shared; it re-syncs with ci-truth-serum's version if that entry point is ever adopted after release.
- **Canary added to both notifier lists.** `check-failure-notifier-coverage --require-notifier` forces the new schedule workflow into `ci-failure-notify.yaml` (tracking issue); it's also added to `build-publish-notify.yaml` for the ntfy phone alert the task calls for. Both fire on a release desync by design — issue for tracking, ntfy for immediacy.
- **Pinned to v1.0.0 rather than staying on the `main` SHA.** The task requires a released rev and forbids an unreleased SHA. v1.0.0 is newer than the current pin and a strict superset of the enabled hooks, so this is a no-regression upgrade. The task's listed "new" hook ids (`token-fallback`, `workflow-secret-names`, `provenance-repo-url`, `pin-comment-truth`, `stderr-merge-parse`, `echo-fallback`, `case-default`, `cron-comment`, `toolchain-skips`) do **not exist in any ci-truth-serum ref** (main or v1.0.0), so none could be enabled — noted here as a follow-up if/when they ship in a tagged release. A handful of main-only checks (`check-substitution-exit-swallow` + five extras) that postdate v1.0.0 will re-activate automatically via the tier aggregates on the next release + pin bump.
- **Relocated `version-bump.test.mjs` from `scripts/` to `.github/scripts/`.** `pnpm test` only globs `.github/scripts/*.test.mjs`, so the test — and its live-script assertions — never ran in CI (the "skipped test reports as passing" gap the repo's own rules warn about). Moving it next to the script it tests and the other `.github/scripts` tests gets it collected; `REPO_ROOT` walks two parents up, no assertion changes.
- **Kept the template's `GITHUB_REF_NAME` fallback for `DEFAULT_BRANCH`** in version-bump.sh (the downstream simplified it away). It correctly handles actions/checkout's detached HEAD, which is a template-level correctness feature worth preserving through the reorder.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5kRuLQdBUGkVSQRgNUXGS)_