### PR TITLE
fix: non-security audit fixes (fail-loud gates, pipefail, drift-guard mark, repo-root)

### DIFF
--- a/.github/scripts/script-configured-output.sh
+++ b/.github/scripts/script-configured-output.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Resolve whether package.json configures the $1 script and write
+# `configured=true|false` to $GITHUB_OUTPUT for a downstream `if:` gate.
+#
+# This is the single place that maps script-configured.sh's three exit codes to
+# a workflow decision, so no call site can independently re-introduce the bug of
+# treating a MALFORMED package.json (exit >=2) as "not configured": that path
+# fails the step LOUD instead, keeping the required check honestly red rather
+# than green-with-zero-work.
+#
+#   script-configured.sh exit 0  -> configured=true
+#   script-configured.sh exit 1  -> configured=false (absent/placeholder)
+#   script-configured.sh exit >=2 -> propagate the failure (malformed JSON)
+
+set -uo pipefail
+
+name="${1:?script name required}"
+out_var="${2:-configured}" # allow a caller to name the output key
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bash "$here/script-configured.sh" "$name"
+rc=$?
+
+sink="${GITHUB_OUTPUT:-/dev/stdout}"
+if [[ "$rc" -eq 0 ]]; then
+  echo "${out_var}=true" >>"$sink"
+elif [[ "$rc" -eq 1 ]]; then
+  echo "${out_var}=false" >>"$sink"
+  echo "::notice::${name} script not configured, skipping"
+else
+  echo "::error::package.json is malformed — cannot determine whether the '${name}' script is configured" >&2
+  exit "$rc"
+fi

--- a/.github/scripts/script-configured.sh
+++ b/.github/scripts/script-configured.sh
@@ -1,15 +1,31 @@
 #!/usr/bin/env bash
-# Exit 0 iff package.json defines $1 as a script whose body does NOT contain
-# the "ERROR: Configure" sentinel emitted by the unconfigured placeholder
-# scripts in the template's package.json.
+# Classify whether package.json configures $1 as a real script.
 #
-# Used by lint / test workflows to skip steps in repos that haven't filled
-# in the placeholder scripts.
+#   exit 0  -> configured (script present, body is not the placeholder)
+#   exit 1  -> not configured (script absent, or still the "ERROR: Configure"
+#              placeholder emitted by the template's unfilled scripts)
+#   exit 2  -> package.json is malformed (jq PARSE failure) — fail LOUD
+#
+# The exit-2 case is the load-bearing distinction: conflating a corrupt
+# package.json with "not configured" lets the caller skip the step and a
+# required check (node-tests / lint) report GREEN with zero work run. Mirrors
+# has_script() in .claude/hooks/lib-checks.sh.
+#
+# Used by lint / test workflows via script-configured-output.sh to skip steps
+# in repos that haven't filled in the placeholder scripts.
 
-set -euo pipefail
+set -uo pipefail
 
 : "${1:?script name required}"
 
-# Use jq so the script name is never interpolated into an expression string.
-val=$(jq -re --arg name "$1" '.scripts[$name]' package.json 2>/dev/null) || exit 1
-! grep -q 'ERROR: Configure' <<<"$val"
+# `2>&1` captures jq's own error text; a non-zero jq exit here is a PARSE
+# failure (invalid JSON), NOT a missing key — `// empty` makes a missing key a
+# clean empty string with exit 0.
+if ! val=$(jq -r --arg name "$1" '.scripts[$name] // empty' package.json 2>&1); then
+  echo "ERROR: package.json is not valid JSON, cannot check for script \"$1\": $val" >&2
+  exit 2
+fi
+
+# Empty (absent) or placeholder body => not configured (exit 1 via set -e on the
+# final failing test); otherwise exit 0.
+[[ -n "$val" && "$val" != *"ERROR: Configure"* ]]

