### PR TITLE
feat(lint): add markdownlint with an orphan-table-row rule

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -4,7 +4,7 @@ This directory contains configuration and skills for Claude Code.
 
 ## Structure
 
-```
+```text
 .claude/
 ├── settings.json              # Claude Code hooks configuration
 ├── agents/

--- a/.claude/skills/pr-creation/SKILL.md
+++ b/.claude/skills/pr-creation/SKILL.md
@@ -77,10 +77,13 @@ You MUST read [pr-templates.md](pr-templates.md) for the PR template and formatt
 
 1. Push the branch: `git push -u origin HEAD`
 2. Check if a PR already exists for the current branch:
+
    ```bash
    EXISTING_PR=$(gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number' 2>/dev/null)
    ```
+
    If a PR already exists, update it with `gh pr edit` instead of creating a new one.
+
 3. Create the PR using `gh pr create` with the template from the resource file. Make sure that you use the target branch
 
 **Write the body for the reviewer's cognitive budget, not as an investigation archive** —
@@ -135,6 +138,7 @@ Push any commits made during the critique and validation steps, then update the 
 
 2. Re-read the diff (`git diff $CLAUDE_CODE_BASE_REF...HEAD`) and commit log (`git log $CLAUDE_CODE_BASE_REF..HEAD --oneline`) to see the full scope
 3. Rewrite the title and body to accurately describe the **current totality** of changes, not just the original scope:
+
    ```bash
    gh pr edit <pr-number> --title "<type>: <updated description>" --body "$(cat <<'EOF'
    <updated body using template from pr-templates.md>
@@ -187,7 +191,7 @@ State each insight as one concrete line. Skip this step if the task was trivial 
 7. Runs `pnpm check && pnpm test && pnpm lint`—all pass
 8. Pushes fixes, updates PR description to reflect the null-check fix
 9. Watches CI with `gh pr checks 47 --watch`—all green
-10. Reports: “PR #47 created and all CI checks pass: https://github.com/org/repo/pull/47"
+10. Reports: “PR #47 created and all CI checks pass: <https://github.com/org/repo/pull/47>"
 
 ### Example 2: Multi-Commit Feature
 

--- a/.claude/skills/update-pr/SKILL.md
+++ b/.claude/skills/update-pr/SKILL.md
@@ -61,12 +61,14 @@ After pushing, dynamically update the PR to reflect **all** changes (not just th
 2. Check for `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, or similar PR description guidance in the repo—if found, adapt the description to follow the repository’s conventions
 3. Read `.claude/skills/pr-creation/pr-templates.md` for the PR template format and merge with any repo-specific guidance
 4. Rewrite the title and body to accurately describe the **current state** of the PR:
+
    ```bash
    gh pr edit <pr-number> --title "<type>: <updated description>" --body "$(cat <<'EOF'
    <updated body using template from pr-templates.md>
    EOF
    )"
    ```
+
 5. The title and summary should reflect the totality of the PR, not just the new changes
 
 ### 6. Verify CI (with 15-minute timeout)

