### PR TITLE
build(pnpm): enforce a 3-day minimum release age for dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# Supply-chain guard: refuse any package version published less than
+# 3 days ago (4320 minutes), so a compromised release gets caught and
+# unpublished upstream before it can land here. Enforced both when
+# resolving versions and against existing pnpm-lock.yaml entries.
+# Must live here, not .npmrc — pnpm 11 silently ignores the .npmrc spelling.
+minimumReleaseAge: 4320

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,10 @@
 # resolving versions and against existing pnpm-lock.yaml entries.
 # Must live here, not .npmrc — pnpm 11 silently ignores the .npmrc spelling.
 minimumReleaseAge: 4320
+
+# First-party packages are exempt: we control their publishing, so a fresh
+# release carries no third-party compromise risk and waiting 3 days to consume
+# our own bump buys nothing. tests/test_pnpm_supply_chain.py holds this list to
+# packages published from this repo's own GitHub owner.
+minimumReleaseAgeExclude:
+  - agent-control-plane-core

--- a/tests/test_pnpm_supply_chain.py
+++ b/tests/test_pnpm_supply_chain.py
@@ -1,0 +1,128 @@
+"""pnpm's minimum-release-age supply-chain floor and its first-party exemptions.
+
+Two ways this config dies silently, both covered here:
+
+1. The floor goes inert. pnpm 11 honors `minimumReleaseAge` only in
+   pnpm-workspace.yaml; the `.npmrc` spelling (`minimum-release-age`) parses
+   without complaint and does nothing, so a plausible "tidy the config into
+   .npmrc" edit disarms the guard while every check stays green.
+2. The exemption list grows. Each entry is a package allowed to install the
+   instant it publishes. That is only safe for packages we publish ourselves,
+   so the list is held to that definition rather than to reviewer vigilance.
+"""
+
+import json
+from pathlib import Path
+
+import yaml
+
+from tests._helpers import REPO_ROOT
+
+WORKSPACE = REPO_ROOT / "pnpm-workspace.yaml"
+PACKAGE_JSON = REPO_ROOT / "package.json"
+NPMRC = REPO_ROOT / ".npmrc"
+NODE_MODULES = REPO_ROOT / "node_modules"
+
+# Spellings pnpm does not honor. Only `minimumReleaseAge` in pnpm-workspace.yaml
+# takes effect; these parse without error and leave the floor off.
+INERT_SPELLINGS = ("minimum-release-age", "minimum_release_age")
+
+
+def _workspace() -> dict:
+    return yaml.safe_load(WORKSPACE.read_text())
+
+
+def _github_owner(repository_url: str) -> str:
+    """Owner segment of a github.com repository URL, lowercased.
+
+    npm `repository.url` values vary in prefix (`git+https://`, `git://`,
+    `ssh://git@`) but all carry `github.com/<owner>/<repo>`, so the owner is the
+    segment after the host rather than a fixed index.
+    """
+    _, _, after_host = repository_url.partition("github.com")
+    owner = after_host.strip(":/").split("/")[0]
+    assert owner, f"no github.com owner in repository url {repository_url!r}"
+    return owner.lower()
+
+
+def test_minimum_release_age_is_set_where_pnpm_reads_it() -> None:
+    age = _workspace().get("minimumReleaseAge")
+    assert isinstance(age, int) and age > 0, (
+        f"{WORKSPACE.name} must declare a positive `minimumReleaseAge` (minutes); "
+        f"got {age!r}. Without it every dependency resolves to versions published "
+        "seconds ago."
+    )
+
+
+def test_no_inert_minimum_release_age_spelling() -> None:
+    """The .npmrc spelling is accepted and ignored — never let it be the only one."""
+    for path in (NPMRC, WORKSPACE):
+        if not path.exists():
+            continue
+        text = path.read_text().lower()
+        # Comments legitimately name the inert spelling to warn about it; only a
+        # line that actually sets it is a problem.
+        settings = [
+            line for line in text.splitlines() if not line.strip().startswith("#")
+        ]
+        for spelling in INERT_SPELLINGS:
+            offenders = [line for line in settings if spelling in line]
+            assert not offenders, (
+                f"{path.name} sets `{spelling}`, which pnpm 11 silently ignores. "
+                f"Use `minimumReleaseAge` in {WORKSPACE.name} instead: {offenders}"
+            )
+
+
+def _exempted() -> list[str]:
+    return _workspace().get("minimumReleaseAgeExclude") or []
+
+
+def test_exempted_packages_are_declared_dependencies() -> None:
+    """A stale exemption is a landmine: if the name is ever re-added — or taken
+    over by a typosquatter — it installs with no release-age floor at all."""
+    manifest = json.loads(PACKAGE_JSON.read_text())
+    declared = {
+        **manifest.get("dependencies", {}),
+        **manifest.get("devDependencies", {}),
+        **manifest.get("optionalDependencies", {}),
+    }
+    undeclared = [name for name in _exempted() if name not in declared]
+    assert not undeclared, (
+        f"{WORKSPACE.name} exempts packages that {PACKAGE_JSON.name} does not "
+        f"depend on: {undeclared}. Drop the stale entries."
+    )
+
+
+def test_exempted_packages_are_first_party() -> None:
+    """Every exemption must be a package this repo's owner publishes.
+
+    Read from the installed copy rather than the registry so the check needs no
+    network; `pnpm install` runs before pytest in CI (setup-base-env).
+    """
+    exempted = _exempted()
+    if not exempted:
+        return
+
+    assert NODE_MODULES.is_dir(), (
+        f"cannot verify first-party ownership of {exempted}: {NODE_MODULES} is "
+        "missing. Run `pnpm install` and re-run."
+    )
+    owner = _github_owner(json.loads(PACKAGE_JSON.read_text())["repository"]["url"])
+
+    for name in exempted:
+        installed = Path(NODE_MODULES, name, "package.json")
+        assert installed.is_file(), (
+            f"{name} is exempt from the release-age floor but is not installed at "
+            f"{installed}; run `pnpm install` and re-run."
+        )
+        repository = json.loads(installed.read_text()).get("repository")
+        url = repository.get("url") if isinstance(repository, dict) else repository
+        assert url, (
+            f"{name} is exempt from the release-age floor but publishes no "
+            "repository URL, so its ownership cannot be verified."
+        )
+        assert _github_owner(url) == owner, (
+            f"{name} is published from {_github_owner(url)!r}, not {owner!r}. Only "
+            "first-party packages may skip the minimum release age — a third-party "
+            "package here reopens the supply-chain window it exists to close."
+        )

