### PR TITLE
fix(ci): refuse a template sync whose source is the repo itself

### DIFF
--- a/.github/scripts/template-sync-preflight.sh
+++ b/.github/scripts/template-sync-preflight.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Decide whether this sync would import the repository into itself.
+#
+# The template is the source of truth for every downstream repo, so it has
+# nothing upstream to sync from. Pointed at itself — or at a fork of itself,
+# which is what a mis-set TEMPLATE_SYNC_ORG produces — the sync either churns a
+# no-op pull request or rewrites the original from a copy that has drifted.
+#
+# Inputs (env):
+#   TEMPLATE_REPO      owner/repo the sync would copy from
+#   GITHUB_REPOSITORY  owner/repo the workflow is running in
+#   GH_TOKEN           token for the fork-parent lookup
+# Output: self_sync=true|false on $GITHUB_OUTPUT
+
+set -euo pipefail
+
+: "${TEMPLATE_REPO:?TEMPLATE_REPO must be set}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY must be set}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+emit() {
+  echo "self_sync=$1" >>"$GITHUB_OUTPUT"
+}
+
+# GitHub slugs are case-insensitive, so a differently-cased owner names the same
+# repository and must not read as a different one.
+if [[ "${TEMPLATE_REPO,,}" == "${GITHUB_REPOSITORY,,}" ]]; then
+  # Not a misconfiguration: the template ships this workflow to its consumers,
+  # so it necessarily also runs it on itself.
+  echo "::notice::$GITHUB_REPOSITORY is the template itself; nothing to sync from. Skipping."
+  emit true
+  exit 0
+fi
+
+if ! parent=$(gh repo view "$TEMPLATE_REPO" --json parent \
+  --jq '.parent.nameWithOwner // ""' 2>&1); then
+  # A private template with no PAT lands here. The slug comparison above still
+  # holds, and refusing the sync outright would silently strand every downstream
+  # repo that legitimately syncs from a template it cannot introspect.
+  echo "::warning::Could not read $TEMPLATE_REPO's fork parent, so a fork-of-self sync cannot be ruled out: $parent"
+  emit false
+  exit 0
+fi
+
+if [[ "${parent,,}" == "${GITHUB_REPOSITORY,,}" ]]; then
+  # Loud rather than a quiet skip: a fork of this repo is never a legitimate
+  # source, and a weekly cron that skipped in silence would look identical to a
+  # healthy one for as long as the variable stayed wrong.
+  echo "::error::TEMPLATE_REPO ($TEMPLATE_REPO) is a fork of this repository, so this sync would import $GITHUB_REPOSITORY from a copy of itself. Unset or correct the TEMPLATE_SYNC_ORG repository variable." >&2
+  emit true
+  exit 1
+fi
+
+echo "Syncing $GITHUB_REPOSITORY from $TEMPLATE_REPO."
+emit false

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -84,9 +84,7 @@ concurrency:
   group: template-sync
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   # A repo cannot be its own upstream. This runs as a separate job because a
@@ -96,6 +94,8 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       self_sync: ${{ steps.check.outputs.self_sync }}
     steps:
@@ -115,6 +115,9 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.self_sync != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 30
     steps:
       - name: Checkout child repository

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -5,6 +5,8 @@ name: Sync from Template
 # No setup required - works out of the box.
 #
 # Features:
+# - Skips entirely in the template repository itself, and fails loud when
+#   TEMPLATE_SYNC_ORG points the sync at a fork of the running repo
 # - 3-way merges local customizations with template updates automatically
 # - Falls back to template version + Claude resolution when no merge base exists
 # - Detects new files, changed files, and deleted files from the template
@@ -87,7 +89,31 @@ permissions:
   pull-requests: write
 
 jobs:
+  # A repo cannot be its own upstream. This runs as a separate job because a
+  # job-level `if:` cannot read workflow `env`, and the alternative — repeating
+  # the guard on every step below — is a condition that a newly added step
+  # silently opts out of.
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      self_sync: ${{ steps.check.outputs.self_sync }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: Refuse to sync this repository from itself
+        id: check
+        env:
+          # token-fallback-ok: designed graceful degradation, not an accident.
+          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || github.token }}
+        run: bash .github/scripts/template-sync-preflight.sh
+
   sync:
