### PR TITLE
fix(ci): treat an absent severity config as the shipped defaults

### DIFF
--- a/.github/scripts/post-pr-review.mjs
+++ b/.github/scripts/post-pr-review.mjs
@@ -136,9 +136,19 @@ let event = EVENT_BY_VERDICT[verdict] || "COMMENT";
 // detail-less finding is still dropped below and never gates (nothing to
 // resolve).
 //
-// Read from the copy that shipped beside this script. The reviewer runs against
-// an untrusted PR head, so resolving the config through the repo root would let
-// a PR author's copy decide which of its own findings hold the merge.
+// The shipped model. `config/` is NOT in template-sync's SYNC_PATHS, so an
+// adopter repo receives this script without the config file — absent therefore
+// means "kept the shipped defaults", exactly as config/pr-review-paths.json is
+// read. Treating absent as fatal would red every review in every repo that
+// syncs this script, since the file cannot arrive.
+const DEFAULT_SEVERITIES = {
+  gating: ["blocking", "warning", "nit"],
+  icons: { blocking: "🔴", warning: "🟡", nit: "🔵" },
+};
+
+// Read relative to this script, not the repo root. The reviewer runs against an
+// untrusted PR head, so a root-relative lookup would let a PR author's copy
+// decide which of its own findings hold the merge.
 const SEVERITY_CONFIG = new URL(
   "../../config/review-severities.json",
   import.meta.url,
@@ -147,18 +157,30 @@ const SEVERITY_CONFIG = new URL(
 const normSeverity = (s) =>
   typeof s === "string" ? s.trim().toLowerCase() : "";
 
-// Fail closed on every malformed shape. This refusal is what prevents the
-// vacuous green: an empty `gating` set makes hasGatingFinding permanently false,
-// so every review posts as APPROVE and the reviewer silently stops holding
-// anything — indistinguishable from a repo where nothing is ever wrong.
+// Absent is a choice; malformed is a mistake. A repo that never wrote the file
+// gets DEFAULT_SEVERITIES. A repo that DID write one and got it wrong fails
+// loud, because the failure it would otherwise cause is invisible: an empty
+// `gating` set makes hasGatingFinding permanently false, so every review posts
+// as APPROVE and the reviewer silently stops holding anything —
+// indistinguishable from a repo where nothing is ever wrong.
 function loadSeverities() {
+  let text;
+  try {
+    text = readFileSync(SEVERITY_CONFIG, "utf8");
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+    return {
+      gating: new Set(DEFAULT_SEVERITIES.gating),
+      icons: new Map(Object.entries(DEFAULT_SEVERITIES.icons)),
+    };
+  }
   let raw;
   try {
-    raw = JSON.parse(readFileSync(SEVERITY_CONFIG, "utf8"));
+    raw = JSON.parse(text);
   } catch (err) {
     throw new Error(
-      `config/review-severities.json is unreadable (${err.message}); refusing to ` +
-        "review with an unknown severity model.",
+      `config/review-severities.json is unparsable (${err.message}); refusing to ` +
+        "review with a severity model somebody meant to set and got wrong.",
     );
   }
   const bad = (why) => new Error(`config/review-severities.json: ${why}`);

--- a/.github/scripts/post-pr-review.test.mjs
+++ b/.github/scripts/post-pr-review.test.mjs
@@ -1008,8 +1008,17 @@ describe("post-pr-review: the severity config is the single source of truth", ()
     assert.match(payload.comments[0].body, /^🔵 /);
   });
 
+  it("an absent config keeps the shipped model rather than failing", () => {
+    // `config/` is not in template-sync's SYNC_PATHS, so every repo that syncs
+    // this script gets it WITHOUT the config file. Treating that as fatal would
+    // red every review in every downstream repo, on a file that cannot arrive.
+    const { code, payload } = runStaged(null, NIT);
+    assert.equal(code, 0);
+    assert.equal(payload.event, "REQUEST_CHANGES", "nit gates by default");
+    assert.match(payload.comments[0].body, /^🔵 /);
+  });
+
   for (const [why, text] of [
-    ["the config is missing", null],
     ["the config is not JSON", "{ not json"],
     // An empty gating set approves every review and retires the hold with no
     // other symptom — the one failure a default would make invisible.


### PR DESCRIPTION
Claims `.github/scripts/post-pr-review.mjs`. **Blocks the downstream template-sync rollout** — the three sync PRs already open (subfont #169, punctilio, agent-glovebox) carry the broken version and need this before any of them merges.

## What changed and why

`post-pr-review.mjs` exited non-zero when `config/review-severities.json` was missing. `config/` is **not** in template-sync's `SYNC_PATHS`, so every repo that syncs this script receives it *without* that file. The reviewer would have gone red on every pull request in all eight downstream repos, over a config that cannot arrive.

I introduced this in #439 by conflating two different things. A config that is **absent** means the adopter never wrote one and the shipped model applies. A config that is **malformed** means somebody meant to set it and got it wrong. Only the second deserves a red, and I made both fatal.

That distinction is not an invention — it is the convention this repo already uses for adopter config, and I should have followed it. `config/pr-review-paths.json` reads absent as "kept the shipped defaults" with `DEFAULT_PATHS` living in the script, and malformed as fail-loud. `auto-resolve/resolve-generated.mjs` does the same: `existsSync` returns no rules. `review-severities.json` was the only one out of step.

Every fail-loud property that mattered survives. A config somebody did write and got wrong still fails: an empty `gating` list makes `hasGatingFinding` permanently false, so every review would post as `APPROVE` and the reviewer would stop holding anything — with no other symptom. Malformed JSON, a missing `icons`, a gating severity with no icon, a non-string icon, and a non-object top level all still exit non-zero.

## Decisions made

| What came up | Chosen | Under the alternative |
| --- | --- | --- |
| How to make the config reach adopters | Leave it in `config/` and put the defaults in the script | Moving it under `.github/scripts/` would sync it, but `config/` is the adopter-owned knob directory by convention, and a synced knob fights the three-way merge on every sync |
| Adding `config/` to `SYNC_PATHS` | No | It would push the template's `pr-review-paths.json` and `auto-resolve-regen-rules.json` into every downstream repo, overwriting exactly the per-repo choices those files exist to hold |
| Whether the defaults duplicate the committed config | Accepted | The committed `config/review-severities.json` is this repo's own live copy and documents the model; the script's defaults are what an adopter gets. They agree today and are free to diverge, which is the point of an override |

<details><summary>Verification residue</summary>

**The falsifier, observed.** Built a tree with `post-pr-review.mjs` and no `config/` directory at all — the exact shape a synced downstream repo has — and ran both versions over the same input:

- `git show origin/main:.github/scripts/post-pr-review.mjs` → **non-zero**, dying at `post-pr-review.mjs:159`.
- this branch → **exit 0**, `event=REQUEST_CHANGES`, `🔵` icon rendered. The nit still gates; the shipped model applied.

**Suites.** `node --test '.github/scripts/**/*.test.mjs'` **330 passing**, unchanged (one parametrized fail-closed case became a positive test, so the count holds). `uv run --extra dev pytest tests/ -q` **364 passing**, unchanged.

**The class, checked rather than assumed.** The other two `config/*.json` consumers were read for the same defect. `pr-review-advisory.mjs` merges over `DEFAULT_PATHS` on absent and fails loud on malformed — already correct. `resolve-generated.mjs` returns `[]` on `!existsSync` and is additionally gated by `has_resolve_generated()` in `auto-resolve/lib.sh` — already correct. `review-severities.json` was the only member out of step, so this is a one-site fix, not a swept class.

**How it escaped #439.** Its tests staged a config in every case, so no test ever ran the script without one. The new `an absent config keeps the shipped model rather than failing` case is that gap closed.

**What this does not prove.** That the reviewer behaves correctly end to end in a downstream repo. That needs a synced repo to run a real review, which cannot happen until a sync PR merges.

**Lints.** Pre-push green. `lychee` and `zizmor` unrunnable in this sandbox as usual (`SKIP=lychee`, `ZIZMOR_OFFLINE=true`); both run in CI.

</details>

## Lessons Learned

- **A script that syncs must not hard-require a config file that does not sync.** `SYNC_PATHS` in `.github/workflows/template-sync.yaml` covers `.claude`, `.hooks`, `.github/actions`, `.github/scripts`, `.github/workflows`, and `.github/prompts` — and nothing else. Any script under those paths that reads `config/…`, or any other unsynced location, must treat the file as an optional override with defaults in the script. Treating it as required breaks the script in every adopter repo the moment it lands, and the breakage looks like a repo-specific CI failure rather than a template defect.
- **Absent and malformed are different failures and deserve different answers.** Absent means the adopter kept the defaults; malformed means somebody tried to configure it and got it wrong. Fail loud only on the second. This is the shape `config/pr-review-paths.json` and `config/auto-resolve-regen-rules.json` already use, and new config readers in downstream repos should match it.
- **A test suite that always stages the config never tests the absent path.** Every fail-closed case in `post-pr-review.test.mjs` wrote a config file, so the one input every downstream repo actually has — no file — was the single case nobody exercised. When a config has an absent branch, test the absent branch explicitly; a suite that only varies the file's *contents* cannot see it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pv4gq3xH55FKVvEgvYkxZR)_