### PR TITLE
fix(ci): pick the review-hold credential by live quota, not by `||`

### DIFF
--- a/.github/scripts/approve-if-reviewer-hold-clear.sh
+++ b/.github/scripts/approve-if-reviewer-hold-clear.sh
@@ -31,11 +31,27 @@
 #      sweep does not, so it never clears a body hold blindly — same trust the
 #      thread path already places in the model's verdicts.json.
 #
-# Env: GH_TOKEN, GH_REPO (owner/name), PR; REVIEWER_LOGIN, BODY_VERDICT_FILE optional.
+# Env: the GH_TOKEN_* ladder rungs (see lib/github-token-ladder.bash), GH_REPO
+# (owner/name), PR; REVIEWER_LOGIN, BODY_VERDICT_FILE optional.
 set -euo pipefail
 
 : "${GH_REPO:?GH_REPO required}"
 : "${PR:?PR number required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/github-token-ladder.bash disable=SC1091
+source "$SCRIPT_DIR/lib/github-token-ladder.bash"
+
+# Every call below spends API quota, so pick a credential that has some before
+# the first one rather than discovering it mid-flight. Reddening only once EVERY
+# rung is spent is the point: a spent top rung is not a reason to fail a step
+# whose posture is to degrade, but nothing left to spend anywhere is a real
+# blocker a human has to clear, so it is not swallowed either.
+GH_TOKEN="$(github_token_with_quota)" || {
+  echo "every configured GitHub credential is out of API quota; cannot read this PR's review state, so the reviewer's hold is left in place. Re-run once quota resets, or provision another TEMPLATE_SYNC_TOKEN." >&2
+  exit 1
+}
+export GH_TOKEN
 REVIEWER_LOGIN="${REVIEWER_LOGIN:-github-actions[bot]}"
 # GitHub's GraphQL API returns an app bot's `login` WITHOUT the `[bot]` suffix the
 # REST API appends (REST `github-actions[bot]` ↔ GraphQL `github-actions`). Both

--- a/.github/scripts/lib/github-token-ladder.bash
+++ b/.github/scripts/lib/github-token-ladder.bash
@@ -1,0 +1,75 @@
+# shellcheck shell=bash
+# github-token-ladder.bash — the ordered GitHub credentials, and the pick of the
+# first one that can actually spend API quota (sourced, not run).
+#
+# A workflow-expression chain (`${{ A || B || C }}`) resolves at expression time,
+# so it answers "which secret is CONFIGURED" and nothing else: the first
+# non-empty one becomes the only credential the step ever holds. A PAT that is
+# configured but out of API quota therefore takes the step down at its first
+# `gh` call, with rungs below it still holding quota and never reached.
+#
+# Selecting here instead makes "configured" and "usable" separate questions, and
+# the answer is cheap: GET /rate_limit is the one endpoint that does not itself
+# consume quota, so probing every rung costs nothing against any of them.
+
+# Org PAT first, then the per-repo PAT, then the Actions token. Both PAT
+# spellings are load-bearing for different consumers: an org-owned repo sets
+# TEMPLATE_SYNC_TOKEN_ORG once for every repo it owns, while a personal fork can
+# only set a repo secret. The Actions token is last because it is the least
+# capable — GitHub bars it from approving a PR and from resolving a review
+# thread — so it is reached only when no PAT can act.
+GITHUB_TOKEN_LADDER_VARS=(
+  GH_TOKEN_ORG_PAT
+  GH_TOKEN_REPO_PAT
+  GH_TOKEN_ACTIONS
+)
+
+# github_token_ladder — the configured credentials on stdout, one per line, in
+# attempt order. Empty rungs are dropped so an unset middle tier is stepped over
+# rather than truncating the ladder, and duplicates collapse so the same
+# credential is not probed (or billed) twice. Empty output means none is
+# configured — the caller decides whether that is a refusal or a skip.
+github_token_ladder() {
+  local -A seen=()
+  local var cred
+  for var in "${GITHUB_TOKEN_LADDER_VARS[@]}"; do
+    cred="${!var:-}"
+    [[ -n "$cred" && -z "${seen["$cred"]:-}" ]] || continue
+    seen["$cred"]=1
+    printf '%s\n' "$cred"
+  done
+}
+
+# github_token_with_quota — the first credential with REST *and* GraphQL quota
+# left, on stdout; non-zero when every rung is spent or unusable.
+#
+# Both resources are checked because these callers span both APIs (thread and
+# review reads over GraphQL, a dismissal over REST), and the two carry separate
+# budgets — a credential with GraphQL quota and no REST quota would pass a
+# core-only probe and then die partway through. A rung whose probe fails at all
+# (a revoked or malformed PAT) is stepped over on the same footing as a spent
+# one: either way it cannot do the work.
+github_token_with_quota() {
+  local cred remaining index=0
+  while IFS= read -r cred; do
+    index=$((index + 1))
+    # Branch on the probe's status rather than letting `set -e` see it: a rung
+    # whose probe FAILS is the revoked-credential case this loop exists to step
+    # over, so it must not abort the walk. A probe that succeeds but reports no
+    # number lands here too — an answer we cannot read is not an answer.
+    if ! remaining="$(GH_TOKEN="$cred" gh api rate_limit \
+      --jq '[.resources.core.remaining, .resources.graphql.remaining]
+            | map(select(type == "number")) | min' 2>/dev/null)" ||
+      [[ ! "$remaining" =~ ^[0-9]+$ ]]; then
+      echo "github credential #${index}: unusable (its quota could not be read); trying the next rung" >&2
+      continue
+    fi
+    if ((remaining == 0)); then
+      echo "github credential #${index}: out of API quota; trying the next rung" >&2
+      continue
+    fi
+    printf '%s\n' "$cred"
+    return 0
+  done < <(github_token_ladder)
+  return 1
+}

