### PR TITLE
feat(ci): run every Claude workflow through one OAuth-with-failover composite

### DIFF
--- a/.github/actions/claude-conflict-resolve/action.yaml
+++ b/.github/actions/claude-conflict-resolve/action.yaml
@@ -6,11 +6,16 @@ description: >-
   set, the github-actions bot allowance, the file-scope prompt) has a single
   source of truth. All of the resolve job's safety rails (base-ref-staged
   scripts, the out-of-set edit guard in finalize, the fail-loud assert) live in
-  the calling workflow; this action only runs the agent.
+  the calling workflow; this action only runs the agent. The credential and the
+  primary->fallback retry live in the shared claude-run action.
 inputs:
-  anthropic_api_key:
-    description: "Anthropic API key this resolve is billed against."
+  oauth_token:
+    description: "Primary Claude Code OAuth token this resolve is billed against."
     required: true
+  fallback_oauth_token:
+    description: "Backup Claude Code OAuth token; a failed primary attempt retries with it."
+    required: false
+    default: ""
   github_token:
     description: >-
       The workflow GITHUB_TOKEN, handed to the action directly so it skips the
@@ -26,18 +31,20 @@ outputs:
   execution_file:
     description: >-
       The action's execution-log path; the caller reads it to detect an is_error
-      run (a missing/invalid key) and to count permission denials.
+      run (a missing/invalid token) and to count permission denials.
     value: ${{ steps.run.outputs.execution_file }}
 runs:
   using: "composite"
   steps:
     - name: Resolve the conflicts with Claude
       id: run
-      uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      uses: ./.github/actions/claude-run
       with:
-        # A wrong/missing key makes the run error on init (is_error, $0, 1 turn);
-        # the caller's assert step turns that into a loud failure.
-        anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        # A wrong/missing token makes the run error on init (is_error, $0, 1 turn);
+        # claude-run retries once with the fallback token, and the caller's assert
+        # step turns a genuine double-failure into a loud failure.
+        oauth_token: ${{ inputs.oauth_token }}
+        fallback_oauth_token: ${{ inputs.fallback_oauth_token }}
         github_token: ${{ inputs.github_token }}
         # The relay dispatches with github.token, so a relayed run's initiating
         # actor is github-actions (a Bot) — which the action rejects by default

