### PR TITLE
fix(ci): point template-sync at the hosting owner and revive dry-run

### DIFF
--- a/.github/workflows/phone-home.yaml
+++ b/.github/workflows/phone-home.yaml
@@ -9,7 +9,7 @@ on:
     types: [closed]
 
 env:
-  TEMPLATE_REPO: "${{ vars.TEMPLATE_SYNC_ORG || 'alexander-turner' }}/claude-automation-template"
+  TEMPLATE_REPO: "${{ vars.TEMPLATE_SYNC_ORG || 'AlexanderMattTurner' }}/claude-automation-template"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -30,16 +30,21 @@ on:
   workflow_dispatch:
     inputs:
       dry-run:
+        # A `type: boolean` input arrives as a real boolean, so both this default
+        # and every condition that reads it below must be boolean too. Comparing
+        # it to the STRING 'true' silently never matches: GitHub casts across
+        # types to a number, and `true == 'true'` compares 1 with NaN. That made
+        # every "dry run" dispatch open a real pull request.
         description: "Show what would be synced without making changes"
         required: false
-        default: "false"
+        default: false
         type: boolean
   schedule:
     # Run weekly on Mondays at 9am UTC
     - cron: "0 9 * * 1"
 
 env:
-  TEMPLATE_REPO: "${{ vars.TEMPLATE_SYNC_ORG || 'alexander-turner' }}/claude-automation-template"
+  TEMPLATE_REPO: "${{ vars.TEMPLATE_SYNC_ORG || 'AlexanderMattTurner' }}/claude-automation-template"
   # Whole directories of core automation files that are always template-owned.
   # Every file under these paths propagates to downstream consumers; new files
   # added to the template auto-sync without anyone having to edit this list.
@@ -127,7 +132,7 @@ jobs:
         run: bash .github/scripts/template-sync.sh
 
       - name: Show diff (dry run)
-        if: inputs.dry-run == 'true' && steps.sync.outputs.has_changes == 'true'
+        if: inputs.dry-run == true && steps.sync.outputs.has_changes == 'true'
         env:
           HAS_CONFLICTS: ${{ steps.sync.outputs.has_conflicts }}
           HAS_DELETIONS: ${{ steps.sync.outputs.has_deletions }}
@@ -136,7 +141,7 @@ jobs:
         run: bash .github/scripts/show-sync-diff.sh
 
       - name: Create Pull Request
-        if: inputs.dry-run != 'true' && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
+        if: inputs.dry-run != true && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
         id: create-pr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
@@ -206,12 +211,12 @@ jobs:
       # After create-pull-request the workspace is back on the base ref and the
       # markers live on the sync branch, so switch to it before resolving.
       - name: Install mergiraf (pinned, digest-verified)
-        if: inputs.dry-run != 'true' && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
+        if: inputs.dry-run != true && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
         run: bash .github/scripts/install-mergiraf.sh
 
       - name: Resolve the sync conflicts
         id: resolve
-        if: inputs.dry-run != 'true' && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
+        if: inputs.dry-run != true && steps.sync.outputs.has_conflicts == 'true' && steps.create-pr.outputs.pull-request-number
         env:
           CONFLICT_FILES: ${{ steps.sync.outputs.conflict_files }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
@@ -237,7 +242,7 @@ jobs:
       # for the full predicate; the two carve-outs are that a model-resolved file
       # never qualifies, and neither does a change to the supervision surface.
       - name: Enable auto-merge on a fully deterministic sync
-        if: inputs.dry-run != 'true' && steps.create-pr.outputs.pull-request-number && vars.TEMPLATE_SYNC_AUTOMERGE != 'false'
+        if: inputs.dry-run != true && steps.create-pr.outputs.pull-request-number && vars.TEMPLATE_SYNC_AUTOMERGE != 'false'
         env:
           GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || github.token }}
           GH_REPO: ${{ github.repository }}