--- a/.github/scripts/resolve-addressed-threads.sh
+++ b/.github/scripts/resolve-addressed-threads.sh
@@ -21,19 +21,26 @@
 #     keeps the github-actions[bot] identity the rest of the reviewer machinery
 #     keys on.
 #
-# Env: GH_TOKEN (reply, GITHUB_TOKEN), GH_RESOLVE_TOKEN (resolve, a PAT with
-# pull-request write), PR_INPUT_DIR. (select-resolvable-threads.mjs reads the
-# threads/verdicts under PR_INPUT_DIR; the reply+resolve mutations act on thread
-# ids alone, so no owner/name/PR number is needed here.)
+# Env: GH_TOKEN (reply, GITHUB_TOKEN), the GH_TOKEN_* ladder rungs the resolve
+# credential is picked from (see lib/github-token-ladder.bash), PR_INPUT_DIR.
+# (select-resolvable-threads.mjs reads the threads/verdicts under PR_INPUT_DIR;
+# the reply+resolve mutations act on thread ids alone, so no owner/name/PR number
+# is needed here.)
 set -euo pipefail
 
 : "${PR_INPUT_DIR:?PR_INPUT_DIR required}"
-: "${GH_RESOLVE_TOKEN:?GH_RESOLVE_TOKEN required — the Actions GITHUB_TOKEN cannot resolve review threads (only reply); set a PAT (TEMPLATE_SYNC_TOKEN) with pull-request write}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/github-token-ladder.bash disable=SC1091
+source "$SCRIPT_DIR/lib/github-token-ladder.bash"
 
 die() {
   echo "$*" >&2
   exit 1
 }
+
+GH_RESOLVE_TOKEN="$(github_token_with_quota)" ||
+  die "every configured GitHub credential is out of API quota; cannot resolve threads. Re-run once quota resets, or provision another TEMPLATE_SYNC_TOKEN."
 
 count="$(node .github/scripts/select-resolvable-threads.mjs)"
 if [[ "$count" -eq 0 ]]; then

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -612,16 +612,16 @@ jobs:
           # (GITHUB_TOKEN) still posts the audit reply, keeping the
           # github-actions[bot] identity.
           #
