### PR TITLE
fix(template-sync): make a directory exclusion work and an adopter deletion hold

### DIFF
--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -75,7 +75,7 @@ main() {
   : >"$DECLINED_FILES"
   : >"$INERT_ENTRIES"
   # WORK_DIR persists between runs, so a stale list from an earlier run would
-  # otherwise decide which files count as delivered before.
+  # otherwise feed the deleted-in-template scan below.
   : >"$PREV_TEMPLATE_FILES"
 
   # An EXCLUDE_PATHS entry names one file or one directory, and a directory
@@ -94,11 +94,19 @@ main() {
   # PROBLEM CLASS — a template file the adopter deleted comes back on the next
   # sync. Case 1 copies in any template file the adopter does not have, so a
   # deletion there survives only until the next sync run: one sync restored 44
-  # files an adopter had already removed more than once. A file present in the
-  # template at PREV_SHA was delivered by the last sync, so its absence now is a
-  # decision the adopter made. This refusal is what makes that deletion hold.
-  was_delivered_before() {
-    [[ -s "$PREV_TEMPLATE_FILES" ]] && grep -Fxq -- "$1" "$PREV_TEMPLATE_FILES"
+  # files an adopter had already removed more than once. This refusal is what
+  # makes that deletion hold.
+  #
+  # The evidence is the adopter's own history, not the template's tree. A commit
+  # that deleted the path IS the adopter saying it does not want the file. The
+  # template tree at PREV_SHA only says the file was available then, which is
+  # also true of every template file the adopter never adopted — reading that as
+  # a deletion would decline a genuinely new file forever. A path with no
+  # deletion commit was never there, so it is new and still arrives. The sync
+  # checks out with fetch-depth: 0; a shallow checkout finds no deletion and
+  # falls back to copying in.
+  was_deleted_here() {
+    [[ -n "$(git log --diff-filter=D --format=%H -1 -- "$1")" ]]
   }
 
   # PROBLEM CLASS — a configuration entry that is accepted and matches nothing.
@@ -255,7 +263,7 @@ main() {
         echo "Opt-in only, not present locally: $rel_path (skipping — copy it from the template to adopt it)"
         return
       fi
-      if was_delivered_before "$rel_path"; then
+      if was_deleted_here "$rel_path"; then
         echo "Declined: $rel_path (deleted in the adopter since the last sync; not re-added)"
         echo "$rel_path" >>"$DECLINED_FILES"
         return

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -5,9 +5,10 @@
 # Inputs (env):
 #   SYNC_PATHS        Space-separated paths to sync from the template
 #                     (path names containing spaces are NOT supported)
-#   EXCLUDE_PATHS     Space-separated paths to exclude (whole SYNC_PATHS entries
-#                     or individual file paths within synced directories)
-#   OPT_IN_PATHS      Space-separated file paths the template only UPDATES, never
+#   EXCLUDE_PATHS     Space-separated paths to exclude. An entry names one file
+#                     or one directory, and a directory entry covers every file
+#                     under it.
+#   OPT_IN_PATHS      Space-separated paths the template only UPDATES, never
 #                     INTRODUCES: absent from the child repo, they are skipped;
 #                     present, they sync normally. Opting in is creating the file
 #                     once; opting out is deleting it.
@@ -20,7 +21,8 @@
 # Side effects:
 #   - Creates/updates files inside the current repo to match the template
 #   - Writes /tmp/conflict_files.txt, /tmp/conflict_report.md,
-#     /tmp/deleted_files.txt, /tmp/auto_merged_files.txt
+#     /tmp/deleted_files.txt, /tmp/auto_merged_files.txt,
+#     /tmp/declined_files.txt
 #   - Writes .template-sync-conflicts if there are unresolved conflicts
 #   - Appends key=value lines to $GITHUB_OUTPUT
 
@@ -60,6 +62,7 @@ main() {
   AUTO_MERGED_FILES="$WORK_DIR/auto_merged_files.txt"
   DOWNGRADE_FILES="$WORK_DIR/downgrade_files.txt"
   DOWNGRADE_REPORT="$WORK_DIR/downgrade_report.md"
+  DECLINED_FILES="$WORK_DIR/declined_files.txt"
   PREV_TEMPLATE_FILES="$WORK_DIR/prev_template_files.txt"
 
   : >"$CONFLICT_FILES"
@@ -68,13 +71,32 @@ main() {
   : >"$AUTO_MERGED_FILES"
   : >"$DOWNGRADE_FILES"
   : >"$DOWNGRADE_REPORT"
+  : >"$DECLINED_FILES"
+  # WORK_DIR persists between runs, so a stale list from an earlier run would
+  # otherwise decide which files count as delivered before.
+  : >"$PREV_TEMPLATE_FILES"
 
+  # An EXCLUDE_PATHS entry names one file or one directory, and a directory
+  # entry covers every file under it. The `/`* arm is what makes the directory
+  # form work: the sync tests one file path at a time, so a directory entry
+  # never equals the path of a file inside it, and an equality-only test syncs
+  # every file the entry was written to keep out.
   is_excluded() {
     local candidate="$1" exclude
     for exclude in $EXCLUDE_PATHS; do
-      [[ "$candidate" = "$exclude" ]] && return 0
+      [[ "$candidate" = "$exclude" || "$candidate" = "$exclude"/* ]] && return 0
     done
     return 1
+  }
+
+  # PROBLEM CLASS — a template file the adopter deleted comes back on the next
+  # sync. Case 1 copies in any template file the adopter does not have, so a
+  # deletion there survives only until the next sync run: one sync restored 44
+  # files an adopter had already removed more than once. A file present in the
+  # template at PREV_SHA was delivered by the last sync, so its absence now is a
+  # decision the adopter made. This refusal is what makes that deletion hold.
+  was_delivered_before() {
+    [[ -s "$PREV_TEMPLATE_FILES" ]] && grep -Fxq -- "$1" "$PREV_TEMPLATE_FILES"
   }
 
   # A file the template may update but must never introduce. Some template
@@ -82,10 +104,12 @@ main() {
   # release workflow is the case that motivated this: a consumer with its own
   # publisher that also received auto-version.yaml ended up with two workflows
   # racing the same semver bump on every push to the default branch.
+  # An OPT_IN_PATHS entry names one file or one directory, on the same terms as
+  # is_excluded above.
   is_opt_in() {
     local candidate="$1" opt_in
     for opt_in in $OPT_IN_PATHS; do
-      [[ "$candidate" = "$opt_in" ]] && return 0
+      [[ "$candidate" = "$opt_in" || "$candidate" = "$opt_in"/* ]] && return 0
     done
     return 1
   }
@@ -208,10 +232,15 @@ main() {
 
     [[ "$parent_dir" != "." ]] && mkdir -p "$parent_dir"
 
-    # Case 1: new file in template.
+    # Case 1: absent locally — a new template file, unless the adopter removed it.
     if [[ ! -f "$rel_path" ]]; then
       if is_opt_in "$rel_path"; then
         echo "Opt-in only, not present locally: $rel_path (skipping — copy it from the template to adopt it)"
+        return
+      fi
+      if was_delivered_before "$rel_path"; then
+        echo "Declined: $rel_path (deleted in the adopter since the last sync; not re-added)"
+        echo "$rel_path" >>"$DECLINED_FILES"
         return
       fi
       cp "$template_file" "$rel_path"
@@ -390,6 +419,11 @@ main() {
   if [[ -s "$AUTO_MERGED_FILES" ]]; then
     auto_merged=$(tr '\n' ' ' <"$AUTO_MERGED_FILES")
     echo "auto_merged_files=$auto_merged" >>"$GITHUB_OUTPUT"
+  fi
+
+  if [[ -s "$DECLINED_FILES" ]]; then
+    declined=$(tr '\n' ' ' <"$DECLINED_FILES")
+    echo "declined_files=$declined" >>"$GITHUB_OUTPUT"
   fi
 
   # Downgrade risk: files whose "clean" auto-merge dropped adopter content. This

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -22,7 +22,7 @@
 #   - Creates/updates files inside the current repo to match the template
 #   - Writes /tmp/conflict_files.txt, /tmp/conflict_report.md,
 #     /tmp/deleted_files.txt, /tmp/auto_merged_files.txt,
-#     /tmp/declined_files.txt
+#     /tmp/declined_files.txt, /tmp/inert_entries.txt
 #   - Writes .template-sync-conflicts if there are unresolved conflicts
 #   - Appends key=value lines to $GITHUB_OUTPUT
 
@@ -63,6 +63,7 @@ main() {
   DOWNGRADE_FILES="$WORK_DIR/downgrade_files.txt"
   DOWNGRADE_REPORT="$WORK_DIR/downgrade_report.md"
   DECLINED_FILES="$WORK_DIR/declined_files.txt"
+  INERT_ENTRIES="$WORK_DIR/inert_entries.txt"
   PREV_TEMPLATE_FILES="$WORK_DIR/prev_template_files.txt"
 
   : >"$CONFLICT_FILES"
@@ -72,6 +73,7 @@ main() {
   : >"$DOWNGRADE_FILES"
   : >"$DOWNGRADE_REPORT"
   : >"$DECLINED_FILES"
+  : >"$INERT_ENTRIES"
   # WORK_DIR persists between runs, so a stale list from an earlier run would
   # otherwise decide which files count as delivered before.
   : >"$PREV_TEMPLATE_FILES"
@@ -97,6 +99,21 @@ main() {
   # decision the adopter made. This refusal is what makes that deletion hold.
   was_delivered_before() {
     [[ -s "$PREV_TEMPLATE_FILES" ]] && grep -Fxq -- "$1" "$PREV_TEMPLATE_FILES"
+  }
+
+  # PROBLEM CLASS — a configuration entry that is accepted and matches nothing.
+  # An EXCLUDE_PATHS or OPT_IN_PATHS entry naming a path the template does not
+  # ship covers nothing, and it fails silently: the entry sits in the list, the
+  # sync treats the file as unlisted, and the list reads as though it covers it.
+  # This warning is what makes a misspelled or stale entry visible. Read the
+  # template tree before the run deletes it.
+  report_inert_entries() {
+    local entry
+    for entry in $EXCLUDE_PATHS $OPT_IN_PATHS; do
+      [[ -e "_template/$entry" ]] && continue
+      echo "::warning::list entry names nothing in the template: $entry"
+      echo "$entry" >>"$INERT_ENTRIES"
+    done
   }
 
   # A file the template may update but must never introduce. Some template
@@ -410,6 +427,7 @@ main() {
     fi
   done
 
+  report_inert_entries
   rm -rf _template
 
   #############################################
@@ -419,6 +437,11 @@ main() {
   if [[ -s "$AUTO_MERGED_FILES" ]]; then
     auto_merged=$(tr '\n' ' ' <"$AUTO_MERGED_FILES")
     echo "auto_merged_files=$auto_merged" >>"$GITHUB_OUTPUT"
+  fi
+
+  if [[ -s "$INERT_ENTRIES" ]]; then
+    inert=$(tr '\n' ' ' <"$INERT_ENTRIES")
+    echo "inert_entries=$inert" >>"$GITHUB_OUTPUT"
   fi
 
   if [[ -s "$DECLINED_FILES" ]]; then

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -24,9 +24,11 @@ name: Sync from Template
 # 2. Preserve local customizations while adopting new template features
 # 3. When in doubt, keep local changes - they exist for a reason
 # 4. Check for duplicate CI: if the target repo already has test/lint/format
-#    workflows, don't add the template's versions — exclude them via
-#    EXCLUDE_PATHS instead. A workflow that must never be introduced into a repo
-#    that has its own equivalent (the release flow) belongs in OPT_IN_PATHS.
+#    workflows, delete the template's versions. A file the sync delivered
+#    before and the adopter deleted is reported as declined, not restored, so
+#    the deletion holds on its own and needs no EXCLUDE_PATHS entry.
+# 5. A workflow that must never be introduced into a repo that has its own
+#    equivalent (the release flow) belongs in OPT_IN_PATHS.
 # =============================================================================
 
 on:
@@ -64,11 +66,13 @@ env:
   # A consumer that maintains its own richer copy of one of these (extra tools
   # pinned for its own CI) keeps it by adding that path to EXCLUDE_PATHS.
   SYNC_PATHS: ".claude .hooks .github/actions .github/scripts .github/workflows .github/prompts .github/tool-versions.sh .github/claude-cli-version config/javascript/commitlint.config.js"
-  # Paths to exclude from syncing. Supports both whole directories (matching
-  # entries in SYNC_PATHS) and individual files within synced directories.
+  # Paths to exclude from syncing. An entry names one file or one directory, and
+  # a directory entry covers every file under it.
   #
-  # NOTE: If the target repo already has its own test/lint/format CI workflows,
-  # exclude the template's equivalents here to avoid duplicate CI jobs.
+  # NOTE: An adopter that already has its own test/lint/format CI workflows can
+  # simply delete the template's equivalents; the sync declines to re-add a file
+  # it delivered before. Use this list for a file the sync has NEVER delivered,
+  # or to freeze one the adopter keeps but maintains itself.
   # Common candidates: .github/workflows/node-tests.yaml,
   # .github/workflows/lint.yaml, .github/workflows/format-check.yaml
   #
@@ -232,7 +236,13 @@ jobs:
 
             `{0}`
 
-            ', steps.sync.outputs.auto_merged_files) || '' }}${{ steps.sync.outputs.has_deletions == 'true' && format('---
+            ', steps.sync.outputs.auto_merged_files) || '' }}${{ steps.sync.outputs.declined_files && format('### Declined files (deleted here, not re-added)
+
+            The template still ships these, and this repo deleted them after an earlier sync. The sync left them out. To adopt one, copy it from the template by hand.
+
+            `{0}`
+
+            ', steps.sync.outputs.declined_files) || '' }}${{ steps.sync.outputs.has_deletions == 'true' && format('---
 
             ## Files Removed from Template
 

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -242,7 +242,13 @@ jobs:
 
             `{0}`
 
-            ', steps.sync.outputs.declined_files) || '' }}${{ steps.sync.outputs.has_deletions == 'true' && format('---
+            ', steps.sync.outputs.declined_files) || '' }}${{ steps.sync.outputs.inert_entries && format('### Inert EXCLUDE_PATHS / OPT_IN_PATHS entries
+
+            These entries name nothing in the template, so they cover nothing. Correct the spelling, or delete the entry.
+
+            `{0}`
+
+            ', steps.sync.outputs.inert_entries) || '' }}${{ steps.sync.outputs.has_deletions == 'true' && format('---
 
             ## Files Removed from Template
 

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -314,6 +314,93 @@ def test_per_file_excludes_within_synced_directory(workdir: Path) -> None:
     assert not (child / "config" / "skip.txt").exists()
 
 
+def test_a_directory_exclusion_covers_the_files_under_it(workdir: Path) -> None:
+    """An EXCLUDE_PATHS entry that names a directory keeps every file under it out.
+
+    The sync tests one file path at a time, so an equality-only match never
+    recognises the directory entry and copies each file in anyway. That is the
+    silent form of the failure: the exclusion is present, and it excludes
+    nothing.
+    """
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "keep" / "a.txt", "from template\n")
+    write(template / "config" / "skip" / "b.txt", "also from template\n")
+    commit_all(template)
+
+    result, _ = run_sync(
+        child, template, sync_paths="config", exclude_paths="config/skip"
+    )
+    assert result.returncode == 0, result.stderr
+
+    assert (child / "config" / "keep" / "a.txt").exists()
+    assert not (child / "config" / "skip" / "b.txt").exists()
+
+
+def test_a_directory_opt_in_covers_the_files_under_it(workdir: Path) -> None:
+    """An OPT_IN_PATHS entry that names a directory covers every file under it."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "always.txt", "always synced\n")
+    write(template / "config" / "opt-in" / "a.txt", "only on request\n")
+    commit_all(template)
+
+    result, _ = run_sync(
+        child, template, sync_paths="config", opt_in_paths="config/opt-in"
+    )
+    assert result.returncode == 0, result.stderr
+
+    assert (child / "config" / "always.txt").exists()
+    assert not (child / "config" / "opt-in" / "a.txt").exists()
+
+
+def test_a_file_the_adopter_deleted_is_not_re_added(workdir: Path) -> None:
+    """A template file the adopter deleted after a sync stays deleted.
+
+    Case 1 copies in any template file the adopter lacks, so a deletion there
+    used to survive only until the next sync. The file's presence in the
+    template at the recorded `.template-version` proves the last sync delivered
+    it, so its absence now is the adopter's own decision.
+    """
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "kept.txt", "x\n")
+    write(template / "config" / "unwanted.txt", "y\n")
+    prev_sha = commit_all(template)
+    # The child took `kept.txt` at the last sync and deleted `unwanted.txt`.
+    write(child / "config" / "kept.txt", "x\n")
+    (child / ".template-version").write_text(prev_sha)
+    commit_all(child)
+    write(template / "config" / "brand-new.txt", "z\n")
+    commit_all(template)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    assert not (child / "config" / "unwanted.txt").exists()
+    # A file the template added since that sync was never delivered to the
+    # adopter, so it is genuinely new and still arrives.
+    assert (child / "config" / "brand-new.txt").exists()
+    assert parse_outputs(output_file)["declined_files"].split() == [
+        "config/unwanted.txt"
+    ]
+
+
+def test_a_first_sync_still_adds_every_template_file(workdir: Path) -> None:
+    """Without a recorded template version nothing was delivered before, so the
+    declined-file check must not swallow the whole first sync."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "a.txt", "x\n")
+    commit_all(template)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    assert (child / "config" / "a.txt").exists()
+    assert "declined_files" not in parse_outputs(output_file)
+
+
 def test_opt_in_path_absent_locally_is_not_introduced(workdir: Path) -> None:
     """The collision guard: a repo that never had the release workflow must not
     be handed one. Two publishers on one default branch race the same semver

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -326,6 +326,7 @@ def test_a_directory_exclusion_covers_the_files_under_it(workdir: Path) -> None:
     template = workdir / "template"
     write(template / "config" / "keep" / "a.txt", "from template\n")
     write(template / "config" / "skip" / "b.txt", "also from template\n")
+    write(template / "config" / "skipper.txt", "sibling, not excluded\n")
     commit_all(template)
 
     result, _ = run_sync(
@@ -335,6 +336,9 @@ def test_a_directory_exclusion_covers_the_files_under_it(workdir: Path) -> None:
 
     assert (child / "config" / "keep" / "a.txt").exists()
     assert not (child / "config" / "skip" / "b.txt").exists()
+    # The `/`* arm must require the separator: a sibling that merely shares the
+    # prefix is not under the excluded directory.
+    assert (child / "config" / "skipper.txt").exists()
 
 
 def test_a_directory_opt_in_covers_the_files_under_it(workdir: Path) -> None:
@@ -358,18 +362,22 @@ def test_a_file_the_adopter_deleted_is_not_re_added(workdir: Path) -> None:
     """A template file the adopter deleted after a sync stays deleted.
 
     Case 1 copies in any template file the adopter lacks, so a deletion there
-    used to survive only until the next sync. The file's presence in the
-    template at the recorded `.template-version` proves the last sync delivered
-    it, so its absence now is the adopter's own decision.
+    used to survive only until the next sync. A commit in the adopter that
+    deleted the path is the adopter saying it does not want the file.
     """
     child = workdir / "child"
     template = workdir / "template"
     write(template / "config" / "kept.txt", "x\n")
     write(template / "config" / "unwanted.txt", "y\n")
+    write(template / "config" / "never-adopted.txt", "w\n")
     prev_sha = commit_all(template)
-    # The child took `kept.txt` at the last sync and deleted `unwanted.txt`.
+    # The child took both files at the last sync, then deleted one. The deletion
+    # commit is the evidence the sync reads.
     write(child / "config" / "kept.txt", "x\n")
+    write(child / "config" / "unwanted.txt", "y\n")
     (child / ".template-version").write_text(prev_sha)
+    commit_all(child)
+    (child / "config" / "unwanted.txt").unlink()
     commit_all(child)
     write(template / "config" / "brand-new.txt", "z\n")
     commit_all(template)
@@ -378,9 +386,12 @@ def test_a_file_the_adopter_deleted_is_not_re_added(workdir: Path) -> None:
     assert result.returncode == 0, result.stderr
 
     assert not (child / "config" / "unwanted.txt").exists()
-    # A file the template added since that sync was never delivered to the
-    # adopter, so it is genuinely new and still arrives.
+    # The adopter never had either file, so nothing there says it is unwanted. A
+    # template file the adopter has not adopted must still arrive — including one
+    # the template already shipped at the recorded version, which is the case
+    # that being "present in the template at PREV_SHA" would wrongly decline.
     assert (child / "config" / "brand-new.txt").exists()
+    assert (child / "config" / "never-adopted.txt").exists()
     assert parse_outputs(output_file)["declined_files"].split() == [
         "config/unwanted.txt"
     ]

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -401,6 +401,33 @@ def test_a_first_sync_still_adds_every_template_file(workdir: Path) -> None:
     assert "declined_files" not in parse_outputs(output_file)
 
 
+def test_a_list_entry_that_names_nothing_is_reported(workdir: Path) -> None:
+    """An EXCLUDE_PATHS or OPT_IN_PATHS entry naming a path the template does not
+    ship covers nothing, and it does so silently. The run reports it so a
+    misspelled or stale entry is visible instead of reading as though it covers
+    a file."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "a.txt", "x\n")
+    commit_all(template)
+
+    result, output_file = run_sync(
+        child,
+        template,
+        sync_paths="config",
+        exclude_paths="config/a.txt config/gone",
+        opt_in_paths="config/never-shipped",
+    )
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    assert outputs["inert_entries"].split() == [
+        "config/gone",
+        "config/never-shipped",
+    ]
+    assert "list entry names nothing in the template" in result.stdout
+
+
 def test_opt_in_path_absent_locally_is_not_introduced(workdir: Path) -> None:
     """The collision guard: a repo that never had the release workflow must not
     be handed one. Two publishers on one default branch race the same semver


### PR DESCRIPTION
## What & why

Fix two defects in the sync this template runs into every adopter repository. Both were found when one adopter's weekly sync came back unmergeable: it copied 44 files the adopter had already deleted, and wrote merge-conflict markers into 80 more.

The first defect is a path test that matched nothing. `EXCLUDE_PATHS` and `OPT_IN_PATHS` are documented to accept a directory and cover the files under it. `is_excluded` and `is_opt_in` compared strings for equality, and the sync asks about one file at a time, so a directory entry never equalled the path of any file inside it. An adopter that listed a directory got every file in that directory synced anyway, with no sign that the entry did nothing.

The second defect is why the deleted files kept coming back. The sync copies in any template file the adopter does not have, so it reads "absent" as "not delivered yet". It cannot read it as "the adopter removed this", and a deletion in an adopter therefore survives exactly one sync run. The sync now reads the adopter's own history: a commit that deleted the path is the adopter saying it does not want the file. Such a file is declined and listed in the sync PR under **Declined files**. A path with no deletion commit was never there, so it is a new template file and still arrives.

A third change closes the reason the first defect stayed hidden. An entry that names a path the template does not ship covers nothing, and it said so nowhere. The run now warns per inert entry and lists them in the sync PR, so a misspelled or stale entry is visible instead of reading as though it works.

This changes the advice an adopter follows. An adopter whose own CI duplicates a template workflow can now delete the template's copy and have that deletion hold, with no `EXCLUDE_PATHS` entry. The comments in `template-sync.yaml` say so. `EXCLUDE_PATHS` keeps its two remaining jobs: a file the sync has never delivered, and a file the adopter keeps but maintains itself.

## Review focus

Read `.github/scripts/template-sync.sh` first. The cross-file invariant is that `was_deleted_here` depends on the sync job checking out the adopter with `fetch-depth: 0`, which it does. A shallow checkout finds no deletion commit and falls back to copying in — the behaviour before this PR.

The part I am least sure of is a file an adopter deleted long ago and now wants back. It reads as deleted-on-purpose and is declined. It appears in the sync PR body rather than vanishing silently, and copying the file in once adopts it for good.

## Decisions made

- **Read the deletion from the adopter's git history, not from the template's tree at the recorded version.** The tree was a proxy: "available at that version" is equally true of every template file the adopter never adopted, so every such file would have been declined forever once the adopter's pointer moved past the commit that added it. The adopter's own deletion commit is the direct evidence. Cost: one `git log` per absent file, and a dependency on the checkout keeping full history.

## How it was tested

`uv run pytest tests/test_template_sync.py -q` — 25 passed (observed).

<details>
<summary>Verification</summary>

| Claim | Falsifying command |
| --- | --- |
| A directory exclusion covers the files under it | `uv run pytest tests/test_template_sync.py -k directory_exclusion` — passes (observed) |
| A directory opt-in covers the files under it | `uv run pytest tests/test_template_sync.py -k directory_opt_in` — passes (observed) |
| A file the adopter deleted is not re-added, and a genuinely new one still arrives | `uv run pytest tests/test_template_sync.py -k adopter_deleted` — passes (observed) |
| A template file present at the recorded version but never adopted still arrives | Same test asserts `config/never-adopted.txt` exists; it fails on the tree-based implementation with `assert False … never-adopted.txt.exists` (observed in the glovebox copy of the same test) |
| A directory exclusion does not swallow a sibling that shares its prefix | `uv run pytest tests/test_template_sync.py -k directory_exclusion` — `config/skipper.txt` arrives while `config/skip/b.txt` does not (observed) |
| An entry naming nothing in the template is reported | `uv run pytest tests/test_template_sync.py -k names_nothing` — passes; red on the prior script with `KeyError: 'inert_entries'` (observed) |
| A first sync (no `.template-version`) still adds every file | `uv run pytest tests/test_template_sync.py -k first_sync_still_adds` — passes (observed) |
| The behaviour tests are red on the unfixed script | Restored `git show HEAD:.github/scripts/template-sync.sh`, ran each `-k` selection — the three directory/declined tests failed on their assertions, the first-sync regression test passed on both (observed) |
| The script parses | `bash -n .github/scripts/template-sync.sh` (observed) |
| The pre-commit gate set passes | The `pre-push` hook ran the full set on push — every check Passed, including shellcheck, shfmt, actionlint, zizmor and the ci-truth-serum aggregates (observed) |

Not verified here: a real sync run against a real adopter. That needs the cron fire, or a `workflow_dispatch` of `template-sync.yaml`.

Class check: two properties. A path-set membership test must answer for the value the caller passes, and the caller passes one file at a time — both sites in this repository that hold such a list are fixed here. A configuration entry must not be accepted and match nothing — the inert-entry report covers both lists this script reads. The adopter that hit the failure holds its own diverged copy of `is_excluded` and the same declined-file behaviour lands there in [agent-glovebox#3519](https://github.com/AlexanderMattTurner/agent-glovebox/pull/3519).

</details>

<details>
<summary>Author checklist</summary>

- [x] Commits use Conventional Commits (`<type>(<scope>): <desc>`)
- [x] Tests added/updated and not skipped or weakened
- [x] README/docs touched **only** if a user-facing or behavior change requires it
- [x] `pre-commit run --all-files` passes locally

</details>

---
_Generated by [Claude Code](https://claude.ai/code)_