### PR TITLE
docs(pr): generalize reviewer-cognitive-budget PR machinery from glovebox #2365

### DIFF
--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -83,6 +83,18 @@ You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatt
    If a PR already exists, update it with `gh pr edit` instead of creating a new one.
 3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch
 
+**Write the body for the reviewer's cognitive budget, not as an investigation archive** —
+see [pr-templates.md](pr-templates.md) "Body Guidelines" for the evidence and the rules. The
+load-bearing ones: lead with _what_ the PR does (inverted pyramid — root-cause forensics go
+below the fold, never above the statement of the change); make length proportional to the
+reviewable diff (a ~10-line change is a few sentences, not a 500-word skeleton); omit empty
+ritual sections instead of spending a paragraph to say "None"; and add a **Review focus**
+line naming the file to read first, the cross-file invariant, and the part you're least sure
+of — the single element most correlated with a human actually engaging, which matters because
+agent-authored PRs are systematically _under_-reviewed. Use the exact headings from
+pr-templates.md (`What & why` / `Review focus` / `How it was tested` / `Decisions made` /
+`Lessons Learned`) so a reviewer can scan by habit.
+
 ### Step 3: Iterative Compress-Critique-Fix Loop
 
 CI is already running; use this time to improve the code.

--- a/.claude/skills/pr-creation/pr-templates.md
+++ b/.claude/skills/pr-creation/pr-templates.md
@@ -22,14 +22,26 @@ If `EXISTING_PR` is non-empty, update the existing PR with `gh pr edit` instead 
 
 ```bash
 gh pr create --base "$CLAUDE_CODE_BASE_REF" --title "<type>: <description>" --body "$(cat <<'EOF'
-## Summary
-<1-3 bullet points describing what changed and why>
+## What & why
+<FIRST sentence states what this PR does, in the imperative — the deliverable, not the
+incident that motivated it. Then, only if it isn't obvious from the what, one or two
+sentences of why. Length scales with the diff, not a fixed floor.>
 
-## Changes
-<List of specific changes made>
+## Review focus
+<!-- Non-trivial PRs only; delete for a small, self-evident diff. -->
+<Where to look first and what you are least sure of — the one element most correlated with
+a reviewer engaging. Name the security-/correctness-critical file to read first, the
+cross-file invariant the diff can't show on one screen, and the part you'd most like
+scrutinized ("the locking in `worker.ts:88`; the rest is a mechanical rename").>
 
-## Testing
-<How the changes were tested>
+## How it was tested
+<What you ran and the outcome. Always this exact heading — never rename it to
+"Tests"/"Verification"/"Testing"; one stable name lets a reviewer scan by habit.>
+
+## Decisions made
+<!-- Only if there are genuinely reviewer-owned judgments. Delete otherwise. -->
+<Forks you resolved, costs you accepted, scope you cut — the highest-value-per-word content
+for a reviewer, so don't bury it under boilerplate.>
 
 ## Lessons Learned
 <!-- OMIT this whole section unless the PR produced a genuinely novel, cross-project insight. -->
@@ -54,26 +66,70 @@ Use imperative mood with a Conventional Commits type prefix:
 - `test:` Test changes
 - `chore:` Maintenance
 
-## Body Guidelines
+## Body Guidelines — write for the reviewer's cognitive budget
 
-- Focus the summary on the “why,” not the “what”
-- List concrete changes
-- Note any breaking changes
+A PR description exists to transfer _understanding_ to a human overseer as cheaply as
+possible, not to advertise the change or archive the investigation. Review is a
+comprehension task before it is a defect-finding task (Bacchelli & Bird, ICSE 2013), and
+for agent-authored PRs the documented failure mode is _under_-review driven by excessive
+detail and trust-validation overhead — so the description must lower the activation energy
+to engage, not raise it. Concretely:
+
+- **Lead with the change, inverted-pyramid.** The first sentence states _what_ this PR does;
+  the _why_ follows only if it isn't self-evident. Readers scan, weighting the first line and
+  each line's start (F-pattern; Nielsen, inverted pyramid), so a lead that opens on
+  root-cause forensics — run IDs, prior-PR chains, timelines — buries the one fact the
+  reader needs. Push that archaeology below the fold or into a `<details>` block; never above
+  the statement of what changed. Both "what" and "why" belong in the body — a diff already
+  shows the what, so "why" alone is as incomplete as "what" alone — but the _lead_ is the what.
+- **Length is proportional to the reviewable diff, not fixed.** A change of ~10 lines or fewer
+  gets one to three sentences and no section headings at all; reserve the full skeleton for a
+  diff big enough to need navigating. A flat ~500-word body on an 8-line change is pure
+  extraneous load.
+- **Omit empty ritual sections — never spend a paragraph to say "None."** If a change touches
+  no security boundary, say nothing about security; a "Security boundary impact: None." section
+  costs a read to learn there's nothing there. Don't spell the mechanical-attestation checklist
+  (Conventional Commits / tests-not-weakened) out as visible body prose — it's enforced by hooks
+  and CI and reads as noise; the GitHub template's collapsed "Author checklist" `<details>`
+  already carries it, out of the reviewer's scan path.
+- **Do the delocalized integration the reviewer's working memory can't.** The defects a reviewer
+  misses are the cross-file ones (Baum et al., EMSE 2019); attention also decays down the file
+  list (Fregnan et al., FSE 2022). So in "Review focus," name the interacting files, the
+  invariant that spans them, and a reading order with the critical file first.
+- **Partition a tangled diff _for_ the reviewer.** One logical concern per PR; tangled changes
+  measurably hurt review accuracy (Herzig & Zeller, MSR 2013). When a refactor and a fix must
+  ride together, label the partitions ("mechanical rename, files 1-7; behavior change, file 8")
+  so each is reviewable on its own.
+- **Match the diff's vocabulary.** Use the same identifiers and file paths in the prose as in
+  the diff, and link claims to specific files/lines — that lexical "scent" is how a reviewer
+  navigates to the code (information foraging).
+- Note any breaking changes.
 - **Default to NO “Lessons Learned” section.** It exists only for a genuinely novel, cross-project insight that would improve the template for a downstream repo sharing none of this code — a rare case; most PRs have none. Each lesson filed triggers the phone-home workflow (one issue per PR on the template repo), so a low-value or repo-specific “lesson” is triage noise, not a contribution. When you do include one, each lesson must specify **what** to change, **where**, and **why**. **Never write a negative placeholder** (“none applicable”, “N/A”, “nothing generalizable”): phone-home now drops those, so the sentence achieves nothing — omit the whole heading instead.
 - **Skip the Lessons Learned section entirely when the PR targets the `claude-automation-template` repo itself.** Phone-home propagates lessons _from_ downstream repos _into_ the template; a change made directly in the template is already there, so the section propagates nothing and is just noise.
 
 ## Updating PR Description After Additional Commits
 
+Reuse the same skeleton as the create step (What & why / Review focus / How it was tested /
+Decisions made / Lessons Learned), rewritten to describe the _current totality_ of the diff
+— same inverted-pyramid lead and proportional length. Don't append a new "and then I also…"
+paragraph on top of the old body; rewrite it so a reviewer arriving fresh reads one coherent
+description, not an accretion log.
+
 ```bash
 gh pr edit --body "$(cat <<'EOF'
