### PR TITLE
docs(claude): require AST over regex for source-code checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ The `pr-creation` skill owns how to write and shape a PR (batching, partitions, 
 Language-specific rules live in `.claude/rules/shell-style.md` and `python-style.md`. These apply everywhere:
 
 - **Always ask whether a real parser (added as a dependency) can do the job before handrolling regex / case-by-case string matching.** When input has a grammar — manifests, lockfiles, YAML/TOML/INI, HTML, shell words, semver, dates — reach for an established parsing library rather than reinventing it. Adding a new dependency is fine except in rare circumstances; don't reinvent the wheel.
+  - **When the input is source code, that parser is an AST — never a regex.** Any lint, guard, codemod, or "does the code do X" check over Python/JS/shell/YAML parses to a tree and queries nodes (`ast` / `libcst` in Python, `tree-sitter`, a custom `ruff`/ESLint rule, `bash -n`+`shellcheck`) instead of matching source text. Text matching can't see scope, strings, comments, aliasing, line continuations, or a call split across two lines, so it fires on a mention in a docstring and misses the real one. Regex earns a place only as a cheap pre-filter that shortlists files for an AST pass to confirm — never as the thing that decides.
 - Fail loudly: throw errors over silent warnings; never remove error output unless the user explicitly asks.
 - Let exceptions propagate—never use try/except unless there is a specific, necessary recovery action. Default to crashing on unexpected input.
 - Un-nest conditionals; combine related checks. Prefer flat control flow with early-return guards.


### PR DESCRIPTION
## What & why

Add a nested sub-rule under the existing "real parser over handrolled regex" bullet in `CLAUDE.md` Code Style: when the input being parsed is **source code**, the parser is an AST — a lint, guard, codemod, or "does the code do X" check parses to a tree and queries nodes (`ast`/`libcst`, `tree-sitter`, a custom `ruff`/ESLint rule, `bash -n` + `shellcheck`) instead of matching source text.

The parent bullet already covered data formats with a grammar (manifests, lockfiles, YAML/TOML/INI), which left checks over code ambiguous — so guards kept landing as grep patterns. Text matching over code can't see scope, strings, comments, aliasing, line continuations, or a call split across two lines: it fires on a mention in a docstring and misses the real call site. Regex is allowed only as a cheap pre-filter that shortlists files for an AST pass to confirm, never as the thing that decides.

Docs only — one bullet, no behavior change.

## How it was tested

`git push` ran the `pre-push` hook's `pre-commit` suite over the pushed range — markdownlint, prettier, and lychee all Passed on `CLAUDE.md`. Falsifier: `uvx pre-commit==<pinned> run --from-ref origin/main --to-ref HEAD`.

Self-critique loop skipped: pure single-bullet docs edit.

<details>
<summary>Author checklist</summary>

- [x] Commits use Conventional Commits (`<type>(<scope>): <desc>`)
- [x] Tests added/updated and not skipped or weakened — n/a, docs only
- [x] README/docs touched **only** if a user-facing or behavior change requires it — the docs *are* the change
- [x] `pre-commit` passes on the pushed range

</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_01SXcKYRNVemoa99VUpDH2bj)_