### PR TITLE
chore(git): ignore .claude/worktrees/ sub-agent scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ out/
 # Claude Code local settings (written by SessionStart hook in web sessions)
 .claude/settings.local.json
 
+# Claude Code sub-agent worktrees (transient scratch; never committed)
+.claude/worktrees/
+
 # Claude Code personal notes (recurring nitpicks / review feedback, never committed)
 CLAUDE.local.md
 .claude/CLAUDE.local.md


### PR DESCRIPTION
## What & why

Async sub-agents launched with the Agent tool (`isolation: "worktree"`) materialize a linked git worktree under `.claude/worktrees/`. That directory is transient, uncommittable scratch, but it shows as an untracked path in `git status` — which trips the Stop-hook git check ("There are untracked files… please commit and push").

This adds `.claude/worktrees/` to the template `.gitignore` so every downstream repo generated from the template inherits the ignore rule (`agent-glovebox` already has it locally; this closes the gap for the rest, e.g. `ci-truth-serum`, fixed in a sibling PR).

## Verification

`git status` is clean with a sub-agent worktree present after the change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GjoQ2tjpXomYoELRnk7Hpy)_