-## Summary
-<Updated summary reflecting all changes>
+## What & why
+<Rewritten lead + why, covering all commits.>
 
-## Changes
-<Updated list of all changes, including new commits>
+## Review focus
+<!-- Delete if the diff is small and self-evident. -->
+<Reading order + least-certain part, updated for the current diff.>
 
-## Testing
-<Updated testing information>
+## How it was tested
+<What you ran and the outcome, updated.>
+
+## Decisions made
+<!-- Delete if none. -->
+<Reviewer-owned judgments.>
 
 ## Lessons Learned
 <!-- OMIT unless the PR produced a genuinely novel, cross-project insight (rare). Never write "none"/"N/A" — delete the heading. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+Thanks for contributing! Before you open this PR:
+  - Commits follow Conventional Commits (the commit-msg hook enforces it).
+  - Run `pre-commit run --all-files` locally; CI re-runs it.
+  - Keep the description accurate to the diff — the pr-desc-accuracy check compares them on merge.
+  - Opening from a fork? Leave "Allow edits from maintainers" checked (on by default) so a
+    maintainer can push conflict/CI fixes straight to your branch instead of recreating the PR.
+
+Write the body for the reviewer, inverted-pyramid: LEAD with what this PR does, keep the
+length proportional to the diff, and DELETE any section below that doesn't apply rather than
+writing "None"/"N/A". Root-cause forensics (run IDs, prior-PR chains, timelines) go below the
+fold or in a <details> block — never above the statement of what changed.
+-->
+
+## What & why
+
+<!-- FIRST line: what this change does, in the imperative. Then, only if it isn't obvious,
+     why. Link any issue. -->
+
+## Review focus
+
+<!-- Delete this section for a small, self-evident diff. Otherwise: where to look first (the
+     security-/correctness-critical file), any invariant that spans multiple files a reviewer
+     can't hold on one screen, and the part you're least sure of — the element most correlated
+     with a reviewer actually engaging. -->
+
+## How it was tested
+
+<!-- Commands run and what you observed. Note new/changed tests. -->
+
+<!-- Reviewer-owned judgments (a fork you resolved, a cost you accepted, scope you cut)? Add a
+     "## Decisions made" section — the highest-value-per-word content for a reviewer. Omit if
+     there are none. -->
+
+<!-- Security boundary change? Add a "## Security boundary impact" section describing it. If
+     this touches no defense layer, trust boundary, or threat-model assumption, omit that
+     section entirely — don't write "None." -->
+
+<!-- ## Lessons Learned — add ONLY a truly generalizable insight that would help a maintainer
+     of an unrelated project sharing none of this code (what to change, where, why). Triggers
+     the phone-home workflow. Omit the section entirely if there are none; never write "None."
+     Skip it altogether when the PR targets the claude-automation-template repo itself. -->
+
+<details>
+<summary>Author checklist</summary>
+
+- [ ] Commits use Conventional Commits (`<type>(<scope>): <desc>`)
+- [ ] Tests added/updated and not skipped or weakened
+- [ ] README/docs touched **only** if a user-facing or behavior change requires it
+- [ ] `pre-commit run --all-files` passes locally
+
+</details>