--- a/.github/actions/claude-run/action.yaml
+++ b/.github/actions/claude-run/action.yaml
@@ -1,0 +1,95 @@
+name: "Run Claude with OAuth failover"
+description: >-
+  Single source of truth for invoking anthropics/claude-code-action across this
+  template's workflows: it pins the action once and runs it with the primary
+  Claude Code OAuth token, transparently retrying once with a fallback token when
+  the primary attempt fails (a subscription-quota exhaustion or a transient
+  outage). Callers pass their own prompt / claude_args / tool gating; the
+  credential and retry logic live only here so no workflow re-implements them.
+inputs:
+  oauth_token:
+    description: "Primary Claude Code OAuth token (secrets.CLAUDE_CODE_OAUTH_TOKEN)."
+    required: true
+  fallback_oauth_token:
+    description: >-
+      Backup Claude Code OAuth token. When set, a failed primary attempt is
+      retried once with this token; leave empty to disable the retry.
+    required: false
+    default: ""
+  github_token:
+    description: >-
+      Token handed to the action directly so it skips the OIDC->GitHub-App
+      exchange. Empty lets the action resolve its own default.
+    required: false
+    default: ""
+  model:
+    description: "Passthrough for claude-code-action's top-level model input (when not set via claude_args)."
+    required: false
+    default: ""
+  prompt:
+    description: "Prompt for the agent. Empty runs the action in its event-driven (tag) mode."
+    required: false
+    default: ""
+  claude_args:
+    description: "CLI args forwarded to claude-code-action (--model, --allowedTools, ...)."
+    required: false
+    default: ""
+  allowed_non_write_users:
+    description: "Passthrough for claude-code-action allowed_non_write_users."
+    required: false
+    default: ""
+  allowed_bots:
+    description: "Passthrough for claude-code-action allowed_bots."
+    required: false
+    default: ""
+outputs:
+  execution_file:
+    description: >-
+      Execution-log path of the attempt that ran (the fallback's when it fired,
+      otherwise the primary's). Callers read it to detect an is_error run.
+    value: ${{ steps.fallback.outputs.execution_file || steps.primary.outputs.execution_file }}
+runs:
+  using: "composite"
+  steps:
+    # Primary attempt. continue-on-error so a credential/quota failure doesn't
+    # abort the composite before the fallback can run; the propagate step below
+    # turns a genuine double-failure back into a hard error.
+    - name: Claude (primary credential)
+      id: primary
+      continue-on-error: true
+      uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      with:
+        claude_code_oauth_token: ${{ inputs.oauth_token }}
+        github_token: ${{ inputs.github_token }}
+        model: ${{ inputs.model }}
+        prompt: ${{ inputs.prompt }}
+        claude_args: ${{ inputs.claude_args }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+    # Fallback attempt: only when the primary actually failed AND a backup token
+    # is configured. Uses outcome (not conclusion — continue-on-error rewrites
+    # conclusion to success), so it fires exactly on a real primary failure.
+    - name: Claude (fallback credential)
+      id: fallback
+      if: steps.primary.outcome == 'failure' && inputs.fallback_oauth_token != ''
+      continue-on-error: true
+      uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+      with:
+        claude_code_oauth_token: ${{ inputs.fallback_oauth_token }}
+        github_token: ${{ inputs.github_token }}
+        model: ${{ inputs.model }}
+        prompt: ${{ inputs.prompt }}
+        claude_args: ${{ inputs.claude_args }}
+        allowed_non_write_users: ${{ inputs.allowed_non_write_users }}
+        allowed_bots: ${{ inputs.allowed_bots }}
+    # Propagate a hard failure only when no attempt succeeded: the primary failed
+    # and either no fallback was configured or the fallback also failed. Otherwise
+    # the composite exits 0 and the caller inspects execution_file as usual.
+    - name: Propagate failover result
+      if: >-
+        steps.primary.outcome == 'failure' &&
+        (inputs.fallback_oauth_token == '' || steps.fallback.outcome == 'failure')
+      shell: bash
+      run: |
+        echo "::error::claude-run: the primary Claude credential failed and no working fallback was available (set CLAUDE_CODE_OAUTH_TOKEN / CLAUDE_CODE_OAUTH_TOKEN_FALLBACK)." >&2
+        exit 1

--- a/.github/workflows/auto-resolve-conflicts.yaml
+++ b/.github/workflows/auto-resolve-conflicts.yaml
@@ -223,7 +223,8 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/claude-conflict-resolve
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_number: ${{ matrix.pr.number }}
           conflict_list: ${{ steps.prepare.outputs.conflict_list }}
@@ -234,8 +235,8 @@ jobs:
         # the step on an internal error (is_error) — so a zero-edit auth/model
         # failure slips through as green, leaving the markers for finalize to
         # misreport as an unresolvable conflict handed to a human. Read the
-        # execution log and stop here instead, so a broken ANTHROPIC_API_KEY or
-        # an inaccessible --model surfaces as itself. A genuine "conflict too
+        # execution log and stop here instead, so a broken CLAUDE_CODE_OAUTH_TOKEN
+        # or an inaccessible --model surfaces as itself. A genuine "conflict too
         # hard" run has is_error false (Claude left the markers on purpose per the
         # prompt) and passes this gate, so finalize still posts the human handoff.
         #
@@ -250,12 +251,12 @@ jobs:
           EXECUTION_FILE: ${{ steps.resolve_llm.outputs.execution_file }}
         run: |
           if [[ -z "${EXECUTION_FILE:-}" || ! -s "${EXECUTION_FILE}" ]]; then
-            echo "::error::Claude resolution produced no execution log — the action failed to run (check ANTHROPIC_API_KEY)." >&2
+            echo "::error::Claude resolution produced no execution log — the action failed to run (check CLAUDE_CODE_OAUTH_TOKEN)." >&2
             exit 1
           fi
           result_jq='if type == "array" then (map(select(.type == "result")) | last) else . end'
           if jq -e "${result_jq} | .is_error == true" "${EXECUTION_FILE}" >/dev/null; then
-            echo "::error::Claude resolution errored (is_error) and made no edits — ANTHROPIC_API_KEY is missing/invalid, or --model is not accessible to it. The conflict was NOT resolved; fix the key and re-run." >&2
+            echo "::error::Claude resolution errored (is_error) and made no edits — CLAUDE_CODE_OAUTH_TOKEN is missing/invalid, or --model is not accessible to it. The conflict was NOT resolved; fix the token and re-run." >&2
             exit 1
           fi
           denials="$(jq -r "${result_jq} | .permission_denials_count // 0" "${EXECUTION_FILE}")"

--- a/.github/workflows/claude-merge-delta-review.yaml
+++ b/.github/workflows/claude-merge-delta-review.yaml
@@ -78,9 +78,10 @@ jobs:
 
       - name: Review the merge deltas with Claude (Sonnet)
         if: steps.prepare.outputs.has_deltas == 'true'
-        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+        uses: ./.github/actions/claude-run
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           # Give the action the workflow token directly. Without it, the action
           # tries to mint one via an OIDC→GitHub-App token exchange that isn't
           # authorized here and fails with "401 Invalid OIDC token" before Claude

--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -1,7 +1,7 @@
 name: Claude PR review
 
 # Auto-review every incoming PR — including PRs from forks/outside contributors
-# — with Claude, using the ANTHROPIC_API_KEY secret.
+# — with Claude, using the CLAUDE_CODE_OAUTH_TOKEN secret (with a fallback).
 #
 # SECURITY — why `pull_request_target` is safe here:
 #   A fork PR triggered via plain `pull_request` gets NO secrets, so it could
@@ -182,9 +182,10 @@ jobs:
       - name: Review the PR with Claude
         id: claude_review
         if: steps.prepare.outputs.oversized != 'true'
-        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+        uses: ./.github/actions/claude-run
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           # Give the action the workflow token directly. Without it, the action
           # tries to mint one via an OIDC→GitHub-App token exchange that isn't
           # authorized here and fails with "401 Invalid OIDC token" before Claude

--- a/.github/workflows/claude-review-thread-resolve.yaml
+++ b/.github/workflows/claude-review-thread-resolve.yaml
@@ -108,9 +108,10 @@ jobs:
       - name: Judge which threads (and any body hold) are addressed (Claude Haiku)
         id: haiku
         if: steps.threads.outputs.has_threads == 'true' || steps.bodyhold.outputs.has_body_hold == 'true'
-        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+        uses: ./.github/actions/claude-run
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Haiku is enough for a per-thread yes/no "does the diff address this?"
           # judgement — far cheaper than the Opus reviewer that raises the concerns.

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -22,9 +22,9 @@ name: Claude
 #   trigger downstream CI, so this is the same existing requirement.
 #
 # AUTH — two credentials, both already documented in the README secrets table:
-#   - Model side: ANTHROPIC_API_KEY authenticates the Anthropic API call. This is
-#     the same secret the security-vulnerability-scan workflow already uses; the
-#     GitHub App does not cover it.
+#   - Model side: CLAUDE_CODE_OAUTH_TOKEN authenticates the Claude Code action
+#     (with CLAUDE_CODE_OAUTH_TOKEN_FALLBACK retried on a primary failure). The
+#     same tokens the other Claude workflows use; the GitHub App does not cover them.
 #   - GitHub side: github_token is TEMPLATE_SYNC_TOKEN (a fine-grained PAT) when
 #     set, falling back to GITHUB_TOKEN. The PAT matters because commits pushed
 #     under GITHUB_TOKEN are suppressed by the recursion guard above and will NOT
@@ -32,7 +32,7 @@ name: Claude
 #     template-sync / phone-home / auto-version.
 #
 # SETUP (per downstream repo, one time): install the Claude GitHub App
-# (https://github.com/apps/claude) and set ANTHROPIC_API_KEY (plus
+# (https://github.com/apps/claude) and set CLAUDE_CODE_OAUTH_TOKEN (plus
 # TEMPLATE_SYNC_TOKEN for CI re-triggering). Access is gated by
 # claude-code-action's built-in check — it only acts for commenters with write
 # access, so a drive-by "@claude" from an outsider is ignored.
@@ -71,8 +71,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Respond to @claude
-        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+        uses: ./.github/actions/claude-run
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           model: claude-sonnet-4-6
           github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-desc-accuracy.yaml
+++ b/.github/workflows/pr-desc-accuracy.yaml
@@ -27,6 +27,12 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # GH_TOKEN authenticates the `gh` CLI the prompt drives (inside the composite
+    # action's Claude step); the action only auths its own internal tools, not the
+    # Bash shell's gh. Set at job level so it reaches the composite's steps — a
+    # step-level env on a composite-action `uses:` step does not propagate inward.
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # pull-requests:write is the real privilege boundary — even a prompt-injected
     # run can only edit this repo's PRs, not push code (contents:read) or reach
     # issues/other scopes. id-token:write is for the action's OIDC auth.
@@ -42,13 +48,10 @@ jobs:
           fetch-depth: 1
 
       - name: Verify and correct the merged PR title/description
-        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
-        # GH_TOKEN authenticates the `gh` CLI the prompt drives — the action
-        # only auths its own internal tools, not the Bash shell's gh.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/claude-run
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           claude_args: >-
             --model claude-haiku-4-5
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr edit:*)"

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -65,9 +65,10 @@ jobs:
 
       - name: Triage and fix with Claude
         id: triage
-        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1.0.157
+        uses: ./.github/actions/claude-run
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          fallback_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_FALLBACK }}
           model: claude-sonnet-4-6
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |


