### PR TITLE
fix(sync): cap the conflict report so a large PR body can't abort sync PR creation

### DIFF
--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -338,6 +338,20 @@ main() {
       echo "has_conflicts=true"
       echo "conflict_files=$conflicts"
     } >>"$GITHUB_OUTPUT"
+    # Cap the total conflict report before it becomes the PR body. GitHub passes
+    # the body to the create-pull-request action through the environment, and a
+    # body over the exec arg/env limit aborts PR creation with E2BIG ("Argument
+    # list too long") before it starts -- reached when many files have no merge
+    # base (each contributes a full old->new diff). The complete conflicted-file
+    # list is preserved in .template-sync-conflicts, so truncating the narrative
+    # detail here loses nothing load-bearing.
+    max_report_bytes=60000
+    if [[ "$(wc -c <"$CONFLICT_REPORT")" -gt "$max_report_bytes" ]]; then
+      capped="${CONFLICT_REPORT}.capped"
+      head -c "$max_report_bytes" "$CONFLICT_REPORT" | sed '$d' >"$capped"
+      printf '\n\n_Conflict report truncated at %d KB. Every conflicted file is listed in .template-sync-conflicts._\n' "$((max_report_bytes / 1000))" >>"$capped"
+      mv "$capped" "$CONFLICT_REPORT"
+    fi
     emit_multiline_output "conflict_report" "$(cat "$CONFLICT_REPORT")"
     echo "Template updates available for: $conflicts" >.template-sync-conflicts
   else

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -220,6 +220,39 @@ def test_no_base_conflict_when_local_differs_without_prev_sha(workdir: Path) -> 
     assert "template version" in outputs["conflict_report"]
 
 
+def test_conflict_report_is_capped_for_many_no_base_files(workdir: Path) -> None:
+    """Many no-merge-base files must not produce an unbounded PR body. The report
+    becomes the create-pull-request body (passed through the environment); an
+    oversized body aborts PR creation with E2BIG ("Argument list too long"). The
+    report is capped, and the full file list still lands in
+    .template-sync-conflicts so nothing load-bearing is lost."""
+    child = workdir / "child"
+    template = workdir / "template"
+    big_local = "".join(f"local line {i}\n" for i in range(700))
+    big_template = "".join(f"template line {i}\n" for i in range(700))
+    for n in range(12):
+        write(template / "config" / f"f{n}.txt", big_template)
+        write(child / "config" / f"f{n}.txt", big_local)
+    commit_all(template)
+    commit_all(child)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    assert outputs["has_conflicts"] == "true"
+    report = outputs["conflict_report"]
+    # Capped well under the exec arg/env limit (60 KB budget + a short note).
+    # Uncapped this would be ~120 KB (12 files x head -500 of the per-file diff).
+    assert len(report.encode()) <= 62000, len(report.encode())
+    assert "truncated" in report
+    assert ".template-sync-conflicts" in report
+    # The complete conflicted-file list is preserved out-of-band.
+    listed = (child / ".template-sync-conflicts").read_text()
+    for n in range(12):
+        assert f"config/f{n}.txt" in listed
+
+
 def test_detects_deleted_files(workdir: Path) -> None:
     child = workdir / "child"
     template = workdir / "template"


### PR DESCRIPTION
## What & why

Surfaced while running downstream template-syncs after #406: the `ci-truth-serum` sync run **failed outright** at the "Create Pull Request" step with `An error occurred trying to start process '.../node' ... Argument list too long` — no PR was ever opened.

Root cause: the sync's conflict report becomes the PR body, which GitHub passes to the `create-pull-request` action through the environment. For each file with **no merge base** (first sync / lost history), the report inlines a full old→new `diff` — capped at 500 lines *per file* but with **no total cap**. A repo whose history yields many no-merge-base files (ci-truth-serum) produces a body past the exec arg/env limit, so the action's process fails to spawn (`E2BIG`) before a PR can be created.

## Fix

Cap the assembled report at 60 KB — cut at a line boundary (`head -c … | sed '$d'`) and append a one-line truncation note. The complete conflicted-file list is already written to `.template-sync-conflicts`, so nothing load-bearing is lost; only the inline narrative diff detail is trimmed.

## How it was tested

- `uv run pytest tests/test_template_sync.py` → **16 passed** (15 existing + the new cap test).
- New test `test_conflict_report_is_capped_for_many_no_base_files`: 12 large no-base files (~120 KB uncapped) → asserts the report stays ≤ 62 KB, carries the truncation note, and `.template-sync-conflicts` still lists every file. **Non-vacuity verified**: `git stash` the fix → the test fails against the pre-cap script (observed `1 failed`), restored → passes.
- `shellcheck -x .github/scripts/template-sync.sh` → clean; `ruff check` → clean.

## Decisions made

- **60 KB cap** — comfortably under the ~128 KB single-arg / ~2 MB total exec limits while leaving room for the rest of the body the workflow wraps around it. The manifest file is the SSOT for *which* files conflicted; the report is just human-readable colour.

## Note

This fixes the sync machinery going forward for every repo that carries the updated `template-sync.sh`. `ci-truth-serum` currently runs its previously-synced (unfixed) copy, so its own sync stays broken until it receives this script — a one-off bootstrap (this file synced/pushed into ci-truth-serum) is needed to unblock its first successful sync.

<details>
<summary>Author checklist</summary>

- [x] Commits use Conventional Commits (`<type>(<scope>): <desc>`)
- [x] Tests added/updated and not skipped or weakened
- [x] README/docs untouched
- [x] Local checks pass (binary-download pre-commit hooks are 403-blocked in this web session; verified with system shellcheck/ruff + the pytest suite)

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_0112EEVpowpd7eex2GTptqEy)_