### PR TITLE
fix(ci): prefer the org PAT for the review resolve and approve steps

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -570,13 +570,21 @@ jobs:
           # resolveReviewThread is not available to the Actions GITHUB_TOKEN — it
           # can reply to a thread but a resolve returns "Resource not accessible by
           # integration" even with pull-requests:write, so resolving needs a PAT
-          # acting as a user. TEMPLATE_SYNC_TOKEN (the repo's PAT, already used by
-          # claude.yaml/template-sync.yaml) is scoped to THIS step only, never the
-          # Haiku step, so it is out of reach of a model injection. The ambient
-          # GH_TOKEN (GITHUB_TOKEN) still posts the audit reply, keeping the
-          # github-actions[bot] identity. Falls back to GITHUB_TOKEN — which then
-          # fails loud on the resolve — if the PAT is unset.
-          GH_RESOLVE_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          # acting as a user. The PAT is scoped to THIS step only, never the Haiku
+          # step, so it is out of reach of a model injection. The ambient GH_TOKEN
+          # (GITHUB_TOKEN) still posts the audit reply, keeping the
+          # github-actions[bot] identity.
+          #
+          # Org secret first, then the per-repo one, then the built-in. Both PAT
+          # spellings are load-bearing for different consumers: an org-owned repo
+          # sets TEMPLATE_SYNC_TOKEN_ORG once for every repo it owns, while a
+          # personal fork can only set a repo secret. Trying the org name first
+          # means a downstream repo needs no edit either way.
+          # token-fallback-ok: designed graceful degradation — every candidate is
+          # an identity this repo's owner controls, so the fallback trades away
+          # capability (a resolve/approve the Actions token may not perform),
+          # never which account acts.
+          GH_RESOLVE_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/resolve-addressed-threads.sh
 
       # State-based, and deliberately NOT gated on has_threads: the approval is a
@@ -597,14 +605,14 @@ jobs:
           BODY_VERDICT_FILE: ${{ runner.temp }}/pr-input/verdicts.json
           # GitHub refuses addPullRequestReview outright for an Actions token
           # ("GitHub Actions is not permitted to approve pull requests"), the
-          # approval-side sibling of the resolve restriction above. The same PAT
-          # acting as a user is what makes the approval postable, so this step
-          # takes the same token with the same fallback — and the script reports
-          # and stands down (rather than reddening the PR) when the PAT is unset
-          # and the platform refuses.
-          # The script detects the Actions-token refusal and stands down with an
-          # actionable message instead of failing, so the PAT only ever upgrades
-          # this step from "a human must approve" to "approved automatically".
-          # token-fallback-ok: designed graceful degradation, not an accident.
-          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          # approval-side sibling of the resolve restriction above. A PAT acting as
+          # a user is what makes the approval postable, so this step takes the
+          # same candidates in the same order as the resolve step — and the script
+          # reports and stands down (rather than reddening the PR) when none of
+          # them can approve, so the PAT only ever upgrades this step from "a
+          # human must approve" to "approved automatically".
+          # token-fallback-ok: designed graceful degradation — every candidate is
+          # an identity this repo's owner controls, so the fallback trades away
+          # capability, never which account acts.
+          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/approve-if-reviewer-hold-clear.sh

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -580,10 +580,10 @@ jobs:
           # sets TEMPLATE_SYNC_TOKEN_ORG once for every repo it owns, while a
           # personal fork can only set a repo secret. Trying the org name first
           # means a downstream repo needs no edit either way.
-          # token-fallback-ok: designed graceful degradation — every candidate is
-          # an identity this repo's owner controls, so the fallback trades away
-          # capability (a resolve/approve the Actions token may not perform),
-          # never which account acts.
+          # Every candidate is an identity this repo's owner controls, so the
+          # fallback trades away capability (a resolve the Actions token may not
+          # perform), never which account acts.
+          # token-fallback-ok: designed graceful degradation, not an accident.
           GH_RESOLVE_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/resolve-addressed-threads.sh
 
@@ -611,8 +611,8 @@ jobs:
           # reports and stands down (rather than reddening the PR) when none of
           # them can approve, so the PAT only ever upgrades this step from "a
           # human must approve" to "approved automatically".