--- a/.github/scripts/markdownlint-orphan-table-row.mjs
+++ b/.github/scripts/markdownlint-orphan-table-row.mjs
@@ -1,0 +1,58 @@
+// markdownlint custom rule: a line written as a table row that the parser does
+// not put in a table.
+//
+// GFM tables end at the first blank line. A row separated from its table by a
+// blank line is not a syntax error — it silently degrades to a paragraph, so
+// the source reads as a table row while the rendered page shows a stray line of
+// `| pipe | text |`. No stock markdownlint rule fires: MD055/MD056/MD060 only
+// inspect rows the parser already accepted as part of a table.
+//
+// Reports only, deliberately. The obvious fix — delete the blank line — is only
+// safe when the row can be proven to rejoin the table above it, and the proof
+// has to account for the paragraph's prose tail, block containers, blockquote
+// prefixes and multi-row paragraphs. Getting any of that wrong rewrites the
+// author's file without fixing the error, which `--fix` then repeats on every
+// run. Naming the line is the whole value; deleting one blank is not.
+//
+// Loaded by markdownlint-cli2 (see .markdownlint-cli2.jsonc) in an environment
+// that installs no other packages, so this module must stay import-free.
+
+// A leading pipe plus at least one more. Up to three leading spaces still
+// starts a table row; a fourth makes it an indented code block, which renders
+// as code and is therefore not this bug. A quoted row (`> | a | b |`) is out of
+// scope — the parser keeps it in the blockquote, where this rule cannot tell a
+// severed row from prose that happens to start with a pipe.
+const TABLE_ROW = /^ {0,3}\|.*\|/;
+
+/** Paragraph tokens, flattened out of the micromark token tree. */
+const paragraphs = (tokens) => {
+  const found = [];
+  const walk = (token) => {
+    if (token.type === "paragraph") found.push(token);
+    for (const child of token.children ?? []) walk(child);
+  };
+  for (const token of tokens) walk(token);
+  return found;
+};
+
+export default {
+  names: ["orphan-table-row"],
+  description:
+    "Line is written as a table row but renders as paragraph text (blank line severs a GFM table)",
+  tags: ["tables"],
+  parser: "micromark",
+  function: ({ lines, parsers }, onError) => {
+    for (const paragraph of paragraphs(parsers.micromark.tokens)) {
+      for (let n = paragraph.startLine; n <= paragraph.endLine; n++) {
+        const line = lines[n - 1];
+        if (!TABLE_ROW.test(line)) continue;
+        onError({
+          lineNumber: n,
+          detail:
+            "GFM tables end at the first blank line; this row renders as literal text",
+          context: line.length > 60 ? `${line.slice(0, 57)}...` : line,
+        });
+      }
+    }
+  },
+};