+    needs: preflight
+    if: needs.preflight.outputs.self_sync != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/tests/test_template_sync_preflight.py
+++ b/tests/test_template_sync_preflight.py
@@ -1,0 +1,133 @@
+"""A repository must never sync itself from a copy of itself.
+
+The template ships `template-sync.yaml` to its consumers, so the workflow also
+runs in the template repo — where there is no upstream to import from. Left
+unguarded that is not a harmless no-op: pointed at a fork of itself (what a
+stale `TEMPLATE_SYNC_ORG` variable produces), the sync rewrites the source of
+truth from a drifted copy and opens a pull request saying so, which is exactly
+what happened on PR #430.
+
+Both directions are tested, because the guard has two failure modes and only one
+of them is visible: refusing a legitimate downstream sync stops every consumer
+from receiving updates, and it stops them silently — the workflow is a cron with
+no pull request to notice.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests._helpers import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "template-sync-preflight.sh"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "template-sync.yaml"
+
+
+def run(tmp_path: Path, template_repo: str, running_repo: str, parent: str = ""):
+    """Run the guard with a fake `gh` whose fork-parent answer is `parent`; a
+    `parent` of "!fail" makes the lookup fail the way a private template does."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    body = (
+        "echo 'gh: Not Found' >&2; exit 1\n"
+        if parent == "!fail"
+        else f"printf '%s\\n' '{parent}'\n"
+    )
+    (bin_dir / "gh").write_text(f"#!/usr/bin/env bash\n{body}")
+    (bin_dir / "gh").chmod(0o755)
+
+    output = tmp_path / "gh-output"
+    output.touch()
+    res = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{bin_dir}:/usr/bin:/bin:/usr/local/bin",
+            "TEMPLATE_REPO": template_repo,
+            "GITHUB_REPOSITORY": running_repo,
+            "GITHUB_OUTPUT": str(output),
+            "GH_TOKEN": "x",
+        },
+    )
+    return res, output.read_text(encoding="utf-8")
+
+
+TEMPLATE = "AlexanderMattTurner/claude-automation-template"
+
+
+def test_refuses_when_the_source_is_this_repo(tmp_path):
+    res, out = run(tmp_path, TEMPLATE, TEMPLATE)
+    assert "self_sync=true" in out
+    # Green: the template running its own shipped workflow is not an error.
+    assert res.returncode == 0, res.stderr
+
+
+def test_slug_comparison_ignores_case(tmp_path):
+    # GitHub slugs are case-insensitive, so a re-cased owner is the same repo.
+    res, out = run(tmp_path, TEMPLATE.lower(), TEMPLATE)
+    assert "self_sync=true" in out
+    assert res.returncode == 0, res.stderr
+
+
+def test_refuses_and_fails_when_the_source_is_a_fork_of_this_repo(tmp_path):
+    res, out = run(
+        tmp_path, "someone-else/claude-automation-template", TEMPLATE, parent=TEMPLATE
+    )
+    assert "self_sync=true" in out
+    # Loud: a misconfigured variable needs a human, and a silent weekly skip
+    # reads exactly like a healthy weekly run.
+    assert res.returncode == 1
+    assert "fork of this repository" in res.stderr
+
+
+def test_allows_a_downstream_repo(tmp_path):
+    res, out = run(tmp_path, TEMPLATE, "someone/their-project")
+    assert "self_sync=false" in out
+    assert res.returncode == 0, res.stderr
+
+
+def test_allows_a_fork_syncing_from_the_upstream_template(tmp_path):
+    # The fork's parent is the template, not the running repo — that is the
+    # normal direction and must keep working.
+    res, out = run(
+        tmp_path,
+        TEMPLATE,
+        "someone/claude-automation-template",
+        parent="someone/upstream",
+    )
+    assert "self_sync=false" in out
+    assert res.returncode == 0, res.stderr
+
+
+def test_proceeds_when_the_fork_parent_cannot_be_read(tmp_path):
+    res, out = run(tmp_path, TEMPLATE, "someone/their-project", parent="!fail")
+    assert "self_sync=false" in out
+    assert res.returncode == 0, res.stderr
+    assert "::warning::" in res.stdout
+
+
+@pytest.mark.parametrize("missing", ["TEMPLATE_REPO", "GITHUB_REPOSITORY"])
+def test_requires_its_inputs(tmp_path, missing):
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "TEMPLATE_REPO": TEMPLATE,
+        "GITHUB_REPOSITORY": TEMPLATE,
+        "GITHUB_OUTPUT": str(tmp_path / "out"),
+    }
+    del env[missing]
+    res = subprocess.run(["bash", str(SCRIPT)], capture_output=True, text=True, env=env)
+    assert res.returncode != 0
+    assert missing in res.stderr
+
+
+def test_the_sync_job_is_gated_on_the_guard():
+    # Without this the script above can hold every opinion it likes while the
+    # sync job runs anyway.
+    jobs = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+    assert "preflight" in jobs["sync"]["needs"]
+    assert jobs["sync"]["if"] == "needs.preflight.outputs.self_sync != 'true'"
+    steps = jobs["preflight"]["steps"]
+    assert any(SCRIPT.name in step.get("run", "") for step in steps)