-          # token-fallback-ok: designed graceful degradation — every candidate is
-          # an identity this repo's owner controls, so the fallback trades away
-          # capability, never which account acts.
+          # Every candidate is an identity this repo's owner controls, so the
+          # fallback trades away capability, never which account acts.
+          # token-fallback-ok: designed graceful degradation, not an accident.
           GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/approve-if-reviewer-hold-clear.sh


### PR DESCRIPTION
One file, two token lines. This is the missing half of #426: that PR made the approve step *degrade gracefully* when it has no usable token; this one gives it a token that actually works, with no secret provisioning needed.

## The defect

Both the resolve and approve steps in `claude-review.yaml` looked for `secrets.TEMPLATE_SYNC_TOKEN` — a **per-repo** secret that is not set on this repo. Both therefore fell back to `GITHUB_TOKEN`, which cannot perform either operation:

- resolve → `Resource not accessible by integration`
- approve → `GitHub Actions is not permitted to approve pull requests`

The second was observed on #426, where the reviewer's only finding had been fixed and its thread resolved, yet the PR stayed at `CHANGES_REQUESTED` because the bot structurally cannot rescind its own hold.

**The org-level `TEMPLATE_SYNC_TOKEN_ORG` already exists**, and `template-sync.yaml` in this same repo already uses it — four times. Only `claude-review.yaml` was still asking for the repo-scoped spelling. So this was a naming mismatch, not a missing credential.

Both steps now resolve `TEMPLATE_SYNC_TOKEN_ORG || TEMPLATE_SYNC_TOKEN || GITHUB_TOKEN`.

## Why both PAT spellings stay

This is not a backward-compatible alias, which the repo's style rules would forbid. The two names serve genuinely different consumers, and this file is copied into repos of both kinds:

- an **org-owned** repo sets `TEMPLATE_SYNC_TOKEN_ORG` once and every repo it owns inherits it;
- a **personal fork** cannot set an org secret at all, and can only offer a repo secret.

Trying the org name first means a downstream repo needs no edit in either case. The glovebox descendant is the org case and uses `_ORG` exclusively — zero plain `TEMPLATE_SYNC_TOKEN` in its workflows — which is what surfaced the mismatch.

## Review focus

- **The three-way fallback**, which the `check-token-fallback` lint flags by design. The annotation is honest here: every candidate is an identity this repo's owner controls, so the fallback trades away *capability* (an operation the Actions token may not perform), never *which account acts* — which is the account-switch hazard the lint exists to catch.
- Whether the ordering should be org-first. It is chosen so the repo that has both gets the broader-scoped token; flip it only if a repo secret should be able to override its org.

## How it was verified

- `yaml.safe_load` parses the workflow.
- The full pre-push suite ran, including `check-tier2` — which is what caught the annotation placement below.
- `secrets.TEMPLATE_SYNC_TOKEN_ORG` confirmed present in this repo's `template-sync.yaml` (lines 105, 116, 149, 204), so the org secret is known-good in this repo's own workflows rather than assumed.

**Not verifiable pre-merge**, and worth stating plainly: `claude-review.yaml` triggers on `pull_request_target`, which always executes the **base branch's** copy. So this PR's own run still uses the old token wiring. It takes effect on the first PR opened after this merges — the same constraint #426 hit. The evidence above is what is obtainable before merge.

## Decisions made

- **Fallback rather than pinning one secret.** Pinning `_ORG` alone would break personal forks, which are a real consumer of this template.
- **The `token-fallback-ok` marker sits on the line directly above each token.** The lint reads only that line; my first attempt put the explanation between the marker and the token and the check correctly still fired. The explanation now precedes the marker.

## Lessons Learned

- **What**: A step that performs a privileged GitHub action (approve a PR, resolve a review thread) must declare its own token — GitHub forbids Actions tokens from approving PRs *at all*, so an Actions-token reviewer can request changes but never clear its own hold, deadlocking every PR it reviews.
- **Where**: `.github/workflows/claude-review.yaml`, and any workflow that both consumes an org secret and is copied into personal forks.
- **Why**: The org (`*_TOKEN_ORG`) and per-repo spellings are not interchangeable and not aliases; a workflow shared across both repo kinds should try org-first-then-repo rather than pick one, or it silently degrades to `GITHUB_TOKEN` on whichever kind it guessed wrong.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ETQEQ2WyhZxYQ6eS9RAoX2)_