--- a/.github/scripts/version-bump.sh
+++ b/.github/scripts/version-bump.sh
@@ -286,7 +286,7 @@ log "Set package.json to $NEW_VERSION (working directory only)"
 # Build and publish to npm. Treat "already published" (the registry's caching
 # can let the earlier safety check miss an existing version) as success.
 if ! PUBLISH_OUTPUT=$(pnpm publish --provenance --access public --no-git-checks 2>&1); then
-  if echo "$PUBLISH_OUTPUT" | grep -q "Cannot publish over previously published version"; then
+  if [[ "$PUBLISH_OUTPUT" == *"Cannot publish over previously published version"* ]]; then
     log "Version $NEW_VERSION already published (detected at publish time). Skipping."
     exit 0
   fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,18 +31,8 @@ jobs:
       - name: Check if scripts are configured
         id: check
         run: |
-          if bash .github/scripts/script-configured.sh check; then
-            echo "check_configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "check_configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Type check script not configured, skipping"
-          fi
-          if bash .github/scripts/script-configured.sh lint; then
-            echo "lint_configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "lint_configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Lint script not configured, skipping"
-          fi
+          bash .github/scripts/script-configured-output.sh check check_configured
+          bash .github/scripts/script-configured-output.sh lint lint_configured
 
       - name: Type check
         if: steps.check.outputs.check_configured == 'true'

--- a/.github/workflows/node-tests.yaml
+++ b/.github/workflows/node-tests.yaml
@@ -30,13 +30,7 @@ jobs:
 
       - name: Check if test script is configured
         id: check
-        run: |
-          if bash .github/scripts/script-configured.sh test; then
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Test script not configured, skipping tests"
-          fi
+        run: bash .github/scripts/script-configured-output.sh test configured
 
       - name: Run tests
         if: steps.check.outputs.configured == 'true'

--- a/.hooks/lint-skills.sh
+++ b/.hooks/lint-skills.sh
@@ -55,13 +55,13 @@ for file in "$@"; do
   frontmatter=$(awk '/^---$/{n++; next} n==1' "$file" | grep -v '^#')
 
   # Check frontmatter has name field
-  if ! echo "$frontmatter" | grep -q '^name:'; then
+  if ! grep -q '^name:' <<<"$frontmatter"; then
     echo "ERROR: $file missing 'name:' in frontmatter" >&2
     errors=$((errors + 1))
   fi
 
   # Check frontmatter has description field
-  if ! echo "$frontmatter" | grep -q '^description:'; then
+  if ! grep -q '^description:' <<<"$frontmatter"; then
     echo "ERROR: $file missing 'description:' in frontmatter" >&2
     errors=$((errors + 1))
   fi
@@ -79,7 +79,7 @@ for file in "$@"; do
 
   # Warn (but don't fail) if Examples section is missing
   body=$(awk '/^---$/{n++; next} n>=2' "$file")
-  if ! echo "$body" | grep -q '^## Examples'; then
+  if ! grep -q '^## Examples' <<<"$body"; then
     echo "WARN: $file missing '## Examples' section — consider adding 2-3 real input/output examples" >&2
   fi
 done

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -47,4 +47,10 @@ if command -v pnpm >/dev/null 2>&1; then
   pnpm exec lint-staged --allow-empty
 elif command -v npm >/dev/null 2>&1; then
   npx lint-staged --allow-empty
+else
+  # lint-staged is installed (guarded above) but no package manager is on PATH:
+  # run the binary directly rather than silently exiting 0 and committing with
+  # zero lint/format enforcement.
+  echo "pre-commit: neither pnpm nor npm on PATH — invoking lint-staged directly." >&2
+  "$git_root/node_modules/.bin/lint-staged" --allow-empty
 fi

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -58,7 +58,10 @@ while read -r _local_ref local_sha _remote_ref remote_sha; do
       from_ref=$(git hash-object -t tree /dev/null)
   fi
   [[ "$from_ref" == "$local_sha" ]] && continue # nothing new to push