### PR DESCRIPTION
## What & why

Stop `template-sync` from importing this repository from a copy of itself.

The workflow ships to consumers, so it also runs in the template repo — where there is no upstream to sync from. #430 is what that produced: a sync PR whose source was `alexander-turner/claude-automation-template`, a fork of this repo, opened to write `.template-version` back into the source of truth. #440 has since corrected the `TEMPLATE_REPO` fallback owner to `AlexanderMattTurner`, which removes that particular source — but nothing stops the next one. `vars.TEMPLATE_SYNC_ORG` can name a fork just as easily as a wrong literal could, and with the fallback now correct the template resolves its source to *itself*, which the workflow will still happily clone and diff.

A new `preflight` job resolves the source before any checkout and gates the `sync` job on it:

- **Source slug == running repo** → skip, green. This is the template's steady state after #440: the template running its own shipped workflow is not an error.
- **Source is a fork of the running repo** (`gh repo view --json parent`) → skip and **fail the run**, so a misconfigured variable reaches a human instead of churning weekly in silence.
- **A fork syncing from the upstream template** → unaffected; that is the normal direction.
- **Parent lookup unavailable** (private template, no PAT) → warn and proceed; the slug comparison still holds.

Slug comparisons are case-insensitive, since GitHub slugs are.

## Review focus

`.github/scripts/template-sync-preflight.sh` — specifically the fork-parent branch. It is the one that can fail *open* (letting a self-sync through) or fail *closed* (silently stranding every downstream consumer on a cron with no PR to notice). Both directions are covered by tests.

The `permissions` move is mine, not incidental: with two jobs, workflow-level `contents: write` / `pull-requests: write` became overly broad and zizmor flagged it. Permissions are now `{}` at workflow level, `contents: read` on `preflight`, and the original pair on `sync`.

## How it was tested

- `uv run pytest -q` → 373 passed (9 new in `tests/test_template_sync_preflight.py`).
- Non-vacuity check: with the workflow's `if:` gate deleted and the fork comparison replaced by `if false`, exactly the two tests that assert those facts fail (`test_the_sync_job_is_gated_on_the_guard`, `test_refuses_and_fails_when_the_source_is_a_fork_of_this_repo`); both pass again once restored.
- `pre-commit run --files <the three touched files>` → clean (shellcheck, shfmt, actionlint, ruff, zizmor).

## Decisions made

- **A fork-of-self source fails the run rather than skipping quietly.** A weekly cron that skips in silence is indistinguishable from a healthy one, and the fix (unsetting or correcting `TEMPLATE_SYNC_ORG`) needs a human. On this repo with no such variable set, the slug branch applies instead and the cron skips green.
- **The parent lookup failing is a warning, not a refusal.** Failing closed there would stop syncs for any downstream repo whose template is private and whose PAT is missing, and that outcome is invisible.
- **Guard by repo identity, not by repo name.** Matching on the `claude-automation-template` basename would also have caught #430, but it would block the legitimate case of a fork syncing from the upstream template.

## Security boundary impact

Workflow-level `permissions` are now empty, with write scopes granted only to the `sync` job; `preflight` runs with `contents: read` and a sparse checkout of `.github/scripts` only.
