### PR TITLE
ci(template-sync): apply merge-conflict label on conflict PRs

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -196,7 +196,7 @@ jobs:
             Please review the changes and merge if appropriate.
           branch: template-sync
           delete-branch: true
-          labels: ${{ steps.sync.outputs.has_conflicts == 'true' && 'template-sync,needs-conflict-resolution' || 'template-sync' }}
+          labels: ${{ steps.sync.outputs.has_conflicts == 'true' && 'template-sync,merge-conflict' || 'template-sync' }}
 
       - name: Request Claude to resolve conflicts
         if: inputs.dry-run != 'true' && (steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true') && steps.create-pr.outputs.pull-request-number


### PR DESCRIPTION
## Summary

Template-sync PRs that carry unresolved conflicts now get labeled `merge-conflict` instead of the bespoke `needs-conflict-resolution` label. `merge-conflict` is the label already used across the repo's conflict tooling (`label-merge-conflicts.sh`, `auto-resolve-conflicts.yaml`, `pr-meta-privileged.yaml`), so this reuses the existing vocabulary rather than introducing a one-off tag. The non-conflict case still applies only `template-sync`.

## Changes

- `.github/workflows/template-sync.yaml`: swap `needs-conflict-resolution` → `merge-conflict` in the Create Pull Request `labels` expression.

## Notes

- Conflict resolution itself is unchanged — the "Request Claude to resolve conflicts" step still fires on `has_conflicts`/`has_deletions` independent of the label.
- `needs-conflict-resolution` had no other references in the repo, so nothing else needed updating.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEnmxvuG9i1xN8dN4gAHYS)_