-  "${precommit_cmd[@]}" run --from-ref "$from_ref" --to-ref "$local_sha" --show-diff-on-failure
+  # Redirect stdin from /dev/null: git feeds this loop the ref list on stdin,
+  # and pre-commit (and the tools it drives) would otherwise inherit and consume
+  # it, so a multi-ref push would check only the first range.
+  "${precommit_cmd[@]}" run --from-ref "$from_ref" --to-ref "$local_sha" --show-diff-on-failure </dev/null
 done
 
 # Portable-symlink check: rejects a tracked symlink with an absolute target

--- a/setup.sh
+++ b/setup.sh
@@ -16,8 +16,12 @@ if [[ -f package.json ]]; then
   if command -v corepack &>/dev/null; then
     corepack enable
   else
-    echo "Installing pnpm..."
-    npm install -g pnpm
+    # Pin the fallback install to the "packageManager" version so a bare
+    # `npm install -g pnpm` can't pull a newer/older pnpm that rewrites the
+    # lockfile into an off-version format — the exact hazard corepack avoids.
+    pnpm_spec=$(node -e 'process.stdout.write(require("./package.json").packageManager || "pnpm")')
+    echo "Installing ${pnpm_spec}..."
+    npm install -g "$pnpm_spec"
   fi
 
   # Install dependencies (postinstall also sets core.hooksPath, redundantly)
@@ -42,6 +46,7 @@ if [[ "$(git config core.hooksPath)" = ".hooks" ]]; then
   echo "  Start coding!"
 else
   echo ""
-  echo "⚠ Warning: Git hooks may not be configured correctly."
-  echo "  Run: git config core.hooksPath .hooks"
+  echo "⚠ Error: Git hooks are not configured correctly (core.hooksPath != .hooks)." >&2
+  echo "  Run: git config core.hooksPath .hooks" >&2
+  exit 1
 fi

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -9,7 +9,22 @@ import shutil
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+
+def _repo_root() -> Path:
+    """Repo root via ``git rev-parse``, per the repo's own testing doctrine:
+    depth-based parent-walking (``parents[1]``) silently breaks the moment a
+    test file is moved to a different directory depth."""
+    return Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    )
+
+
+REPO_ROOT = _repo_root()
 
 GIT_IDENTITY_ENV = {
     "GIT_AUTHOR_NAME": "t",

--- a/tests/test_check_token_scope.py
+++ b/tests/test_check_token_scope.py
@@ -9,7 +9,8 @@ import os
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "check-token-scope.sh"
 
 

--- a/tests/test_claude_hooks.py
+++ b/tests/test_claude_hooks.py
@@ -9,7 +9,8 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 SESSION_SETUP = REPO_ROOT / ".claude" / "hooks" / "session-setup.sh"
 SAFE_LAUNCH_PARSE = REPO_ROOT / ".claude" / "hooks" / "safe-launch-parse.py"
 SAFE_LAUNCH = REPO_ROOT / ".claude" / "hooks" / "safe-launch.sh"

--- a/tests/test_drop_superseded_ci_events.py
+++ b/tests/test_drop_superseded_ci_events.py
@@ -17,7 +17,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 HOOKS_DIR = REPO_ROOT / ".claude" / "hooks"
 HOOK = HOOKS_DIR / "drop-superseded-ci-events.mjs"
 HOOK_LIBS = ("lib-hook-io.mjs", "lib-control-plane.mjs")

--- a/tests/test_parallelism_nudge.py
+++ b/tests/test_parallelism_nudge.py
@@ -9,7 +9,8 @@ import json
 import subprocess
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 HOOK = REPO_ROOT / ".claude" / "hooks" / "parallelism-nudge.mjs"
 
 SERIAL_TOOL_TURN_THRESHOLD = 15

--- a/tests/test_required_env.py
+++ b/tests/test_required_env.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
 SCRIPTS = REPO_ROOT / ".github" / "scripts"
 
 # (script, required env vars, vars to scrub from inherited environment)

--- a/tests/test_script_configured.py
+++ b/tests/test_script_configured.py
@@ -1,6 +1,7 @@
 """Tests for .github/scripts/script-configured.sh."""
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -47,3 +48,62 @@ def test_errors_when_no_argument(tmp_path: Path, copy_script) -> None:
         ["bash", str(script)], cwd=tmp_path, capture_output=True, text=True
     )
     assert result.returncode != 0