-          # Org secret first, then the per-repo one, then the built-in. Both PAT
-          # spellings are load-bearing for different consumers: an org-owned repo
-          # sets TEMPLATE_SYNC_TOKEN_ORG once for every repo it owns, while a
-          # personal fork can only set a repo secret. Trying the org name first
-          # means a downstream repo needs no edit either way.
-          # Every candidate is an identity this repo's owner controls, so the
-          # fallback trades away capability (a resolve the Actions token may not
-          # perform), never which account acts.
-          # token-fallback-ok: designed graceful degradation, not an accident.
-          GH_RESOLVE_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          # The rungs the script picks the resolve credential from, in order.
+          # Passed as separate vars rather than an `||` chain so the choice is
+          # made against live API quota at run time: `||` picks the first
+          # CONFIGURED secret, which strands the step on a spent PAT while a
+          # rung below it still has quota. Every candidate is an identity this
+          # repo's owner controls, so the fallback trades away capability (a
+          # resolve the Actions token may not perform), never which account acts.
+          GH_TOKEN_ORG_PAT: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG }}
+          GH_TOKEN_REPO_PAT: ${{ secrets.TEMPLATE_SYNC_TOKEN }}
+          GH_TOKEN_ACTIONS: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/resolve-addressed-threads.sh
 
       # State-based, and deliberately NOT gated on has_threads: the approval is a
@@ -649,7 +649,12 @@ jobs:
           # them can approve, so the PAT only ever upgrades this step from "a
           # human must approve" to "approved automatically".
           # Every candidate is an identity this repo's owner controls, so the
-          # fallback trades away capability, never which account acts.
-          # token-fallback-ok: designed graceful degradation, not an accident.
-          GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.TEMPLATE_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          # fallback trades away capability, never which account acts. Passed as
+          # separate rungs rather than an `||` chain so the script picks against
+          # live API quota: `||` picks the first CONFIGURED secret, so a spent
+          # PAT reddened this step instead of falling through to a rung that
+          # could still act.
+          GH_TOKEN_ORG_PAT: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG }}
+          GH_TOKEN_REPO_PAT: ${{ secrets.TEMPLATE_SYNC_TOKEN }}
+          GH_TOKEN_ACTIONS: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/approve-if-reviewer-hold-clear.sh

--- a/.github/workflows/claude-reviewer-hold-clear.yaml
+++ b/.github/workflows/claude-reviewer-hold-clear.yaml
@@ -36,8 +36,15 @@ jobs:
       contents: read # sparse-checkout the trusted approval scripts
       pull-requests: write # submit the approving review; no other scope
     env:
+      # The sweep's own PR listing runs on the Actions token.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
+      # The only rung the sweep gets. approve-if-reviewer-hold-clear.sh picks its
+      # credential from this ladder, and the sweep deliberately carries no PAT:
+      # GitHub bars the Actions token from approving, so the sweep clears a hold
+      # by dismissing it rather than by minting an approval on a PR no push-time
+      # review just examined.
+      GH_TOKEN_ACTIONS: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout the trusted approval scripts (default branch)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/tests/test_approve_if_reviewer_hold_clear.py
+++ b/tests/test_approve_if_reviewer_hold_clear.py
@@ -64,6 +64,9 @@ def graphql_payloads(threads: list[dict], reviews: list[dict]) -> tuple[str, str
     return json.dumps(t), json.dumps(r)
 
 
+ACTIONS_TOKEN = "actions-token"
+
+
 def run(
     tmp_path: Path,
     *,
@@ -71,11 +74,21 @@ def run(
     reviews: list[dict],
     approve_error: str | None = None,
     dismiss_error: str | None = None,
+    rungs: dict[str, str] | None = None,
+    quotas: dict[str, int] | None = None,
 ):
-    """Drive the script with a `gh` that executes its real --jq filters."""
+    """Drive the script with a `gh` that executes its real --jq filters.
+
+    `rungs` maps ladder env var -> credential; `quotas` maps credential ->
+    requests remaining, where a negative value makes the probe itself fail (a
+    revoked token) rather than report zero.
+    """
+    rungs = {"GH_TOKEN_ACTIONS": ACTIONS_TOKEN} if rungs is None else rungs
+    quotas = {ACTIONS_TOKEN: 5000} if quotas is None else quotas
     threads_json, reviews_json = graphql_payloads(threads, reviews)
     (tmp_path / "threads.json").write_text(threads_json)
     (tmp_path / "reviews.json").write_text(reviews_json)
+    (tmp_path / "quotas.json").write_text(json.dumps(quotas))
     log = tmp_path / "gh-calls.txt"
 
     def arm(err: str | None) -> str:
@@ -90,6 +103,29 @@ def run(
     # then applies the script's own --jq to it, exactly as `gh api graphql` would.
     stub = f"""#!/usr/bin/env bash
 printf '%s\\n' "$*" >> "{log}"
+# The quota probe answers for whichever credential the ladder is currently
+# holding, and runs the ladder's real --jq so its core/graphql min is exercised.
+if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
+  filter=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --jq) filter="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  left="$(jq -r --arg t "${{GH_TOKEN:-}}" '.[$t] // 0' "{tmp_path}/quotas.json")"
+  # A negative budget stands for a credential whose probe fails outright.
+  if [[ "$left" -lt 0 ]]; then exit 1; fi
+  printf '{{"resources":{{"core":{{"remaining":%s}},"graphql":{{"remaining":%s}}}}}}' "$left" "$left" | jq -r "$filter"
+  exit 0
+fi
+# Any real call spends quota, so a credential with none left fails the way the
+# live API fails — this is what took the step down before the ladder existed.
+left="$(jq -r --arg t "${{GH_TOKEN:-}}" '.[$t] // 0' "{tmp_path}/quotas.json")"
+if [[ "$left" -le 0 ]]; then
+  echo "gh: API rate limit already exceeded for user ID 3458070." >&2
+  exit 1
+fi
 if [[ "$1" == "api" && "$2" == "graphql" ]]; then
   query=""; filter=""
   while [[ $# -gt 0 ]]; do
@@ -124,9 +160,9 @@ exit 0
         cwd=REPO_ROOT,
         env={
             "PATH": f"{bin_dir}:/usr/bin:/bin:/usr/local/bin",
-            "GH_TOKEN": "x",
             "GH_REPO": "o/r",
             "PR": "438",
+            **rungs,
         },
     )
     calls = log.read_text() if log.exists() else ""
@@ -140,6 +176,52 @@ def dismissed(calls: str) -> bool:
 CLEARED = dict(threads=[thread(resolved=True)], reviews=[review("CHANGES_REQUESTED")])
 SELF_APPROVAL = "GraphQL: Can not approve your own pull request (addPullRequestReview)"
 ACTIONS_BARRED = "GitHub Actions is not permitted to approve pull requests"
+
+
+SPENT_PAT = "spent-pat"
+
+
+def test_a_spent_top_rung_falls_through_to_one_with_quota(tmp_path: Path):
+    """THE regression. A configured-but-spent PAT used to take this step down at
+    its first API call, with the Actions token below it still holding quota."""
+    res, _ = run(
+        tmp_path,
+        **CLEARED,
+        rungs={"GH_TOKEN_ORG_PAT": SPENT_PAT, "GH_TOKEN_ACTIONS": ACTIONS_TOKEN},
+        quotas={SPENT_PAT: 0, ACTIONS_TOKEN: 5000},
+    )
+    assert res.returncode == 0, res.stderr
+    assert "out of API quota; trying the next rung" in res.stderr
+    assert "approved to satisfy the review gate" in res.stderr, (
+        "the rung with quota must do the work the spent one could not"
+    )
+
+
+def test_a_rung_whose_probe_fails_is_stepped_over(tmp_path: Path):
+    # A revoked or malformed PAT cannot report a quota at all; it is as unusable
+    # as a spent one and must not strand the step either.
+    res, _ = run(
+        tmp_path,
+        **CLEARED,
+        rungs={"GH_TOKEN_ORG_PAT": "revoked", "GH_TOKEN_ACTIONS": ACTIONS_TOKEN},
+        quotas={"revoked": -1, ACTIONS_TOKEN: 5000},
+    )
+    assert res.returncode == 0, res.stderr
+    assert "its quota could not be read" in res.stderr
+    assert "approved to satisfy the review gate" in res.stderr
+
+
+def test_every_rung_spent_fails_loudly(tmp_path: Path):
+    # Nothing left to spend anywhere is a real blocker, not something to swallow:
+    # the hold stays up, so the failure has to be visible.
+    res, _ = run(
+        tmp_path,
+        **CLEARED,
+        rungs={"GH_TOKEN_ORG_PAT": SPENT_PAT, "GH_TOKEN_ACTIONS": ACTIONS_TOKEN},
+        quotas={SPENT_PAT: 0, ACTIONS_TOKEN: 0},
+    )
+    assert res.returncode == 1
+    assert "every configured GitHub credential is out of API quota" in res.stderr
 
 
 def test_a_self_approval_refusal_dismisses_the_stale_hold(tmp_path: Path):

--- a/tests/test_github_token_ladder.py
+++ b/tests/test_github_token_ladder.py
@@ -1,0 +1,137 @@
+"""The GitHub credential ladder that callers pick a usable token from.
+
+The ladder exists because a workflow-expression chain (`${{ A || B || C }}`)
+answers "which secret is configured" and never "which one can still spend
+quota", so a configured-but-spent PAT stranded every caller below it. These
+tests drive the real shell functions; the end-to-end consequence for a caller
+lives in test_approve_if_reviewer_hold_clear.py.
+
+# covers: .github/scripts/lib/github-token-ladder.bash
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+from tests._helpers import REPO_ROOT
+
+LIB = REPO_ROOT / ".github" / "scripts" / "lib" / "github-token-ladder.bash"
+
+
+def _bash(body: str, env: dict[str, str], path: str | None = None):
+    return subprocess.run(
+        ["bash", "-c", f"set -euo pipefail; source {LIB}; {body}"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": path or "/usr/bin:/bin:/usr/local/bin", **env},
+    )
+
+
+def ladder(**rungs: str) -> list[str]:
+    res = _bash("github_token_ladder", rungs)
+    assert res.returncode == 0, res.stderr
+    return res.stdout.split()
+
+
+def test_the_ladder_is_ordered_org_pat_then_repo_pat_then_actions():
+    assert ladder(
+        GH_TOKEN_ORG_PAT="org", GH_TOKEN_REPO_PAT="repo", GH_TOKEN_ACTIONS="actions"
+    ) == ["org", "repo", "actions"]
+
+
+def test_an_unset_middle_rung_is_stepped_over_not_truncated():
+    # The rung below an unset one must still be reached: a repo that sets only
+    # the org PAT and the Actions token still gets both.
+    assert ladder(GH_TOKEN_ORG_PAT="org", GH_TOKEN_ACTIONS="actions") == [
+        "org",
+        "actions",
+    ]
+
+
+def test_the_same_credential_configured_twice_is_probed_once():
+    # An org-owned repo commonly sets both PAT spellings to the same token;
+    # probing it twice would spend a request to learn what rung one already said.
+    assert ladder(
+        GH_TOKEN_ORG_PAT="same", GH_TOKEN_REPO_PAT="same", GH_TOKEN_ACTIONS="actions"
+    ) == ["same", "actions"]
+
+
+def _with_quota(tmp_path: Path, budgets: dict[str, dict[str, int]], **rungs: str):
+    """Drive github_token_with_quota against a `gh` whose /rate_limit answers
+    from `budgets` (credential -> {core, graphql} requests remaining)."""
+    (tmp_path / "budgets.json").write_text(json.dumps(budgets))
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    stub = f"""#!/usr/bin/env bash
+filter=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in --jq) filter="$2"; shift 2 ;; *) shift ;; esac
+done
+entry="$(jq -c --arg t "${{GH_TOKEN:-}}" '.[$t] // empty' "{tmp_path}/budgets.json")"
+# No entry stands for a credential whose probe fails outright (revoked token).
+[[ -n "$entry" ]] || exit 1
+jq -r "$filter" <<<"{{\\"resources\\":$entry}}"
+"""
+    (bin_dir / "gh").write_text(stub)
+    (bin_dir / "gh").chmod(0o755)
+    return _bash(
+        "github_token_with_quota", rungs, path=f"{bin_dir}:/usr/bin:/bin:/usr/local/bin"
+    )
+
+
+FULL = {"core": {"remaining": 5000}, "graphql": {"remaining": 5000}}
+
+
+def test_the_first_rung_with_quota_is_chosen(tmp_path: Path):
+    res = _with_quota(
+        tmp_path,
+        {"org": {"core": {"remaining": 0}, "graphql": {"remaining": 0}}, "act": FULL},
+        GH_TOKEN_ORG_PAT="org",
+        GH_TOKEN_ACTIONS="act",
+    )
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == "act"
+
+
+def test_a_credential_out_of_graphql_quota_alone_is_skipped(tmp_path: Path):
+    """REST and GraphQL carry separate budgets, and these callers span both — a
+    core-only probe would pick a token that dies on its first thread query."""
+    res = _with_quota(
+        tmp_path,
+        {
+            "org": {"core": {"remaining": 5000}, "graphql": {"remaining": 0}},
+            "act": FULL,
+        },
+        GH_TOKEN_ORG_PAT="org",
+        GH_TOKEN_ACTIONS="act",
+    )
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == "act"
+
+
+def test_a_revoked_credential_is_stepped_over(tmp_path: Path):
+    res = _with_quota(
+        tmp_path, {"act": FULL}, GH_TOKEN_ORG_PAT="revoked", GH_TOKEN_ACTIONS="act"
+    )
+    assert res.returncode == 0, res.stderr
+    assert res.stdout.strip() == "act"
+    assert "quota could not be read" in res.stderr
+
+
+def test_every_rung_spent_reports_failure(tmp_path: Path):
+    empty = {"core": {"remaining": 0}, "graphql": {"remaining": 0}}
+    res = _with_quota(
+        tmp_path,
+        {"org": empty, "act": empty},
+        GH_TOKEN_ORG_PAT="org",
+        GH_TOKEN_ACTIONS="act",
+    )
+    assert res.returncode != 0
+    assert res.stdout.strip() == "", "a spent ladder must name no credential"
+
+
+def test_no_configured_rung_reports_failure(tmp_path: Path):
+    res = _with_quota(tmp_path, {})
+    assert res.returncode != 0
+    assert res.stdout.strip() == ""

--- a/tests/test_required_env.py
+++ b/tests/test_required_env.py
@@ -33,7 +33,9 @@ CASES = [
     ("post-pr-review.sh", ["PR", "GH_REPO", "PR_INPUT_DIR"]),
     ("auto-approve-skipped-pr.sh", ["PR", "GH_REPO"]),
     ("fetch-unresolved-review-threads.sh", ["GH_REPO", "PR", "PR_INPUT_DIR"]),
-    ("resolve-addressed-threads.sh", ["PR_INPUT_DIR", "GH_RESOLVE_TOKEN"]),
+    # The resolve credential is no longer an input: it is picked from the
+    # GH_TOKEN_* ladder, so PR_INPUT_DIR is the only var this script demands.
+    ("resolve-addressed-threads.sh", ["PR_INPUT_DIR"]),
     ("approve-if-reviewer-hold-clear.sh", ["GH_REPO", "PR"]),
     ("sweep-reviewer-holds.sh", ["GH_REPO"]),
     ("append-haiku-cost.sh", ["GH_REPO", "PR"]),


### PR DESCRIPTION
## What & why

Make the reviewer-hold steps pick their GitHub credential at run time against live API quota, instead of taking whichever secret a `${{ A || B || C }}` chain resolved to.

That chain resolves at expression time, so it answers one question — which secret is *configured* — and the first non-empty one becomes the only credential the step ever holds. When that PAT is out of API quota, the step dies at its first `gh` call with `API rate limit already exceeded for user ID …`, while the rungs below it still have quota and are never reached. Observed on #451, twice.

It also contradicts the step's own documented posture. The script's comments say a refusal it cannot retry past should stand down loudly rather than red a check, "because a check that can only fail teaches nothing" — but that handling only ever covered the two *structural* approval refusals (Actions tokens can't approve; nobody can self-approve). A spent token hits the very first GraphQL read, long before any of it.

## Review focus

`.github/scripts/lib/github-token-ladder.bash` — the new shared selector, and the only new logic. Two things worth a look:

- **It probes `GET /rate_limit`**, the one GitHub endpoint that does not itself consume quota, so walking every rung costs nothing against any of them.
- **It requires both REST and GraphQL budget.** These callers span both APIs (thread and review reads over GraphQL, a dismissal over REST) and the two budgets are separate, so a core-only probe would happily pick a credential that dies on its first thread query.

Reddening now requires *every* rung to be spent — a real blocker a human must clear, not a transient one — so the failure isn't swallowed either.

## How it was tested

- **The defect reproduces, and the fix resolves it.** Drove both script versions with a `gh` stub that rate-limits a spent credential exactly as the live API does. The pre-fix script, wired as its workflow wired it (`GH_TOKEN` = the `||` pick = the spent PAT), prints `gh: API rate limit already exceeded for user ID 3458070.` and exits 1 — the CI failure verbatim. The post-fix script, same spent PAT on the top rung, logs `github credential #1: out of API quota; trying the next rung` and exits 0 having posted the approval.
- **Regression tests** in `tests/test_approve_if_reviewer_hold_clear.py` cover the fall-through, a rung whose probe fails outright (revoked PAT), and the all-spent case. The existing `gh` stub was extended to enforce quota on *real* calls, not just the probe, so the fixture fails the way production failed.
- **Unit tests** in `tests/test_github_token_ladder.py` cover ladder order, an unset middle rung, credential dedup, the REST-vs-GraphQL split, and both failure exits.
- **Non-vacuity, found a real bug:** `test_a_revoked_credential_is_stepped_over` failed on first run. Under `set -e`, the probe's non-zero exit killed `github_token_with_quota` at the assignment before the skip logic ran, so a revoked top rung would have stranded the step just like a spent one — the exact class of bug this PR fixes, reintroduced in the fix. Now branched on explicitly.
- `uv run --extra dev pytest tests/` → 472 passed. `pre-commit run` over the changed files → all hooks pass (shellcheck, shfmt, actionlint, zizmor included).

## Decisions made

- **Applied to the sibling resolve step too** (`GH_RESOLVE_TOKEN`, same `||` chain, same file). Falling through to the Actions token can't resolve a thread, but falling from the org PAT to the repo PAT can, and both are real rungs.
- **The periodic sweep keeps exactly one rung** (`GH_TOKEN_ACTIONS`). It carries no PAT today, and handing it one would newly let it mint approvals on PRs no push-time review examined — a capability change, not a defect fix. It still clears holds by dismissal.
- **All-rungs-spent exits non-zero.** The alternative, standing down silently, leaves the hold up with no signal; quota exhaustion is exactly the operational fact the maintainer needs to see.
- **Dropped the two `# token-fallback-ok:` suppressions.** They annotated the `||` chains as deliberate graceful degradation. That was true of capability and false of quota, and the chains are gone.
- **`tests/test_required_env.py` listed `GH_RESOLVE_TOKEN`** as required for a script that no longer takes it. The entry was stale but still passing, because that test asserts `any()` of the listed vars appears in stderr and `PR_INPUT_DIR` fires first. Corrected the entry; the `any()` weakness is pre-existing and left alone.

## Security boundary impact

No change to which identities can act. The candidate set and its order are unchanged — org PAT, then repo PAT, then the Actions token — and every candidate is an identity this repo's owner already controls. What changes is only whether a candidate that cannot spend quota is skipped instead of stranding the step. The resolve credential remains scoped to its own step, out of reach of the Haiku step and any model injection.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkDfA9YpVte6Q9q3ZLrkbC)_