--- a/tests/test_template_repo_default.py
+++ b/tests/test_template_repo_default.py
@@ -1,0 +1,65 @@
+"""Every workflow that reaches the template repo must name the same owner.
+
+`TEMPLATE_REPO` is declared once per workflow that crosses the repo boundary —
+template-sync clones the template, phone-home files an issue on it. Each
+declaration carries its own fallback owner, and a fallback naming an account
+that does not host the template fails in the quietest way available: the sync
+clones nothing new, or phone-home posts a downstream repo's lessons into the
+void. No error, no red check, just a workflow that has stopped doing its job.
+
+Two downstream repos were already patched by hand to the right owner, which is
+what a defect that cannot announce itself looks like from the outside.
+
+This iterates the declarations rather than naming them, so a workflow added
+later is covered without an edit here.
+
+A single source for the fallback is not available: GitHub Actions shares no
+environment across workflow files, so each one that crosses the repo boundary
+must carry the literal itself. `vars.TEMPLATE_SYNC_ORG` is the real override a
+fork sets once; the literal is only what a repo gets when nobody sets it.
+"""
+
+import re
+
+import pytest
+
+from tests._helpers import REPO_ROOT
+
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# The account that actually hosts this template. The `vars.TEMPLATE_SYNC_ORG`
+# override still redirects a fork; this is only what a repo gets when nobody
+# sets that variable.
+EXPECTED_OWNER = "AlexanderMattTurner"
+
+DECLARATION = re.compile(
+    r"TEMPLATE_REPO:\s*\"\$\{\{\s*vars\.TEMPLATE_SYNC_ORG\s*\|\|\s*"
+    r"'(?P<owner>[^']+)'\s*\}\}/(?P<repo>[^\"]+)\""
+)
+
+
+def _declarations() -> list[tuple[str, str, str]]:
+    """(workflow name, owner, repo) for every TEMPLATE_REPO declaration."""
+    found = []
+    for path in sorted(WORKFLOWS.glob("*.yaml")):
+        for match in DECLARATION.finditer(path.read_text(encoding="utf-8")):
+            found.append((path.name, match["owner"], match["repo"]))
+    return found
+
+
+def test_the_declarations_are_still_here():
+    # Without this the parametrized test below silently covers nothing: a
+    # renamed variable or a changed quoting style would empty the list and every
+    # case would pass by never running.
+    names = {name for name, _, _ in _declarations()}
+    assert {"template-sync.yaml", "phone-home.yaml"} <= names, (
+        f"TEMPLATE_REPO declarations found in {names or 'no workflow'}"
+    )
+
+
+@pytest.mark.parametrize("workflow,owner,repo", _declarations())
+def test_every_declaration_names_the_hosting_owner(workflow, owner, repo):
+    assert owner == EXPECTED_OWNER, (
+        f"{workflow} falls back to '{owner}', which does not host this template"
+    )
+    assert repo == "claude-automation-template"

--- a/tests/test_template_sync_dry_run.py
+++ b/tests/test_template_sync_dry_run.py
@@ -1,0 +1,72 @@
+"""template-sync's `dry-run` input must be compared as a boolean.
+
+The input is declared `type: boolean`, so GitHub hands the expression a real
+boolean. Comparing it to the STRING 'true' never matches: GitHub casts across
+types to a number, so `true == 'true'` compares 1 with NaN. The dry-run branch
+was therefore dead and the pull-request branch always ran — every "dry run"
+dispatch opened a real pull request, with no error and nothing in the log to say
+so.
+
+That is invisible from inside the workflow, which is why it survived long enough
+to reach every downstream repo. These tests read the workflow GitHub actually
+executes and pin the type agreement between the declaration and its readers.
+"""
+
+import re
+
+import yaml
+
+from tests._helpers import REPO_ROOT
+
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "template-sync.yaml"
+INPUT_NAME = "dry-run"
+
+# `on` is the YAML 1.1 boolean True, which is what safe_load gives back for the
+# unquoted key. Reading it as the string "on" finds nothing and the whole suite
+# passes vacuously.
+ON_KEY = True
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _conditions() -> list[str]:
+    """Every step `if:` in the workflow that reads the dry-run input."""
+    found = []
+    for job in _workflow()["jobs"].values():
+        for step in job.get("steps", []):
+            condition = step.get("if")
+            if isinstance(condition, str) and f"inputs.{INPUT_NAME}" in condition:
+                found.append(condition)
+    return found
+
+
+def test_the_input_is_declared_boolean():
+    spec = _workflow()[ON_KEY]["workflow_dispatch"]["inputs"][INPUT_NAME]
+    assert spec["type"] == "boolean"
+
+
+def test_the_default_is_a_boolean_not_a_string():
+    # A quoted "false" default is the same type confusion one step earlier: it
+    # reads as truthy wherever a caller forwards it verbatim.
+    spec = _workflow()[ON_KEY]["workflow_dispatch"]["inputs"][INPUT_NAME]
+    assert spec["default"] is False, f"default is {spec['default']!r}, not a boolean"
+
+
+def test_every_condition_compares_the_input_to_a_boolean():
+    conditions = _conditions()
+    # Non-vacuity: the assertion below is satisfied by an empty list, and this
+    # workflow's whole dry-run behaviour is carried by these conditions.
+    assert len(conditions) >= 5, (
+        f"expected the dry-run conditions to still be here, found {len(conditions)}"
+    )
+    quoted = [
+        c
+        for c in conditions
+        if re.search(rf"inputs\.{re.escape(INPUT_NAME)}\s*[!=]=\s*'", c)
+    ]
+    assert quoted == [], (
+        "these conditions compare a boolean input to a string, which never "
+        f"matches: {quoted}"
+    )