### PR DESCRIPTION
## What & why

Downstream repos carry `CLAUDE_CODE_OAUTH_TOKEN` (+ a backup), **not** `ANTHROPIC_API_KEY` — so the Claude workflows this template synced out couldn't authenticate. Switch every `claude-code-action` invocation from `anthropic_api_key` to the Claude Code OAuth token, and add a primary→fallback retry. Done **DRY**: one shared composite owns the credential, the retry, and the action pin, so no workflow re-implements any of it.

## Review focus

- **`.github/actions/claude-run/action.yaml`** (new) — the single source of truth. Runs `claude-code-action` with `CLAUDE_CODE_OAUTH_TOKEN`; on a real *primary failure* (uses `outcome`, not `conclusion`, since `continue-on-error` rewrites the latter) it retries once with `CLAUDE_CODE_OAUTH_TOKEN_FALLBACK`; a final step turns a genuine double-failure back into a hard error. Forwards `github_token`, `model`, `prompt`, `claude_args`, `allowed_non_write_users`, `allowed_bots`; exposes `execution_file`.
- **The `execution_file` chain** — `auto-resolve-conflicts` → `claude-conflict-resolve` → `claude-run` all forward `execution_file`, and `claude-pr-review`/`claude-review-thread-resolve` read `steps.<id>.outputs.execution_file`. Step `id`s were preserved so those references still resolve to `claude-run`'s output.