### PR DESCRIPTION
## What & why

Port glovebox PR #2365's reviewer-cognitive-budget reforms into this template: rewrite `.claude/skills/pr-creation/pr-templates.md` and `SKILL.md`, and add a new `.github/PULL_REQUEST_TEMPLATE.md`, so PR descriptions optimize for a human overseer's comprehension budget instead of archiving the investigation. Docs/template only — no code or behavior changes.

The doctrine: lead with _what_ the PR does (inverted pyramid — root-cause forensics go below the fold); make length proportional to the reviewable diff; omit empty ritual sections instead of writing "None"; add a **Review focus** line naming the file to read first and the part you're least sure of; and use one stable heading vocabulary (`What & why` / `Review focus` / `How it was tested` / `Decisions made` / `Lessons Learned`) so a reviewer can scan by habit.

## Review focus

`.github/PULL_REQUEST_TEMPLATE.md` is new and the highest-leverage file — it pre-populates every PR box, so its headings become the de-facto SSOT. The cross-file invariant to check: the heading vocabulary now matches across all three files (a stray `Summary`/`Changes`/`Testing` anywhere reintroduces the churn this removes — verified `grep` finds none). I tailored the template to *this* repo's actual CI rather than copying glovebox's: no `changelog.d`/`SECURITY.md`/`kcov`/`JS-100%` references (this repo has none), the header says pre-commit "CI re-runs it" but **not** auto-fixes (this repo's `pre-commit.yaml` only runs `--all-files`, it does not amend/force-push), and `pr-desc-accuracy` "compares on merge" (its trigger is `closed`).

## How it was tested

- `prettier --check` on all three files: clean.
- `.hooks/lint-skills.sh` on both skill files: RC 0.
- `grep` confirms no stray old-vocabulary headings and the new vocabulary is present in all three files.
- `pre-commit run --files` couldn't complete in this sandbox (network 403 building `shellcheck-py` — unrelated to these markdown-only files); the individual hooks that gate these paths (prettier, lint-skills) were run directly and pass.

## Decisions made

- **Added a `.github/PULL_REQUEST_TEMPLATE.md` (the template repo had none).** #2365's biggest lever was glovebox's GitHub template, and the skill's "matches the GitHub template's pre-fill" note dangles without one. Adding it gives downstream repos a native default and makes the cross-file heading invariant real. Alternative was skill-files-only, which would leave the skill referencing a template that doesn't exist here.
- **Dropped the specific arXiv citation IDs from glovebox's prose, kept the named peer-reviewed ones** (Bacchelli & Bird, Baum et al., Fregnan et al., Herzig & Zeller, Nielsen). The generalizable claim ("agent-authored PRs are under-reviewed") stands on its own; pinning it to specific future-dated preprint IDs added no value to a template consumed by unrelated repos.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UZRMHehdbGLSNQsAiUnPEF)_