### PR DESCRIPTION
Claims `.github/workflows/template-sync.yaml` and `phone-home.yaml`. Prerequisite for syncing #438 and #439 out to the eight downstream repos — both defects below would otherwise propagate on the very sync meant to distribute the fixes.

## What changed and why

**The sync pointed at an account that does not host this template.** `TEMPLATE_REPO` fell back to `alexander-turner/claude-automation-template`. Every repository in this account lives under `AlexanderMattTurner`, so six of the eight downstream repos only synced correctly if a repository variable happened to be set — and the two that did not depend on that variable, `punctilio` and `agent-glovebox`, had each been patched by hand to the right owner. Two independent local patches for the same line is what a defect that cannot announce itself looks like from the outside: the sync does not fail, it just quietly stops bringing anything new.

`phone-home.yaml` carried the same fallback. That workflow takes a merged pull request's `## Lessons Learned` section and files it as an issue on the template, so downstream repos have been posting their lessons at an account that does not host the template. Both now default to `AlexanderMattTurner`. `vars.TEMPLATE_SYNC_ORG` still redirects a fork, so nothing about the override mechanism changes.

**"Dry run" never ran dry.** The `dry-run` input is declared `type: boolean`, so the expression receives a real boolean — but all five step conditions compared it to the string `'true'`. GitHub casts across types to a number when the sides differ, so `true == 'true'` compares `1` with `NaN` and never matches. The dry-run branch was dead code and the pull-request branch always ran: every "dry run" dispatch opened a real PR, with no error and nothing in the log to say so. `.dotfiles` already carries the corrected `== true` form, and its `CLAUDE.md` explicitly asks for it to be folded upstream; this is that fold. The quoted `default: "false"` goes with it — the same type confusion one step earlier.

Scheduled runs are unaffected either way. On a `schedule` event `inputs.dry-run` is empty, which coerces to `0` against both `true` and `'true'`, so the cron took and still takes the PR-creating branch.

## Decisions made

| What came up | Chosen | Under the alternative |
| --- | --- | --- |
| Which owner is authoritative | `AlexanderMattTurner`, per the user's answer and every repo's git remote | If `alexander-turner` were a genuine separate upstream, six repos are correct as-is and `punctilio`/`agent-glovebox` are the anomalies |
| Whether to fix `phone-home.yaml` too | Yes — same defect, same class, same change | Fixing only the sync leaves the lessons channel pointed at the wrong account, and the next reader has no reason to look there |
| Test shape for the owner | Iterate every `TEMPLATE_REPO` declaration and assert the owner | Naming the two workflows explicitly means a third one added later is uncovered until someone remembers to edit the test |

## Merge authorization

Quoting the instruction that authorizes landing this, so the consent is recorded on the artifact rather than living only in a chat session:

> You can automatically merge it on those branches using force merge for the organization change.

Auto-merge is armed on that basis. The required checks still gate.

<details><summary>Verification residue</summary>

**Suites.** `uv run --extra dev pytest tests/ -q` 358 → **364 passing** (+6: 3 dry-run, 3 owner). `node --test '.github/scripts/**/*.test.mjs'` **330**, unchanged.