--- a/.github/scripts/markdownlint-orphan-table-row.test.mjs
+++ b/.github/scripts/markdownlint-orphan-table-row.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { lint } from "markdownlint/promise";
+
+import rule from "./markdownlint-orphan-table-row.mjs";
+
+const RULE = "orphan-table-row";
+
+const DETAIL =
+  "GFM tables end at the first blank line; this row renders as literal text";
+
+/** Lint `markdown` with only this rule enabled. */
+const run = async (markdown) => {
+  const results = await lint({
+    strings: { s: markdown },
+    config: { default: false, [RULE]: true },
+    customRules: [rule],
+  });
+  return results.s;
+};
+
+const linesFlagged = async (markdown) =>
+  (await run(markdown)).map((error) => error.lineNumber);
+
+const TABLE = "| Hook | Failure |\n| ---- | ------- |\n| `a`  | first   |\n";
+const ROW = "| `b` | second |";
+
+const FLAGGED = [
+  {
+    name: "a row severed from its table by a blank line",
+    markdown: `${TABLE}\n${ROW}\n`,
+    lines: [5],
+  },
+  {
+    name: "a severed row with no trailing pipe (GFM lets a row drop it)",
+    markdown: `${TABLE}\n| \`b\` | second\n`,
+    lines: [5],
+  },
+  {
+    name: "a severing line of whitespace rather than nothing",
+    markdown: `${TABLE}   \n${ROW}\n`,
+    lines: [5],
+  },
+  {
+    name: "every row of a run of severed paragraphs",
+    markdown: `${TABLE}\n| 3 | 4 |\n| 5 | 6 |\n\n| 7 | 8 |\n`,
+    lines: [5, 6, 8],
+  },
+  {
+    name: "a severed row nested in a list item (the table is not top level)",
+    markdown:
+      "- item\n\n  | A | B |\n  | - | - |\n  | 1 | 2 |\n\n  | 3 | 4 |\n",
+    lines: [7],
+  },
+  {
+    name: "a row two blank lines below its table",
+    markdown: `${TABLE}\n\n${ROW}\n`,
+    lines: [6],
+  },
+  {
+    name: "a row mid-paragraph, a lazy continuation of the prose above it",
+    markdown: `${TABLE}\nProse lead-in.\n${ROW}\n`,
+    lines: [6],
+  },
+  {
+    name: "a row with no table anywhere above it",
+    markdown: `${ROW}\n`,
+    lines: [1],
+  },
+];
+
+for (const { name, markdown, lines } of FLAGGED) {
+  test(`flagged: ${name}`, async () => {
+    assert.deepEqual(await linesFlagged(markdown), lines);
+  });
+}
+
+const CLEAN = [
+  { name: "a well-formed table", markdown: `${TABLE}${ROW}\n` },
+  {
+    name: "a fenced code block quoting a row",
+    markdown: "```\n| `b` | second |\n```\n",
+  },
+  {
+    name: "an indented code block quoting a row",
+    markdown: "Prose.\n\n    | `b` | second |\n",
+  },
+  {
+    // The shape test is anchored: only a *leading* pipe starts a row.
+    name: "prose with interior pipes",
+    markdown: `${TABLE}\nUse \`a | b\` to pipe | like this.\n`,
+  },
+  {
+    // Out of scope: inside a blockquote this rule cannot tell a severed row
+    // from prose that happens to start with a pipe.
+    name: "a severed row inside a blockquote",
+    markdown: "> | A | B |\n> | - | - |\n> | 1 | 2 |\n>\n> | 3 | 4 |\n",
+  },
+];
+
+for (const { name, markdown } of CLEAN) {
+  test(`not flagged: ${name}`, async () => {
+    assert.deepEqual(await linesFlagged(markdown), []);
+  });
+}
+
+test("the rule reports but never rewrites", async () => {
+  // Deleting the severing blank line only helps when the row provably rejoins
+  // the table above it, and that proof has to survive prose tails, block
+  // containers and blockquote prefixes. A fix that guesses wrong rewrites the
+  // file without clearing the error, so `--fix` churns on it every run.
+  const errors = await run(`${TABLE}\n${ROW}\n`);
+  assert.deepEqual(
+    errors.map((error) => error.fixInfo),
+    [null],
+  );
+});
+
+test("a long row is reported truncated, a short one in full", async () => {
+  const long = `| \`b\` | ${"x".repeat(200)} |`;
+  const [longError] = await run(`${TABLE}\n${long}\n`);
+  assert.deepEqual(longError.ruleNames, [RULE]);
+  assert.equal(longError.errorDetail, DETAIL);
+  assert.equal(longError.errorContext, `${long.slice(0, 57)}...`);
+
+  // Exactly at the threshold is short; one over is truncated.
+  const exactly60 = `| a |${" ".repeat(54)}|`;
+  assert.equal(exactly60.length, 60);
+  const [atLimit] = await run(`${TABLE}\n${exactly60}\n`);
+  assert.equal(atLimit.errorContext, exactly60);
+  const [overLimit] = await run(`${TABLE}\n${exactly60} |\n`);
+  assert.equal(overLimit.errorContext, `${`${exactly60} |`.slice(0, 57)}...`);
+});
+
+test("the repo's own markdownlint config catches both defects it exists for", async () => {
+  // Drives the real config through the real CLI rather than grepping the file
+  // for a path: a config that stopped loading the rule, or that switched MD056
+  // off, would keep a grep-style guard passing.
+  const { execFileSync } = await import("node:child_process");
+  const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const { tmpdir } = await import("node:os");
+
+  const repoRoot = new URL("../..", import.meta.url).pathname;
+  const lintThroughRepoConfig = (markdown) => {
+    const dir = mkdtempSync(join(tmpdir(), "mdl-"));
+    try {
+      const file = join(dir, "fixture.md");
+      writeFileSync(file, markdown);
+      // The CLI exits non-zero when it finds anything, which is the point.
+      try {
+        execFileSync(
+          join(repoRoot, "node_modules/.bin/markdownlint-cli2"),
+          ["--config", join(repoRoot, ".markdownlint-cli2.jsonc"), file],
+          { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+        );
+        return "";
+      } catch (exit) {
+        // Only a real lint failure carries an exit status; anything else (a
+        // missing binary, say) must not be mistaken for "found no issues".
+        if (exit.status === undefined) throw exit;
+        return `${exit.stdout}${exit.stderr}`;
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  };
+
+  assert.match(
+    lintThroughRepoConfig(`${TABLE}\n${ROW}\n`),
+    new RegExp(`error ${RULE}`),
+    "the custom rule must load and fire through the repo config",
+  );
+  assert.match(
+    lintThroughRepoConfig("| A | B |\n| - | - |\n| a `|` b | c |\n"),
+    /error MD056/,
+    "an unescaped pipe splitting a cell must still be caught",
+  );
+});

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,31 @@
+// markdownlint config. Scope: whether the markdown *renders* as written.
+// Whitespace/wrapping style is Prettier's job — every rule Prettier already
+// owns or would fight is disabled below, so the two tools never thrash.
+{
+  "customRules": ["./.github/scripts/markdownlint-orphan-table-row.mjs"],
+  "config": {
+    "default": true,
+
+    // Prettier owns these; leaving them on means two tools rewriting the same
+    // bytes in different directions.
+    "line-length": false, // MD013
+    "ul-style": false, // MD004
+    "ol-prefix": false, // MD029
+    "no-multiple-blanks": false, // MD012
+    "hr-style": false, // MD035
+    "emphasis-style": false, // MD049
+    "strong-style": false, // MD050
+    "table-pipe-style": false, // MD055
+
+    // Prose choices, not rendering defects.
+    "first-line-heading": false, // MD041
+    "no-duplicate-heading": false, // MD024
+    "no-inline-html": false, // MD033
+    "no-emphasis-as-heading": false, // MD036
+    "single-title": false, // MD025
+  },
+  // No `globs` key on purpose: a config-level glob is *added* to any files
+  // passed on the command line, so lint-staged would drag the whole repo into
+  // every commit. The repo-wide glob lives in the `lint:md` scripts instead.
+  "ignores": ["node_modules", ".venv", "**/node_modules/**"],
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,19 @@ repos:
     hooks:
       - id: actionlint
 
+  # Catches markdown that does not render as written — malformed tables, broken
+  # link fragments, code spans that swallow their delimiters — plus the local
+  # `orphan-table-row` rule (.github/scripts/markdownlint-orphan-table-row.mjs),
+  # which reports a table row a blank line severed from its table: the parser
+  # never accepted it as a row, so no stock rule inspects it. Prettier owns
+  # whitespace/wrapping; every rule it touches is off in .markdownlint-cli2.jsonc
+  # so the two never rewrite each other.
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.23.1
+    hooks:
+      - id: markdownlint-cli2
+        args: [--fix]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.5
     hooks:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The same file's `permissions.deny` block blocks Claude from reading secret files
 
 ## How the Pieces Fit Together
 
-```
+```text
 Developer / Claude Code session
         │
         ├── git commit
@@ -214,7 +214,7 @@ Repository **settings and secrets are never copied** when you create a repo from
 
 ## Project Structure
 
-```
+```text
 .
 ├── .claude/
 │   ├── hooks/              # Claude session hooks (SessionStart, PreToolUse)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "start": "echo 'ERROR: Configure start script in package.json' && exit 1",
     "test": "bash .github/scripts/install-input-sanitizer.sh && node --test .github/scripts/*.test.mjs",
     "lint": "echo 'ERROR: Configure lint script in package.json' && exit 1",
+    "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\"",
     "check": "echo 'ERROR: Configure check script in package.json' && exit 1",
     "format": "prettier --write ."
   },
@@ -40,6 +42,7 @@
       "prettier --write"
     ],
     "*.md": [
+      "markdownlint-cli2 --fix",
       "prettier --write"
     ],
     ".claude/skills/*/SKILL.md": [
@@ -57,6 +60,8 @@
     "@commitlint/cli": "^21.0.1",
     "@commitlint/config-conventional": "^21.0.1",
     "lint-staged": "^17.0.5",
+    "markdownlint": "^0.41.1",
+    "markdownlint-cli2": "^0.23.1",
     "prettier": "^3.0.0",
     "typescript": "6.0.3"
   }


### PR DESCRIPTION
## Why

Prettier formats markdown in every downstream repo, which reads as coverage — but it validates nothing about whether the markdown *renders*. It will happily reformat a table whose rows have already fallen out of it, and it pads cells **inside** a row a stray `|` has split, actively corrupting the text. Any repo whose README carries a table is one blank line away from shipping visibly broken docs with a fully green CI.

That is not hypothetical: this came out of `ci-truth-serum`, where three README rows had been shipping as literal `| pipe | text |` paragraphs and two cells had been silently truncated by unescaped pipes, through Prettier, pre-commit, and CI, for months.

## What

`markdownlint-cli2` over every `.md` file, from three places: `pnpm lint:md` / `pnpm lint:md:fix`, lint-staged on commit, and pre-commit repo-wide (which is what CI runs). `.markdownlint-cli2.jsonc` scopes it to rendering correctness — every rule Prettier owns (wrapping, emphasis style, pipe alignment) is off, so the two never rewrite each other. `MD056` alone catches the unescaped-pipe half of the bug above.

`lint` stays the `ERROR: Configure` placeholder each downstream repo fills in with its own toolchain; markdown gets its own entry point rather than squatting on that name.

`.github/scripts/markdownlint-orphan-table-row.mjs` is the part no off-the-shelf config supplies. A row a blank line severed from its table parses as a **paragraph**, so `MD055`/`MD056`/`MD060` skip it by construction — there is no table for them to inspect — while it renders as a stray line of pipes. The rule walks the micromark token tree and reports any paragraph line shaped like a table row. It is import-free so pre-commit's isolated node environment can load it.

## Decisions made

- **The rule reports and never rewrites.** The obvious autofix is to delete the severing blank line, and three review passes found a distinct corruption in every version of it: a prose tail eaten as table rows; a column-0 row "rejoined" to a list-indented table it cannot belong to; a run that settled one paragraph per pass; a blockquote table whose `>` prefix an indentation check cannot see. Each rewrote the file **without** clearing the error, so `--fix` churned on it on every run — worse than not fixing. Naming the line is the whole value, so the rule is 58 lines with no fix logic and no proof obligation. markdownlint's own fixable rules autofix as before.
- **Nine real violations in the template's own markdown are fixed here** — unlabelled code fences in `README.md` and `.claude/README.md`, fences without surrounding blank lines in two `SKILL.md` files, and one bare URL. Adopting a linter without fixing what it finds would be adopting a linter that is permanently red.
- **No workflow changes.** The template's workflows deliberately carry no `paths` filters (they are required checks), and `pre-commit.yaml` runs every hook, so the new hook runs in CI with no gate to update.

## Verification

- 16 unit tests for the rule (`.github/scripts/markdownlint-orphan-table-row.test.mjs`), covering severed rows in and out of list items, runs of severed paragraphs, and the cases that must **not** fire: fenced and indented code, prose with interior pipes, blockquotes. One test drives the real config through the real CLI and pins `MD056` on, so switching it off fails rather than silently dropping the other half of the coverage.
- `pnpm test` (233 tests) and the Python suite (232 tests) pass; `markdownlint-cli2` reports 0 issues over the repo; Prettier reports no drift, confirming the two tools agree on every file.
- `pre-commit run --all-files` passes except `lychee` and `zizmor`, which both fail on a sandbox 403 to the GitHub API — unrelated to this diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SPTEzwFZwT9AeJJmahjV26)_