## Changes

- **New** `claude-run` composite (above).
- `claude-conflict-resolve` now calls `claude-run` — its bounded-tool set / `acceptEdits` / file-scope prompt stay SSOT here; the credential + retry moved out to `claude-run`.
- Inline `claude-code-action` calls replaced by `claude-run` in: `claude-pr-review`, `claude` (@claude responder), `security-vulnerability-scan`, `claude-review-thread-resolve`, `claude-merge-delta-review`, `pr-desc-accuracy`, `auto-resolve-conflicts`. After this, `anthropics/claude-code-action` appears in **exactly one file** (the composite).
- `pr-desc-accuracy`: `GH_TOKEN` moved from the step to **job level** — a step-level `env` on a composite-action `uses:` step does not propagate into the composite's inner steps, but job-level env does.
- Comments referencing `ANTHROPIC_API_KEY` updated.

## Decisions made

- **`auto-version.yaml` / `version-bump.sh` intentionally stay on `ANTHROPIC_API_KEY`.** They call the raw Anthropic Messages API with an `x-api-key` header (for changelog prose) — an OAuth token can't authenticate that endpoint — and already degrade to a plain commit list when the key is absent. Converting them would break, not help.
- **Failover lives inside the composite, not per-workflow.** The alternative (glovebox's per-workflow two-invocation pattern) repeats the retry in every caller; centralizing it is the DRY win requested and keeps the action pin in one place.
- **Tag-mode / empty inputs:** `claude` (@claude responder) passes empty `prompt`/`claude_args` through `claude-run`; GitHub's `getInput` returns `''` for both empty and unset, so the action still enters tag mode.

## How it was tested

- `actionlint` on all 7 changed workflows → OK; `zizmor --offline .github/` → no findings; both composite `action.yaml`s parse.
- ci-truth-serum aggregates on the changed set — `check-tier1`/`tier2`/`extras`/`path-gate-deps`/`failure-notifier-coverage` → **all Passed**.
- Verified `anthropics/claude-code-action` is now referenced in exactly one file, and every `execution_file` consumer still resolves to a real output.

## Security boundary impact

Credential change only: the model-side auth moves from an API key to the Claude Code OAuth token (+ backup). No change to the tool gating, the `allowed_bots`/`allowed_non_write_users` boundaries, the base-only checkouts, or the least-privilege `github_token`s — all preserved verbatim through the composite.

<details>
<summary>Author checklist</summary>

- [x] Commits use Conventional Commits
- [x] Tests added/updated and not skipped or weakened (no test asserts on the credential; behavior-equivalent refactor)
- [x] README/docs untouched (no repo docs referenced the secret name)
- [x] Local checks pass (binary-download pre-commit hooks 403-blocked in this web session; verified with system actionlint/zizmor + ci-truth-serum aggregates)

</details>

---
_Generated by [Claude Code](https://claude.ai/code/session_0112EEVpowpd7eex2GTptqEy)_