**Non-vacuity, both tests, observed.** Swapped each fixed workflow for `git show origin/main:<path>` and re-ran:

- `tests/test_template_sync_dry_run.py` → 2 failed, 1 passed. The two that go red are `test_the_default_is_a_boolean_not_a_string` and `test_every_condition_compares_the_input_to_a_boolean`, the latter naming all five stale conditions in its message. `test_the_input_is_declared_boolean` passes on both sides, correctly — `type: boolean` was already right on `main`, and that test pins the premise the other two rest on.
- `tests/test_template_repo_default.py` → 2 failed (`template-sync.yaml`, `phone-home.yaml`, each reporting `alexander-turner`), 1 passed — the passing one is `test_the_declarations_are_still_here`, the anchor that stops the parametrized case from covering nothing if the declaration's spelling changes.

**What is NOT verified here.** That a dispatched run actually clones `AlexanderMattTurner/…`, and that a `dry-run: true` dispatch now opens no PR. Neither is observable from the workflow file — only a run's checkout log and an actual dispatch can show it, and both need this merged first. Those are the first two checks on the downstream sync that follows.

**YAML key gotcha, pinned in the test.** `on` parses as the YAML 1.1 boolean `True`, so the test reads `workflow[True]["workflow_dispatch"]`. Reading it as the string `"on"` finds nothing and the whole file passes vacuously.

**Lints.** Pre-push suite green. Two hooks unrunnable in this sandbox and green in CI: `lychee` (builds from source, `cargo-install does not support --install-path`) and `zizmor` (run with `ZIZMOR_OFFLINE=true`; the egress proxy 403s `api.github.com/advisories`).

</details>

## Proposed guards

**A boolean `workflow_dispatch` input compared to a string literal, across every workflow.** The class is wider than this one input: any `type: boolean` or `type: number` input read with `== 'true'` / `!= 'false'` is silently inert the same way, and the failure is always a branch that quietly never runs.

- *Shape*: parse each workflow's `on.workflow_dispatch.inputs`, collect the names whose declared `type` is not `string`, then flag any step `if:` comparing one of those names to a quoted literal.
- *Expected false-positive rate*: near zero. The pattern has no legitimate use — a boolean input compared to a string cannot match under GitHub's coercion rules, so every hit is a defect.
- *Cost*: one YAML parse over `.github/workflows/` per pre-commit run, a few hundred milliseconds; maintenance is limited to the input-type list, which is GitHub's, not ours.
- *Benefit*: this repo hit the class once, and it propagated to eight downstream repos and survived long enough for one of them to patch it locally and document the fix as unfolded. The escape cost is high (an inert safety feature nobody knows is inert) and detection is cheap and total.

Not shipped here: a fix PR does not carry a new lint. Recorded for a human to promote.

## Lessons Learned

- **A `type: boolean` workflow input must be compared to a boolean, never to a quoted string.** In `.github/workflows/template-sync.yaml`, step conditions read `inputs.dry-run == true`, not `== 'true'`. GitHub casts across types to a number, so a boolean-vs-string comparison compares `1` with `NaN` and never matches — the guarded branch becomes dead code with no error. Downstream repos should check every `workflow_dispatch` input they declare as `boolean` or `number` and fix the readers in the same change as the declaration.
- **A workflow's `TEMPLATE_REPO` fallback owner is load-bearing and fails silently when wrong.** Both `template-sync.yaml` and `phone-home.yaml` declare it independently, so fixing one leaves the other pointed at the wrong account. When forking or transferring a repo, update every `TEMPLATE_REPO` declaration together, and prefer `vars.TEMPLATE_SYNC_ORG` over hardcoding the owner so the account can be redirected without a code change.
- **A test that asserts a property across sibling declarations must first assert the declarations exist.** `tests/test_template_repo_default.py` pairs its parametrized check with `test_the_declarations_are_still_here`, because a parametrized test over an empty list passes while covering nothing — and the list empties the moment someone reformats the value the regex matches.
- **`on` in a workflow YAML parses as the boolean `True`, not the string `"on"`.** Any downstream test that reads a workflow's triggers with `yaml.safe_load` must index with `True`. Indexing with `"on"` raises or returns `None`, and a test that tolerates `None` passes vacuously forever.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pv4gq3xH55FKVvEgvYkxZR)_