+
+
+def test_malformed_package_json_fails_loud(tmp_path: Path, copy_script) -> None:
+    """A corrupt package.json must NOT be conflated with "not configured".
+
+    Exit >= 2 (distinct from the exit-1 "not configured") with a loud stderr,
+    so a downstream `if:` gate can't skip the step and let a required check
+    report green with zero work. Red on the old script, which used
+    `jq -re … || exit 1` and returned 1 (== "not configured") on invalid JSON.
+    """
+    (tmp_path / "package.json").write_text('{ "scripts": { "test": }')  # invalid
+    result = run_script(tmp_path, copy_script, "test")
+    assert result.returncode >= 2, (result.returncode, result.stderr)
+    assert "not valid JSON" in result.stderr
+
+
+def run_output(
+    repo: Path, copy_script, name: str, out_var: str = "configured"
+) -> tuple[subprocess.CompletedProcess, str]:
+    """Run the workflow wrapper with a real $GITHUB_OUTPUT file; return the
+    process and the file's contents."""
+    copy_script("script-configured.sh", repo)  # sibling the wrapper resolves
+    wrapper = copy_script("script-configured-output.sh", repo)
+    gh_out = repo / "gh_output"
+    gh_out.write_text("")
+    result = subprocess.run(
+        ["bash", str(wrapper), name, out_var],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GITHUB_OUTPUT": str(gh_out)},
+    )
+    return result, gh_out.read_text()
+
+
+def test_wrapper_writes_true_when_configured(tmp_path: Path, copy_script) -> None:
+    write_package_json(tmp_path, {"test": "vitest run"})
+    result, out = run_output(tmp_path, copy_script, "test")
+    assert result.returncode == 0, result.stderr
+    assert "configured=true" in out
+
+
+def test_wrapper_writes_false_when_missing(tmp_path: Path, copy_script) -> None:
+    write_package_json(tmp_path, {"build": "tsc"})
+    result, out = run_output(tmp_path, copy_script, "test")
+    assert result.returncode == 0, result.stderr
+    assert "configured=false" in out
+
+
+def test_wrapper_fails_loud_on_malformed_json(tmp_path: Path, copy_script) -> None:
+    """The single decision point must fail the STEP on a malformed package.json
+    (never emit configured=false), so the required check can't go green with
+    zero work. Red on the old inline `if bash …; then true; else false; fi`,
+    which routed exit >=2 into the false branch."""
+    (tmp_path / "package.json").write_text('{ "scripts": { "test": }')
+    result, out = run_output(tmp_path, copy_script, "test")
+    assert result.returncode >= 2, (result.returncode, result.stderr)
+    assert "configured=false" not in out
+    assert "malformed" in result.stderr

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -11,9 +11,8 @@ from pathlib import Path
 
 import pytest
 
-from tests._helpers import GIT_IDENTITY_ENV, commit_all, init_test_repo
+from tests._helpers import GIT_IDENTITY_ENV, REPO_ROOT, commit_all, init_test_repo
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "template-sync.sh"
 
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,4 +1,4 @@
-"""Contract test: tool version pins must agree across every file that pins them.
+"""Drift guard: tool version pins must agree across every file that pins them.
 
 Versioned tools are pinned in more than one place, and a mismatch makes local
 hooks behave differently from CI:
@@ -34,7 +34,16 @@ from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+from tests._helpers import REPO_ROOT
+
+# Each pinned tool is spelled in bash (session-setup.sh), YAML (.pre-commit-config,
+# workflows), and a plain version file — three languages/processes with no shared
+# runtime source to hoist the value into, so the duplication can't be eliminated;
+# the honest move is to keep the guard and mark it in the open.
+pytestmark = pytest.mark.drift_guard(
+    "pins live in bash, YAML, and workflow files — no shared runtime source"
+)
+
 SESSION_SETUP = REPO_ROOT / ".claude" / "hooks" / "session-setup.sh"
 PRE_COMMIT_CFG = REPO_ROOT / ".pre-commit-config.yaml"
 ZIZMOR_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "zizmor.yaml"


