### PR TITLE
feat(ci): scheduled scan so auto-resolve handles born-conflicted PRs

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yaml
+++ b/.github/workflows/auto-resolve-conflicts.yaml
@@ -66,10 +66,12 @@ on:
     branches: [main]
   # Backstop for born-conflicted PRs no push/label/opened event resolved in time
   # (see the header note). Runs discover across every open PR and relays like the
-  # push scan. Every 30 minutes — a cheap discover job that only fans out to the
-  # paid resolve when it actually finds a conflicting PR.
+  # push scan. Every 5 minutes (GitHub's minimum cron granularity) — discover is a
+  # cheap, deterministic scan (a few gh API calls, ~30s) that only fans out to the
+  # paid resolve when it actually finds a conflicting PR, so a tight cadence just
+  # shortens the born-conflicted wait without incurring LLM cost on empty scans.
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "*/5 * * * *"
   # The push/schedule scan's resolve vehicle (see the relay note above); discover
   # re-scans every open PR, so the dispatch carries no inputs.
   workflow_dispatch:

--- a/.github/workflows/auto-resolve-conflicts.yaml
+++ b/.github/workflows/auto-resolve-conflicts.yaml
@@ -38,12 +38,23 @@
 # turns whichever event fired into the set of eligible PRs; `resolve` fans out
 # over them.
 #
-# claude-code-action rejects `push` events outright ("Unsupported event type:
-# push"), so a push run never resolves directly: when its scan finds conflicting
-# PRs, the `relay` job re-fires this workflow as a workflow_dispatch (which the
-# action does support) and THAT run re-discovers and resolves. GITHUB_TOKEN's
-# recursion guard exempts workflow_dispatch, so the relay dispatch does start a
-# run; the dispatched run can't relay again (relay is push-only), so no loop.
+# claude-code-action rejects `push` (and `schedule`) events outright
+# ("Unsupported event type"), so such a run never resolves directly: when its
+# scan finds conflicting PRs, the `relay` job re-fires this workflow as a
+# workflow_dispatch (which the action does support) and THAT run re-discovers and
+# resolves. GITHUB_TOKEN's recursion guard exempts workflow_dispatch, so the relay
+# dispatch does start a run; the dispatched run can't relay again (relay fires
+# only on push/schedule), so no loop.
+#
+# The scheduled scan closes the born-conflicted gap: a PR whose branch was cut
+# from an older main conflicts the instant it opens, but the `opened` event may
+# never drive a resolve — most sharply when the PR is opened via the API/app
+# token, since GitHub suppresses workflow triggers for events a GITHUB_TOKEN /
+# app actor generates (its own recursion guard). Such a PR then waits for the
+# next push-to-main scan, which is arbitrarily far off. The schedule re-scans
+# every open PR on a fixed cadence and relays exactly like the push scan, so a
+# conflicting PR is picked up within the interval no matter which events reached
+# (or skipped) it.
 name: Auto-resolve merge conflicts
 
 on:
@@ -53,8 +64,14 @@ on:
   # them all (the labeler fires on the same event for the same reason).
   push:
     branches: [main]
-  # The push scan's resolve vehicle (see the relay note above); discover re-scans
-  # every open PR, so the dispatch carries no inputs.
+  # Backstop for born-conflicted PRs no push/label/opened event resolved in time
+  # (see the header note). Runs discover across every open PR and relays like the
+  # push scan. Every 30 minutes — a cheap discover job that only fans out to the
+  # paid resolve when it actually finds a conflicting PR.
+  schedule:
+    - cron: "*/30 * * * *"
+  # The push/schedule scan's resolve vehicle (see the relay note above); discover
+  # re-scans every open PR, so the dispatch carries no inputs.
   workflow_dispatch:
 
 permissions: {}
@@ -107,10 +124,13 @@ jobs:
           fi
 
   relay:
-    name: Relay push scan as workflow_dispatch
+    name: Relay push/schedule scan as workflow_dispatch
     needs: discover
+    # Both the push and the scheduled scan run under an event claude-code-action
+    # rejects, so both resolve indirectly by re-dispatching. Keep this off
+    # workflow_dispatch itself so the relayed run can't relay again (no loop).
     if: >-
-      github.event_name == 'push' &&
+      (github.event_name == 'push' || github.event_name == 'schedule') &&
       needs.discover.outputs.prs != '' && needs.discover.outputs.prs != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -126,9 +146,11 @@ jobs:
   resolve:
     name: Auto-resolve merge conflicts
     needs: discover
-    # push runs relay instead of resolving (claude-code-action rejects push).
+    # push and schedule run relay instead of resolving (claude-code-action rejects
+    # both); resolve happens on the relayed workflow_dispatch (and directly on a
+    # pull_request event).
     if: >-
-      github.event_name != 'push' &&
+      github.event_name != 'push' && github.event_name != 'schedule' &&
       needs.discover.outputs.prs != '' && needs.discover.outputs.prs != '[]'
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Problem

A PR whose branch was cut from an **older main** conflicts the instant it opens ("born-conflicted"). The auto-resolve workflow's event-driven triggers can all miss it:

- The `pull_request: opened` event **does not drive a resolve when the PR is opened via the API/app token** — GitHub deliberately suppresses workflow triggers for events a `GITHUB_TOKEN`/app actor generates (its own recursion guard). Empirically, three born-conflicted PRs opened this way got **zero** auto-resolve runs at open time; the first run only came ~20 min later from a human `synchronize` push.
- The only trigger that re-scans **every** open PR — the push-to-main scan — is arbitrarily far off and, on a busy runner pool, queued.

So a born-conflicted PR can sit `CONFLICTING` with no auto-resolve attempt until a human pushes.

Note the discover script **already** handles the async-mergeability race (its `MAX_PASSES` retry loop re-queries a PR whose mergeability GitHub hasn't computed yet). The gap this fixes is purely *"no timely event reached discover at all."*

## Fix

Add a `schedule:` trigger (**every 5 minutes**, GitHub's minimum cron granularity) that re-scans every open PR and relays to `workflow_dispatch` exactly like the existing push scan:

- `relay` job now fires on **push OR schedule** (both run under events `claude-code-action` rejects, so both resolve indirectly by re-dispatching).
- `resolve` job now skips **both** push and schedule (runs only on the relayed `workflow_dispatch`, or directly on a `pull_request` event) — so there is no resolve loop: the relayed run is `workflow_dispatch`, and relay never fires on `workflow_dispatch`.

## Why it's safe / cheap

- **No double-resolve:** the `resolve` job already has per-PR `concurrency` with `cancel-in-progress`, so overlapping scans of the same PR supersede rather than collide.
- **No loop:** relay fires only on push/schedule; the dispatched run is `workflow_dispatch`.
- **Cost:** the 5-minute scan is just the cheap, deterministic `discover` job (a few `gh` API calls, ~30s on `ubuntu-latest`). It fans out to the paid LLM `resolve` **only** when it actually finds a conflicting PR, so a tight cadence shortens the born-conflicted wait without incurring LLM cost on empty scans (it does use ~30s of runner time per scan).

## Verification

- YAML valid; ci-truth-serum workflow-shape lints pass against the file: `check_cron_comment`, `check_static_concurrency`, `check_requires_concurrency`, `check_always_reporter`, `check_required_reporter`.
- The three `github.event_name` gates audited: discover admits schedule, relay fires on push|schedule, resolve excludes push&schedule.

The 5-minute cadence is a single documented value in the `on: schedule:` comment and trivially tunable.