### PR TITLE
fix(ci): sync the pin files the installer scripts read

### DIFF
--- a/.github/scripts/installer-pins.test.mjs
+++ b/.github/scripts/installer-pins.test.mjs
@@ -1,0 +1,99 @@
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const TEMPLATE_SYNC_YAML = join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "template-sync.yaml",
+);
+
+// SYNC_PATHS is the whole contract: a consumer receives these paths and nothing
+// else. Reading it here rather than restating the list is what makes the tests
+// below fail when an installer's data dependency stops being delivered.
+function syncPaths() {
+  const yaml = readFileSync(TEMPLATE_SYNC_YAML, "utf8");
+  const match = /^\s*SYNC_PATHS:\s*"(?<paths>[^"]*)"/m.exec(yaml);
+  assert.ok(match, "template-sync.yaml declares SYNC_PATHS");
+  return match.groups.paths.split(/\s+/).filter(Boolean);
+}
+
+// The tree a consumer actually gets: every SYNC_PATHS entry copied out of the
+// template, and nothing outside them. An installer that reads a pin the sync
+// does not deliver dies here exactly as it dies in the consumer's CI.
+function consumerTree() {
+  const root = mkdtempSync(join(tmpdir(), "consumer-"));
+  for (const path of syncPaths()) {
+    mkdirSync(join(root, dirname(path)), { recursive: true });
+    cpSync(join(REPO_ROOT, path), join(root, path), { recursive: true });
+  }
+  return root;
+}
+
+function stubDir(root, stubs) {
+  const dir = join(root, "stub");
+  mkdirSync(dir, { recursive: true });
+  for (const [name, body] of Object.entries(stubs)) {
+    writeFileSync(join(dir, name), `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  }
+  return dir;
+}
+
+function runInstaller(root, script, stubs, args = []) {
+  const dir = stubDir(root, stubs);
+  return spawnSync(
+    "bash",
+    [join(root, ".github", "scripts", script), ...args],
+    {
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+    },
+  );
+}
+
+test("template-sync delivers the mergiraf pin install-mergiraf reads", () => {
+  const root = consumerTree();
+  try {
+    const run = runInstaller(
+      root,
+      "install-mergiraf.sh",
+      { curl: 'echo "REACHED-DOWNLOAD" >&2\nexit 42' },
+      [join(root, "dest")],
+    );
+    assert.doesNotMatch(run.stderr, /No such file or directory/);
+    assert.match(run.stderr, /REACHED-DOWNLOAD/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("template-sync delivers the CLI pin install-claude-cli reads", () => {
+  const root = consumerTree();
+  try {
+    const run = runInstaller(root, "install-claude-cli.sh", {
+      npm: 'echo "REACHED-INSTALL $*" >&2\nexit 0',
+      claude: 'echo "2.0.0"',
+    });
+    assert.doesNotMatch(run.stderr, /No such file or directory/);
+    assert.match(
+      run.stderr,
+      /REACHED-INSTALL .*@anthropic-ai\/claude-code@\d+\.\d+\.\d+/,
+    );
+    assert.equal(run.status, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/synced-deps.test.mjs
+++ b/.github/scripts/synced-deps.test.mjs
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { spawnSync } from "node:child_process";
 import {
   cpSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -23,7 +24,7 @@ const TEMPLATE_SYNC_YAML = join(
 
 // SYNC_PATHS is the whole contract: a consumer receives these paths and nothing
 // else. Reading it here rather than restating the list is what makes the tests
-// below fail when an installer's data dependency stops being delivered.
+// below fail when a synced file's data dependency stops being delivered.
 function syncPaths() {
   const yaml = readFileSync(TEMPLATE_SYNC_YAML, "utf8");
   const match = /^\s*SYNC_PATHS:\s*"(?<paths>[^"]*)"/m.exec(yaml);
@@ -93,6 +94,25 @@ test("template-sync delivers the CLI pin install-claude-cli reads", () => {
       /REACHED-INSTALL .*@anthropic-ai\/claude-code@\d+\.\d+\.\d+/,
     );
     assert.equal(run.status, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// The commit-msg hook passes this path to commitlint with no fallback, and the
+// hook runs under `set -euo pipefail`. Undelivered, every commit in the consumer
+// fails with a commitlint ENOENT rather than a message about the hook.
+test("template-sync delivers the commitlint config the commit-msg hook names", () => {
+  const hook = readFileSync(join(REPO_ROOT, ".hooks", "commit-msg"), "utf8");
+  const declared = /^config="(?<path>[^"]+)"$/m.exec(hook);
+  assert.ok(declared, ".hooks/commit-msg declares its commitlint config path");
+
+  const root = consumerTree();
+  try {
+    assert.ok(
+      existsSync(join(root, declared.groups.path)),
+      `${declared.groups.path} is read by .hooks/commit-msg but no SYNC_PATHS entry delivers it`,
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -53,7 +53,17 @@ env:
   # added to the template auto-sync without anyone having to edit this list.
   # Downstream-added files in these directories are left alone (sync only
   # copies files that exist in the template).
-  SYNC_PATHS: ".claude .hooks .github/actions .github/scripts .github/workflows .github/prompts"
+  #
+  # An entry may also be a single FILE, which is how a script's data dependency
+  # travels when it lives outside every synced directory. `.github` itself is not
+  # synced, so a script under `.github/scripts` that reads a pin from `.github/`
+  # arrives downstream without it and dies on the read. The two pin files below
+  # are each read by exactly one synced installer, and every consumer needs both:
+  #   .github/tool-versions.sh   <- .github/scripts/install-mergiraf.sh
+  #   .github/claude-cli-version <- .github/scripts/install-claude-cli.sh
+  # A consumer that maintains its own richer copy of one of these (extra tools
+  # pinned for its own CI) keeps it by adding that path to EXCLUDE_PATHS.
+  SYNC_PATHS: ".claude .hooks .github/actions .github/scripts .github/workflows .github/prompts .github/tool-versions.sh .github/claude-cli-version"
   # Paths to exclude from syncing. Supports both whole directories (matching
   # entries in SYNC_PATHS) and individual files within synced directories.
   #

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -54,16 +54,16 @@ env:
   # Downstream-added files in these directories are left alone (sync only
   # copies files that exist in the template).
   #
-  # An entry may also be a single FILE, which is how a script's data dependency
-  # travels when it lives outside every synced directory. `.github` itself is not
-  # synced, so a script under `.github/scripts` that reads a pin from `.github/`
-  # arrives downstream without it and dies on the read. The two pin files below
-  # are each read by exactly one synced installer, and every consumer needs both:
-  #   .github/tool-versions.sh   <- .github/scripts/install-mergiraf.sh
-  #   .github/claude-cli-version <- .github/scripts/install-claude-cli.sh
+  # An entry may also be a single FILE, which is how a synced file's DATA
+  # dependency travels when it lives outside every synced directory. A synced
+  # script that reads such a file arrives downstream without it and dies on the
+  # read, so each one a synced file names by a fixed path is listed here:
+  #   .github/tool-versions.sh                 <- .github/scripts/install-mergiraf.sh
+  #   .github/claude-cli-version               <- .github/scripts/install-claude-cli.sh
+  #   config/javascript/commitlint.config.js   <- .hooks/commit-msg
   # A consumer that maintains its own richer copy of one of these (extra tools
   # pinned for its own CI) keeps it by adding that path to EXCLUDE_PATHS.
-  SYNC_PATHS: ".claude .hooks .github/actions .github/scripts .github/workflows .github/prompts .github/tool-versions.sh .github/claude-cli-version"
+  SYNC_PATHS: ".claude .hooks .github/actions .github/scripts .github/workflows .github/prompts .github/tool-versions.sh .github/claude-cli-version config/javascript/commitlint.config.js"
   # Paths to exclude from syncing. Supports both whole directories (matching
   # entries in SYNC_PATHS) and individual files within synced directories.
   #


### PR DESCRIPTION
## What & why

Add `.github/tool-versions.sh` and `.github/claude-cli-version` to `SYNC_PATHS`, so the two installer scripts downstream already has can actually find the pins they read.

`SYNC_PATHS` names whole directories, and `.github` is not one of them — only `.github/scripts` is. So every consumer received `install-mergiraf.sh` and `install-claude-cli.sh` while neither pin file ever travelled, and each script dies on the read:

```
install-mergiraf.sh: line 15: .../.github/scripts/../tool-versions.sh: No such file or directory
```

This is not theoretical. It reddened the template-sync runs for [subfont](https://github.com/AlexanderMattTurner/subfont/actions/runs/30921941631) and [agent-sanitizer](https://github.com/AlexanderMattTurner/agent-sanitizer/actions/runs/30921911402) at the mergiraf install step today. All nine consumers hold both scripts and neither pin file, so `install-claude-cli` carries the identical break wherever a job reaches for the CLI.

`template-sync.sh` already handles a `SYNC_PATHS` entry that is a file — the `else process_file "$path"` branch — so no script change is needed.

## Review focus

Read the `SYNC_PATHS` change in `.github/workflows/template-sync.yaml` first; everything else follows from it.

The cross-file invariant a reviewer cannot hold on one screen: `install-mergiraf.sh` and `install-claude-cli.sh` each read a pin by a path relative to themselves, and whether that path is delivered is decided in a third file. `installer-pins.test.mjs` binds the three by building its fixture **from** `SYNC_PATHS` rather than restating the list, so dropping either entry turns the tests red.

Least sure of: whether `.github/claude-cli-version` should ship to consumers at all, versus the pin moving into each consumer's `package.json`. See Decisions made.

## How it was tested

| Check | Command | Result |
|---|---|---|
| New tests | `node --test .github/scripts/installer-pins.test.mjs` | 2 pass |
| Full node suite | `pnpm test` | 337 pass / 0 fail (was 335) |
| Sync-script tests | `uv run --extra dev pytest tests/test_template_sync.py -q` | 20 pass |
| ESLint | `pnpm exec eslint .github/scripts/installer-pins.test.mjs` | clean |
| Prettier | `npx prettier --check` on both changed files | clean |
| Pre-push hooks | the `git push` hook suite | all passed, 96 s |

**The new tests are red on the unfixed tree.** I ran them in a `git worktree add --detach <dir> HEAD` checkout, against the pre-fix `SYNC_PATHS`: both fail, each reproducing its consumer's exact error text. Post-fix both pass. Predicted that outcome before running; it matched.

The tests drive the real scripts rather than asserting on source text. Each builds the tree a consumer actually receives — every `SYNC_PATHS` entry copied out of the template and nothing else — then runs the installer in it with `curl`/`npm` stubbed, and asserts it reached the download rather than dying on the pin.

## Decisions made

**Add the pins to `SYNC_PATHS` rather than move them beside their readers.** Moving both files into `.github/scripts/` would also have worked, and needs no `SYNC_PATHS` change. I did not, because the path is load-bearing downstream: `agent-glovebox` maintains its own much larger `.github/tool-versions.sh` — the pin file for cosign, shellharden, shfmt, gitleaks, shellcheck-py, uv, pre-commit, actionlint and gh-stack — and hardcodes that path in an action's cache key and in four `paths-regex` gates. Moving the template's copy would have split its pins across two files. Under the alternative, both files move, the two `source`/read lines change, and this `SYNC_PATHS` entry goes away.

**A consumer with its own copy opts out through `EXCLUDE_PATHS`**, the mechanism already there, rather than a new precedence rule. I have opened [agent-glovebox#3481](https://github.com/AlexanderMattTurner/agent-glovebox/pull/3481) to add that entry before its sync adopts the new `SYNC_PATHS`.

## Proposed guards

Not shipped here — the fix stands on its own, and this is the class the fix does not close.

**Class:** a synced file reads a path outside every `SYNC_PATHS` entry, so the sync delivers the reader without its data. Both known members are fixed above; nothing stops a third.

**Shape:** parse `SYNC_PATHS` from `template-sync.yaml`, then for each shell script under a synced path resolve every `source`/read of a `${SCRIPT_DIR}`-relative literal and assert the target is covered. It must use the bash grammar, not a regex — the question "is this token a path this script reads" is structural.

**Cost/benefit:** the class has produced 2 defects in the template's lifetime, both landing as a red sync run in every consumer at once and needing a human to read a log to diagnose. Against that, one more pre-commit hook on every commit forever, plus maintenance whenever a script's read moves. Expected false positives are low but not zero: a script may legitimately read a path a consumer supplies. I judge this genuinely marginal — the two behavior tests added here already cover both live readers, and a third reader is more cheaply caught by the same test being extended than by a new lint.

<details>
<summary>Verification residue</summary>

- Consumer state is **observed**, not inferred: all nine cloned consumers hold `install-mergiraf.sh` and `install-claude-cli.sh`; eight hold neither pin file; `agent-glovebox` holds its own `.github/tool-versions.sh` and no `claude-cli-version`. Checker: `ls <repo>/.github/{tool-versions.sh,claude-cli-version} <repo>/.github/scripts/install-*.sh`.
- The two red runs are **observed** from their job logs, which end at `install-mergiraf.sh: line 15`. The PR that each run opened was created **before** that step, so those PRs exist and only the conflict-resolution steps after it were skipped.
- **Convergence takes two sync cycles, and this PR does not shorten that.** A run reads `SYNC_PATHS` from the workflow file GitHub loaded to start it, so the new entries take effect only after each consumer merges the sync PR that updates its own `template-sync.yaml`. The next run after that delivers the pins. Both currently-red consumers stay red until then.
- **Not verified here:** that a consumer's sync actually delivers the two files end to end. That needs a real cross-repo run against a merged `main`; the test above proves only that the installers work in the tree `SYNC_PATHS` describes.
- `.pre-commit-config.yaml` was not run in full — `lychee` cannot install in this container, the same limit recorded on #444. The pre-push hook suite did run and passed.

</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_01GU8KNNmLkH3mnxUPFStdGq)_

---
_Generated by [Claude Code](https://claude.ai/code)_