--- a/tests/test_pnpm_supply_chain.py
+++ b/tests/test_pnpm_supply_chain.py
@@ -14,6 +14,7 @@ Two ways this config dies silently, both covered here:
 import json
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tests._helpers import REPO_ROOT
@@ -32,17 +33,45 @@ def _workspace() -> dict:
     return yaml.safe_load(WORKSPACE.read_text())
 
 
-def _github_owner(repository_url: str) -> str:
-    """Owner segment of a github.com repository URL, lowercased.
+def _github_owner(repository: str) -> str:
+    """Owner of an npm `repository` value, lowercased.
 
-    npm `repository.url` values vary in prefix (`git+https://`, `git://`,
-    `ssh://git@`) but all carry `github.com/<owner>/<repo>`, so the owner is the
-    segment after the host rather than a fixed index.
+    Accepts the full-URL forms, whose prefixes vary (`git+https://`, `git://`,
+    `ssh://git@`) but which all carry `github.com/<owner>/<repo>`, and npm's
+    `github:<owner>/<repo>` and bare `<owner>/<repo>` shorthands. Anything else
+    — a non-GitHub host — has no owner to compare and fails loudly rather than
+    granting an unverifiable exemption.
     """
-    _, _, after_host = repository_url.partition("github.com")
-    owner = after_host.strip(":/").split("/")[0]
-    assert owner, f"no github.com owner in repository url {repository_url!r}"
+    _, on_github, after_host = repository.partition("github.com")
+    path = after_host if on_github else repository.removeprefix("github:")
+    assert "://" not in path, (
+        f"repository {repository!r} is not on github.com, so its owner cannot be "
+        "compared against this repo's."
+    )
+    owner = path.strip(":/").split("/")[0]
+    assert owner, f"no owner in repository value {repository!r}"
     return owner.lower()
+
+
+@pytest.mark.parametrize(
+    "repository",
+    [
+        "git+https://github.com/Owner/repo.git",
+        "https://github.com/Owner/repo",
+        "ssh://git@github.com/Owner/repo.git",
+        "git://github.com/Owner/repo.git",
+        "github:Owner/repo",
+        "Owner/repo",
+    ],
+)
+def test_github_owner_reads_every_npm_repository_form(repository: str) -> None:
+    assert _github_owner(repository) == "owner"
+
+
+def test_github_owner_rejects_a_non_github_host() -> None:
+    """Fail closed: an owner we can't compare must never pass as first-party."""
+    with pytest.raises(AssertionError, match="not on github.com"):
+        _github_owner("git+https://gitlab.com/Owner/repo.git")
 
 
 def test_minimum_release_age_is_set_where_pnpm_reads_it() -> None:
@@ -61,9 +90,12 @@ def test_no_inert_minimum_release_age_spelling() -> None:
             continue
         text = path.read_text().lower()
         # Comments legitimately name the inert spelling to warn about it; only a
-        # line that actually sets it is a problem.
+        # line that actually sets it is a problem. .npmrc takes both ini comment
+        # markers, so a commented-out setting is not an offender either.
         settings = [
-            line for line in text.splitlines() if not line.strip().startswith("#")
+            line
+            for line in text.splitlines()
+            if not line.strip().startswith(("#", ";"))
         ]
         for spelling in INERT_SPELLINGS:
             offenders = [line for line in settings if spelling in line]


### PR DESCRIPTION
## What & why

Enforce pnpm's `minimumReleaseAge: 4320` (3 days, in minutes) so no dependency version published less than 3 days ago can be resolved or installed — a window for the registry to catch and unpublish compromised releases before they land here. Because `pnpm-lock.yaml` is gitignored in this repo, every fresh session and CI run resolves versions live, which is exactly the path this floor protects.

First-party packages are exempt via `minimumReleaseAgeExclude` (today: `agent-control-plane-core`). We control their publishing, so a fresh release carries no third-party compromise risk, and waiting 3 days to consume our own bump buys nothing.

## Review focus

`tests/test_pnpm_supply_chain.py`. An exemption list is the obvious way to gut the floor one entry at a time, so the test holds it to its definition rather than to reviewer vigilance: every exempted package must be a declared dependency **and** be published from this repo's own GitHub owner, read offline from the installed copy in `node_modules` (`setup-base-env` runs `pnpm install` before pytest). Adding a third-party package to that list is a red test, not a quiet policy change.

The same file pins the floor against going inert: pnpm 11 honors `minimumReleaseAge` only in `pnpm-workspace.yaml`, while the `.npmrc` spelling `minimum-release-age` parses without complaint and does nothing — so a plausible "tidy this into `.npmrc`" edit would disarm the guard with every check still green.

## How it was tested

Behavioral checks against real pnpm resolution, not source text:

- **The floor works, and only from `pnpm-workspace.yaml`.** With a 1-year floor there, pnpm resolved `typescript@5.9.2` instead of `7.0.2`. The same floor as `minimum-release-age` in `.npmrc` still resolved `7.0.2` — the inert spelling this PR guards against.
- **The exemption works, on this repo's actual manifest.** Under a floor wide enough to reject everything, `agent-control-plane-core@0.2.2` is listed as blocked without the exemption and absent from the blocked list with it.
- **The floor is enforced against existing lockfiles too.** `pnpm install --frozen-lockfile` rejected the pre-existing `@types/node@26.2.0` (published 2026-08-07, inside the cutoff); rebuilt resolution picked `26.1.2`.
- **Non-vacuity, config guards:** each was driven red by a separate mutation — dropping `minimumReleaseAge`, adding the inert `.npmrc` spelling, exempting an undeclared name, and exempting a real-but-third-party dep (`semver`). Each mutation failed exactly one test, and `semver` correctly passed the declared-dependency test while failing the first-party one.
- **Non-vacuity, owner parser:** removing the URL-path stripping from `_github_owner` fails 5 tests (4 repository forms plus the real first-party check).
- `uv run --extra dev pytest tests/` → 471 passed. `corepack pnpm test` → 340/340 passed.

## Decisions made

- **Age is 4320 minutes (3 days)**, per the request; changing it is a one-line edit.
- **Ownership is verified from `node_modules`, not the registry**, so the test needs no network. A missing `node_modules` fails loud with a "run `pnpm install`" message rather than skipping green.
- **A non-GitHub repository value on an exempted package fails the check.** Fail-closed: an owner we can't compare needs an explicit widening rather than passing unverified. The GitHub shorthands (`github:owner/repo`, bare `owner/repo`) are accepted, since rejecting them would have failed a legitimate first-party package.
- **Introduced `pnpm-workspace.yaml`** (the repo had none) because pnpm 11 only honors this setting there. It marks the repo as a single-package workspace root, which changed no install or test behavior in verification.

## Security boundary impact

Adds a supply-chain defense layer: freshly published dependency versions are excluded from resolution and rejected in lockfiles for 3 days after publish. It does not protect against malicious versions older than 3 days. The exemption list is a deliberate hole in that layer, scoped by test to packages this repo's owner publishes.

<details>
<summary>Author checklist</summary>

- [x] Commits use Conventional Commits (`<type>(<scope>): <desc>`)
- [x] Tests added/updated and not skipped or weakened
- [x] README/docs touched **only** if a user-facing or behavior change requires it
- [x] `pre-commit run --all-files` passes locally (runs on push via the pre-push hook)

</details>