### PR DESCRIPTION
Consolidated non-security audit fixes. Each fix eliminates its class (a shared helper or an in-the-open marker), not just the instance, and ships a behavior-driving test where one applies. One commit per concern.

## Partitions

| Commit | Item | Concern |
| --- | --- | --- |
| `fix(ci): fail loud on malformed package.json…` | **T1 (HIGH)** | `script-configured.sh` conflated a jq PARSE failure with "script not configured", so a corrupt `package.json` made the required lint / node-tests checks report **green with zero work run**. Now returns 0/1/**≥2** (mirroring `has_script()` in `lib-checks.sh`), and one new `script-configured-output.sh` is the single place mapping those codes to the workflow gate — so no call site can re-introduce the swallow. Both `lint.yaml` and `node-tests.yaml` route through it. |
| `fix(ci): replace pipe-to-\`grep -q\`…` | **T2 (MED) + T9 (LOW)** | `cmd \| grep -q` under `set -o pipefail` is a latent SIGPIPE (141) bug on slow runners. `version-bump.sh` (already-published detection) → bash pattern match; `lint-skills.sh` ×3 → here-strings. |
| `fix(hooks): redirect pre-push loop body stdin…` | **T3 (MED)** | The `while read` ref loop's body ran `pre-commit`, which drained the ref list off stdin, so a multi-ref push checked only the first range. Body command now reads from `/dev/null`. |
| `test: derive REPO_ROOT via \`git rev-parse\`…` | **T5 (LOW)** | Seven test modules hand-rolled `Path(__file__).resolve().parents[1]` (breaks silently when a test moves depth). Hoisted a git-derived `REPO_ROOT` into `tests/_helpers.py` (one source) and imported it. |
| `test: mark version-sync as a drift guard…` | **T4 (LOW)** | A copies-agree guard framed as a "contract test". The pins live in bash + YAML + a version file — no shared runtime source — so it's marked `pytest.mark.drift_guard(...)` and retitled, not laundered. |
| `fix(setup): pin fallback pnpm install and fail loud…` | **T6 (LOW) + T7 (LOW)** | `setup.sh` fallback ran unpinned `npm install -g pnpm` (the lockfile-drift hazard its own comment names) → now reads the `packageManager` pin; the hooksPath verification warned then `exit 0` → now `exit 1`. |
| `fix(hooks): run lint-staged directly when no package manager…` | **T8 (LOW)** | `pre-commit`'s `if pnpm … elif npm …` had no `else`, so with lint-staged present but no package manager it committed with zero enforcement. Added an `else` invoking `node_modules/.bin/lint-staged` directly. |

## Tests

- `tests/test_script_configured.py`: added malformed-JSON cases for both the script (exit ≥2 + "not valid JSON") and the wrapper (fails the step loud, never emits `configured=false`). Red on the old `\|\| exit 1` / inline `if…else` form.
- Shell changes dogfooded with `shellcheck -x`, `shfmt -i 2`, `shellharden --check` (all clean).

## Decisions made

- **T1 scope widened to the workflows.** Fixing only `script-configured.sh` would leave the stated bug live — the old workflow `if…else` still routed exit ≥2 into the "not configured" branch. To make the required check actually go red on a corrupt `package.json`, the decision point moved into a shared `script-configured-output.sh` (also the class-elimination). Alternative (inline branching per call site) was rejected: it duplicates >10-line branching logic across three sites, against the extract-inline-scripts rule.
- **T4 and T5 kept as separate commits** though both touch `test_version_sync.py`; the drift-guard mark and the repo-root hoist are independent concerns.

Note: `tests/test_drop_superseded_ci_events.py::test_blocks_superseded_sha` fails in a bare sandbox (no `node_modules`; the hook needs the JS control-plane package) — identical on `origin/main`, unrelated to this change; CI installs deps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NS4j1wJdQ9kfkc4cGbrtHh)_