### PR TITLE
feat(ci): derive a gate's watched paths from the shell entry point it runs

### DIFF
--- a/.github/scripts/decide-reusable-diff.sh
+++ b/.github/scripts/decide-reusable-diff.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Decide whether a gate/track job runs: diff the PR for path matches and scan
-# commit titles for the trigger/heldout keywords; emit run/heldout outputs.
-# Env: BASE_SHA, HEAD_SHA, PATHS_REGEX, PYTEST_TARGETS, TRIGGER_KEYWORD, HELDOUT_KEYWORD,
+# commit titles for the trigger keyword; emit the run output.
+# Env: BASE_SHA, HEAD_SHA, PATHS_REGEX, PYTEST_TARGETS, SHELL_TARGETS, TRIGGER_KEYWORD,
 #      KEYWORD_SCOPE, IGNORE_COMMENT_ONLY, BASE_REF, GH_TOKEN,
 #      SKIP_ON_DRAFT, IS_DRAFT
 set -euo pipefail
@@ -19,8 +19,8 @@ BASE_SHA="${BASE_SHA:-}"
 HEAD_SHA="${HEAD_SHA:-}"
 PATHS_REGEX="${PATHS_REGEX:-}"
 PYTEST_TARGETS="${PYTEST_TARGETS:-}"
+SHELL_TARGETS="${SHELL_TARGETS:-}"
 TRIGGER_KEYWORD="${TRIGGER_KEYWORD:-}"
-HELDOUT_KEYWORD="${HELDOUT_KEYWORD:-}"
 # PATHS_REGEX_FILE names a repo shell snippet defining GATE_PATHS_REGEX — the
 # SSOT for a trigger regex that a local git hook (.hooks/pre-push) sources too,
 # so the workflow cannot carry a drifted inline copy. Resolved before anything
@@ -50,7 +50,6 @@ fi
 BASE_SHA="$(decide_diff_base "${BASE_SHA:-}")"
 if ! decide_range_usable "$BASE_SHA" "$HEAD_SHA"; then
   echo "run=true" >>"$GITHUB_OUTPUT"
-  echo "heldout=false" >>"$GITHUB_OUTPUT"
   exit 0
 fi
 # Past the early-exit this is a real PR diff. A gate reaching here with NO trigger
@@ -60,8 +59,8 @@ fi
 # PATHS_REGEX), never a valid "never run on PRs" request, so fail LOUD (a red
 # decide step) instead of a false green. Every real caller passes at least one
 # trigger, so this only fires on the mistake it is meant to catch.
-if [[ -z "$PATHS_REGEX" && -z "$PYTEST_TARGETS" && -z "$TRIGGER_KEYWORD" && -z "$HELDOUT_KEYWORD" ]]; then
-  echo "::error::decide-reusable-diff: no PATHS_REGEX, PYTEST_TARGETS, TRIGGER_KEYWORD, or HELDOUT_KEYWORD is set — a gate with no trigger can only skip. Check for a mistyped env key." >&2
+if [[ -z "$PATHS_REGEX" && -z "$PYTEST_TARGETS" && -z "$SHELL_TARGETS" && -z "$TRIGGER_KEYWORD" ]]; then
+  echo "::error::decide-reusable-diff: no PATHS_REGEX, PYTEST_TARGETS, SHELL_TARGETS, or TRIGGER_KEYWORD is set — a gate with no trigger can only skip. Check for a mistyped env key." >&2
   exit 1
 fi
 # This refusal is what defers a skip-on-draft caller's expensive jobs until the
@@ -73,7 +72,6 @@ fi
 if decide_draft_skip; then
   echo "draft PR — deferring until ready for review"
   echo "run=false" >>"$GITHUB_OUTPUT"
-  echo "heldout=false" >>"$GITHUB_OUTPUT"
   exit 0
 fi
 # Re-anchor to the LIVE base branch tip. The pull_request webhook's base.sha is a
@@ -118,19 +116,26 @@ if [[ "${KEYWORD_SCOPE:-range}" == head ]]; then
 else
   subjects="$(git log --format='%s' "$BASE_SHA..$HEAD_SHA")"
 fi
-# Derived watched paths: the files pytest executes when it collects the caller's
-# test targets, computed from their own import lines rather than restated here.
-# Failing RED on a bad target, never falling back to the regex alone: a silently
-# empty closure would drop exactly the paths this input exists to cover, which is
-# the false-green the caller opted in to prevent.
-PYTEST_CLOSURE=""
-if [[ -n "$PYTEST_TARGETS" ]]; then
-  read -ra pytest_targets <<<"$PYTEST_TARGETS"
-  if ! PYTEST_CLOSURE="$(python3 "$HERE/pytest-import-closure.py" "${pytest_targets[@]}")"; then
-    echo "::error::decide-reusable-diff: could not derive the pytest import closure for '$PYTEST_TARGETS'" >&2
+# DERIVED watched paths: the files the caller's own entry points reach, computed
+# from those files' text rather than restated in the regex. pytest-targets gives
+# the collection-time import closure of a test; shell-targets gives what a shell
+# entry point can run. Both fail RED on a bad target and never fall back to the
+# regex alone: a silently empty closure would drop exactly the paths the input
+# exists to cover, which is the false green the caller opted in to prevent.
+DERIVED_CLOSURE=""
+derive() {
+  local _script="$1" _targets="$2" _what="$3" _out
+  local -a _argv=()
+  [[ -n "$_targets" ]] || return 0
+  read -ra _argv <<<"$_targets"
+  if ! _out="$(python3 "$HERE/$_script" "${_argv[@]}")"; then
+    echo "::error::decide-reusable-diff: could not derive the $_what for '$_targets'" >&2
     exit 1
   fi
-fi
+  DERIVED_CLOSURE+="${_out}"$'\n'
+}
+derive pytest-import-closure.py "$PYTEST_TARGETS" "pytest import closure"
+derive shell-run-closure.py "$SHELL_TARGETS" "shell run closure"
 # paths_trigger CHANGED — the gate's verdict for one changed-file list, on stdout:
 #   true          a watched path changed, so the gate fires
 #   comment-only  a watched path changed, but the diff is comment/blank churn
@@ -150,9 +155,9 @@ paths_trigger() {
   if [[ -n "$PATHS_REGEX" ]]; then
     mapfile -t _matched < <(path_gate_matching_lines "$PATHS_REGEX" "$_changed")
   fi
-  if [[ -n "$PYTEST_TARGETS" ]]; then
+  if [[ -n "$DERIVED_CLOSURE" ]]; then
     mapfile -t -O "${#_matched[@]}" _matched < <(
-      grep -Fxf <(printf '%s\n' "$PYTEST_CLOSURE") <<<"$_changed" || true
+      grep -Fxf <(printf '%s\n' "$DERIVED_CLOSURE") <<<"$_changed" || true
     )
   fi
   ((${#_matched[@]} > 0)) || return 0
@@ -210,11 +215,4 @@ if [[ -n "$TRIGGER_KEYWORD" ]] && grep -qiF "$TRIGGER_KEYWORD" <<<"$subjects"; t
   run=true
   echo "trigger: $TRIGGER_KEYWORD in a commit title"
 fi
-heldout=false
-if [[ -n "$HELDOUT_KEYWORD" ]] && grep -qiF "$HELDOUT_KEYWORD" <<<"$subjects"; then
-  heldout=true
-  run=true
-  echo "trigger: $HELDOUT_KEYWORD — gate will include the frozen held-out split"
-fi
 echo "run=$run" >>"$GITHUB_OUTPUT"
-echo "heldout=$heldout" >>"$GITHUB_OUTPUT"

--- a/.github/scripts/shell-run-closure.py
+++ b/.github/scripts/shell-run-closure.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Print every in-repo file the given shell entry points can reach.
+
+PROBLEM CLASS — a job's declared trigger paths disagreeing with what the job
+actually runs, silently. A decide-gated workflow states its inputs as a
+`paths-regex`, which is a hand-written second spelling of a fact the scripts
+already state in their own text. When the two disagree nothing fails: the decide
+job says run=false, the work job skips, and report-job-result counts the skip as
+a pass, so a required check reports green without running. This module is the one
+definition of "what a shell entry point depends on", so a caller derives it
+instead of retyping it. Its Python twin is pytest-import-closure.py.
+
+WHY IT READS MENTIONS RATHER THAN PARSING COMMANDS. A lifecycle script EXECUTES
+its dependencies (`.hooks/pre-commit`) as often as it `source`s them, and the two
+look nothing alike to a parser, so a source-only closure comes back empty on the
+very entry point this exists for. Both forms do share one property: the path is
+written in the file. So this collects every token that names an existing in-repo
+file and recurses into the ones that are shell.
+
+That over-approximates, and the direction is the point. A path the script names
+but never runs costs one wasted job run. A path the script runs but never names —
+a target assembled from variables — is invisible here, so the caller keeps a
+`paths-regex` beside this input and the two are a UNION, never a replacement.
+Every doubt in this module therefore adds a path rather than dropping one.
+
+Stdlib only: the decide job runs on a bare runner with no virtualenv. It never
+executes, imports or sources what it reads.
+
+Usage: shell-run-closure.py <entry-point>...
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# A path-like run of characters. Quotes, `$`, and whitespace end it, so a token
+# built by expansion (`"$dir/tool.sh"`) yields at most its literal tail and never
+# a wrong file — the tail simply fails the tracked-file check below. The leading
+# dot is what reaches this tree's dot-directories (`.hooks/`, `.claude/hooks/`),
+# which is where a hook entry point's whole dependency set lives.
+TOKEN = re.compile(r"[A-Za-z0-9_.][A-Za-z0-9_./-]*")
+
+# Extensions whose files are read as shell, plus a shebang check for the
+# extensionless entry points (.hooks/pre-commit) that make up most of a hook tree.
+SHELL_SUFFIXES = (".sh", ".bash")
+
+
+def tracked_files() -> set[str]:
+    """Every path git tracks, as repo-relative strings.
+
+    Git's index is the authority on what is in the repo, so a build artifact or a
+    scratch file sharing a name with a real script cannot enter a closure.
+    """
+    listing = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return {entry for entry in listing.split("\0") if entry}
+
+
+def is_shell(rel: str) -> bool:
+    """True when `rel` should be scanned for further paths."""
+    if rel.endswith(SHELL_SUFFIXES):
+        return True
+    return (REPO_ROOT / rel).read_bytes()[:2] == b"#!"
+
+
+def candidates(token: str):
+    """`token` and each of its path suffixes, longest first.
+
+    A script names most of its dependencies through a root variable —
+    `"$git_root/.github/scripts/check-symlinks.sh"` — so the literal that survives
+    expansion is a SUFFIX of the token, never the whole of it. Yielding the
+    suffixes is what reaches those; a suffix that names no tracked file is simply
+    dropped by the caller.
+    """
+    trimmed = token.rstrip("./-").removeprefix("./")
+    yield trimmed
+    for index, char in enumerate(trimmed):
+        if char == "/":
+            yield trimmed[index + 1 :]
+
+
+def mentioned_paths(rel: str, tracked: set[str]) -> set[str]:
+    """The tracked files named anywhere in `rel`'s text."""
+    text = (REPO_ROOT / rel).read_text(encoding="utf-8", errors="replace")
+    found = set()
+    for match in TOKEN.finditer(text):
+        for candidate in candidates(match.group(0)):
+            if candidate in tracked and candidate != rel:
+                found.add(candidate)
+    return found
+
+
+def closure(entries: list[str]) -> list[str]:
+    """Every tracked file reachable from `entries`, entries included."""
+    tracked = tracked_files()
+    for entry in entries:
+        if entry not in tracked:
+            raise SystemExit(f"shell-run-closure: {entry} is not tracked in this repo")
+    seen: set[str] = set()
+    queue = list(entries)
+    while queue:
+        rel = queue.pop()
+        if rel in seen:
+            continue
+        seen.add(rel)
+        if not is_shell(rel):
+            continue
+        queue.extend(mentioned_paths(rel, tracked) - seen)
+    return sorted(seen)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: shell-run-closure.py <entry-point>...")
+    print("\n".join(closure(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/decide-reusable.yaml
+++ b/.github/workflows/decide-reusable.yaml
@@ -22,6 +22,10 @@ on:
         type: string
         default: ""
         description: "Space-separated pytest files this gate's job runs. The decide job derives their collection-time import closure (.github/scripts/pytest-import-closure.py) and treats every member as a watched path, so a caller states its test dependencies once — in the test's own import lines — instead of retyping them into paths-regex, where the copy drifts silently. Combines with paths-regex (either one matching sets run=true); a target that does not exist fails the decide job red"
+      shell-targets:
+        type: string
+        default: ""
+        description: "Space-separated shell entry points this gate's job runs. The decide job derives every in-repo file they can reach (.github/scripts/shell-run-closure.py) and treats each as a watched path, so a caller states its script dependencies once — in the scripts' own text — instead of retyping them into paths-regex, where the copy drifts silently. The derivation over-approximates and cannot see a path built from variables, so it combines with paths-regex rather than replacing it; a target that is not tracked fails the decide job red"
       trigger-keyword:
         type: string
         default: ""
@@ -29,11 +33,7 @@ on:
       keyword-scope:
         type: string
         default: "range"
-        description: "Where to scan for the trigger/heldout keyword: 'range' (every commit in the PR, the default) or 'head' (only the head commit, so the keyword fires once for the commit it tags and not on later untagged pushes)"
-      heldout-keyword:
-        type: string
-        default: ""
-        description: "Keyword in any commit title (subject line) that sets heldout=true (implies run=true)"
+        description: "Where to scan for the trigger keyword: 'range' (every commit in the PR, the default) or 'head' (only the head commit, so the keyword fires once for the commit it tags and not on later untagged pushes)"
       skip-on-draft:
         type: boolean
         default: false
@@ -80,9 +80,6 @@ on:
       run:
         description: "Whether the gate/track job should run"
         value: ${{ jobs.decide.outputs.run }}
-      heldout:
-        description: "Whether the frozen held-out split was requested"
-        value: ${{ jobs.decide.outputs.heldout }}
 
 # EVERY CALLER'S `decide` JOB MUST GRANT THESE THREE. A called workflow may only
 # request permissions the calling job already holds, and a caller that grants
@@ -106,7 +103,6 @@ jobs:
     timeout-minutes: 10
     outputs:
       run: ${{ steps.check.outputs.run }}
-      heldout: ${{ steps.check.outputs.heldout }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -134,8 +130,8 @@ jobs:
           PATHS_REGEX: ${{ inputs.paths-regex }}
           PATHS_REGEX_FILE: ${{ inputs.paths-regex-file }}
           PYTEST_TARGETS: ${{ inputs.pytest-targets }}
+          SHELL_TARGETS: ${{ inputs.shell-targets }}
           TRIGGER_KEYWORD: ${{ inputs.trigger-keyword }}
-          HELDOUT_KEYWORD: ${{ inputs.heldout-keyword }}
           KEYWORD_SCOPE: ${{ inputs.keyword-scope }}
           IGNORE_COMMENT_ONLY: ${{ inputs.ignore-comment-only-changes }}
           SKIP_ON_DRAFT: ${{ inputs.skip-on-draft }}

--- a/.github/workflows/hook-lifecycle.yaml
+++ b/.github/workflows/hook-lifecycle.yaml
@@ -23,8 +23,14 @@ jobs:
       actions: read # its memo shadow lists this workflow's past runs (needed in a private fork)
     uses: ./.github/workflows/decide-reusable.yaml
     with:
+      # Most of this gate's watched set is DERIVED from the entry point below, so
+      # it cannot drift out of date. The regex carries only what the derivation
+      # cannot see: a path this job's tooling reads without any script naming it,
+      # and the composite action, which is YAML rather than shell.
       # POSIX ERE, read by `grep -E` — no PCRE escapes (\d, \w, (?:…)).
-      paths-regex: '^(\.claude/hooks/|\.hooks/|setup\.sh$|package\.json$|pnpm-lock\.yaml$|pyproject\.toml$|uv\.lock$|\.pre-commit-config\.yaml$|\.github/scripts/run-hook-lifecycle\.sh$|\.github/scripts/check-symlinks\.sh$|\.github/actions/setup-base-env/|\.github/workflows/hook-lifecycle\.yaml$)'
+      paths-regex: '^(\.claude/hooks/|\.hooks/|setup\.sh$|pnpm-lock\.yaml$|\.github/actions/setup-base-env/)'
+      # path-gate-ok: .github/scripts/run-hook-lifecycle.sh it is the shell-targets entry point below, so the decide job derives it and everything it reaches
+      shell-targets: .github/scripts/run-hook-lifecycle.sh
       # The lifecycle run is a behavior test, so a comment-only touch of a watched
       # file cannot change its outcome. Never set this on a lint/format/type gate,
       # where a directive comment IS behavior.
@@ -49,6 +55,7 @@ jobs:
         with:
           setup-python: "true"
 
+      # path-gate-ok: .github/scripts/run-hook-lifecycle.sh the decide job watches it through shell-targets, which derives it and everything it reaches; the checker reads paths-regex only
       - name: Run hook lifecycle
         run: bash .github/scripts/run-hook-lifecycle.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ the prose from the release's commits.
 
 ### Added
 
+- `shell-targets`, a decide-gate input that DERIVES a gate's watched paths from
+  the shell entry point the job runs, instead of restating them in `paths-regex`
+  where the copy drifts silently. `.github/scripts/shell-run-closure.py` walks
+  every in-repo file the entry point can reach, following the paths it EXECUTES
+  as well as those it sources, and reaching a target written as
+  `"$root/path/to/x.sh"` through the token's path suffix. It over-approximates
+  on purpose, so it combines with `paths-regex` rather than replacing it.
 - Three skills ported from the downstream `agent-glovebox` tree: `git-workflow`
   (commit/push mechanics, who owns a merge conflict, auditing a bot's merge
   delta), `babysit-prs` (watch sets, mergeability and merge-queue state,
@@ -30,9 +37,9 @@ the prose from the release's commits.
 - The `decide` reusable workflow diffs the change range itself instead of calling
   `dorny/paths-filter`, and gains the inputs that go with it: `paths-regex`,
   `paths-regex-file` (an SSOT a local git hook can source too), `pytest-targets`
-  (watched paths derived from a test's own import lines), `trigger-keyword` /
-  `heldout-keyword`, `keyword-scope`, `skip-on-draft`,
-  `ignore-comment-only-changes`, and `memoize-anchor-jobs`. It now gates `push`
+  (watched paths derived from a test's own import lines), `trigger-keyword`,
+  `keyword-scope`, `skip-on-draft`, `ignore-comment-only-changes`,
+  `shell-targets`, and `memoize-anchor-jobs`. It now gates `push`
   and `merge_group` events on their own ranges, re-anchors a stale webhook base
   to the live base tip so a merge commit stops over-triggering every gate, and
   fails loud on a gate configured with no trigger at all.

--- a/tests/test_decide_reusable_diff.py
+++ b/tests/test_decide_reusable_diff.py
@@ -16,10 +16,13 @@ rather than only on a fast box.
 """
 
 import os
+import re
 import shutil
 import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+
+import yaml
 
 from tests._fake_gh import run_jobs, workflow_runs, write_gh_stub
 from tests._helpers import REPO_ROOT, git_out, init_test_repo, run_capture
@@ -556,9 +559,11 @@ def test_bad_pytest_target_fails_red(tmp_path: Path) -> None:
 
 
 SHELL_TARGET = ".github/scripts/run-hook-lifecycle.sh"
-# The lifecycle script EXECUTES this rather than sourcing it, and no gate regex
-# in the tree names it — so it is only watched because the closure derives it.
-SHELL_CLOSURE_MEMBER = ".hooks/lib-gate.sh"
+# The lifecycle runs this through `.hooks/pre-push`, which names it only as
+# `"$git_root/.github/scripts/check-symlinks.sh"` — so the closure reaches it
+# through the token's path SUFFIX. hook-lifecycle.yaml's own paths-regex no
+# longer names it either, making it genuinely closure-only coverage.
+SHELL_CLOSURE_MEMBER = ".github/scripts/check-symlinks.sh"
 
 
 def test_shell_targets_fire_on_a_script_the_regex_does_not_name(
@@ -566,7 +571,8 @@ def test_shell_targets_fire_on_a_script_the_regex_does_not_name(
 ) -> None:
     """A file the entry point reaches triggers the gate even though no alternative
     of the regex names it. Non-vacuity — the same diff with shell-targets unset
-    must NOT fire, which is the silent green this input removes."""
+    must NOT fire, which is the silent green this input removes. The member is
+    also reached only through a token suffix, so a whole-token match fails here."""
     diff = _flood(tmp_path / "diff.txt", SHELL_CLOSURE_MEMBER)
     skipped = _run(tmp_path, PATHS_REGEX="^docs/", FAKE_DIFF_FILE=str(diff))
     assert "run=false" in skipped, skipped
@@ -579,19 +585,19 @@ def test_shell_targets_fire_on_a_script_the_regex_does_not_name(
     assert "run=true" in fired, fired
 
 
-def test_shell_targets_reach_a_path_built_from_a_root_variable(
-    tmp_path: Path,
-) -> None:
-    """`.hooks/pre-push` names check-symlinks.sh only as `"$git_root/…"`, so the
-    closure finds it through the token's path SUFFIX. Without that the gate would
-    skip exactly when the script it runs changed."""
-    diff = _flood(tmp_path / "diff.txt", ".github/scripts/check-symlinks.sh")
-    output = _run(
-        tmp_path,
-        SHELL_TARGETS=SHELL_TARGET,
-        FAKE_DIFF_FILE=str(diff),
+def test_the_hook_lifecycle_gate_watches_its_closure_member_only_by_derivation() -> (
+    None
+):
+    """The comment above SHELL_CLOSURE_MEMBER claims hook-lifecycle's own regex
+    does not name that file, which is what makes the case above non-vacuous for
+    the REAL gate rather than only for the test's `^docs/`. Assert it, because a
+    later widening of that regex would quietly turn the claim false."""
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "hook-lifecycle.yaml").read_text()
     )
-    assert "run=true" in output, output
+    gate = workflow["jobs"]["decide"]["with"]
+    assert SHELL_TARGET in gate["shell-targets"].split()
+    assert not re.search(gate["paths-regex"], SHELL_CLOSURE_MEMBER)
 
 
 def test_shell_targets_do_not_fire_on_an_unrelated_file(tmp_path: Path) -> None:

--- a/tests/test_decide_reusable_diff.py
+++ b/tests/test_decide_reusable_diff.py
@@ -16,6 +16,7 @@ rather than only on a fast box.
 """
 
 import os
+import shutil
 import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -30,10 +31,20 @@ FLOOD_LINES = 50_000
 def _fakegit_out(tmp_path: Path) -> None:
     """A `git` stub that `exec cat`s the flood file for `log`/`diff` (so a
     SIGPIPE-killed cat makes the git process exit non-zero, exactly as real git
-    does), and emits nothing for an unset stream."""
+    does), and emits nothing for an unset stream.
+
+    `ls-files` reaches the REAL git by absolute path. The stub sits first on PATH,
+    so it answers for every process the script starts, and `shell-run-closure.py`
+    asks git which files the repo tracks — a question this fixture has no business
+    answering. Everything else keeps the catch-all `exit 0`, which is what lets
+    the fake `base`/`head` SHAs pass the script's own range checks.
+    """
+    real_git = shutil.which("git")
+    assert real_git, "the tests drive real git for everything the stub does not fake"
     git = tmp_path / "git"
     git.write_text(
         "#!/usr/bin/env bash\n"
+        f'case " $* " in *" ls-files "*) exec {real_git} "$@" ;; esac\n'
         'case "$1" in\n'
         '  log)  [[ -n "${FAKE_LOG_FILE:-}" ]] && exec cat "$FAKE_LOG_FILE" ;;\n'
         '  diff) [[ -n "${FAKE_DIFF_FILE:-}" ]] && exec cat "$FAKE_DIFF_FILE" ;;\n'
@@ -64,7 +75,6 @@ def _run_raw(tmp_path: Path, **env_overrides: str) -> subprocess.CompletedProces
         "HEAD_SHA": "head",
         "PATHS_REGEX": "",
         "TRIGGER_KEYWORD": "",
-        "HELDOUT_KEYWORD": "",
         "GITHUB_OUTPUT": str(out),
     }
     env.update(env_overrides)
@@ -82,13 +92,6 @@ def test_keyword_trigger_fires_when_match_precedes_a_large_log(tmp_path: Path) -
     log = _flood(tmp_path / "log.txt", "fix(hooks): rerun [full-lifecycle]")
     output = _run(tmp_path, TRIGGER_KEYWORD="[full-lifecycle]", FAKE_LOG_FILE=str(log))
     assert "run=true" in output, output
-
-
-def test_heldout_keyword_fires_when_match_precedes_a_large_log(tmp_path: Path) -> None:
-    log = _flood(tmp_path / "log.txt", "eval: refresh [heldout]")
-    output = _run(tmp_path, HELDOUT_KEYWORD="[heldout]", FAKE_LOG_FILE=str(log))
-    assert "run=true" in output, output
-    assert "heldout=true" in output, output
 
 
 def test_paths_trigger_fires_when_match_precedes_a_large_diff(tmp_path: Path) -> None:
@@ -141,12 +144,10 @@ def test_no_match_does_not_trigger(tmp_path: Path) -> None:
         tmp_path,
         PATHS_REGEX=r"^\.claude/hooks/",
         TRIGGER_KEYWORD="[full-lifecycle]",
-        HELDOUT_KEYWORD="[heldout]",
         FAKE_LOG_FILE=str(log),
         FAKE_DIFF_FILE=str(diff),
     )
     assert "run=false" in output, output
-    assert "heldout=false" in output, output
 
 
 def test_paths_regex_file_resolves_the_ssot_regex(tmp_path: Path) -> None:
@@ -211,7 +212,7 @@ def test_no_trigger_configured_on_real_diff_fails_loud(tmp_path: Path) -> None:
     assert res.returncode == 1, res.stdout + res.stderr
     assert "no PATHS_REGEX" in res.stderr, res.stderr
     assert (tmp_path / "gh_output").read_text(encoding="utf-8") == "", (
-        "must not emit a run/heldout verdict on misconfig"
+        "must not emit a run verdict on misconfig"
     )
 
 
@@ -234,7 +235,6 @@ def _run_realgit(
         "HEAD_SHA": "",
         "PATHS_REGEX": "",
         "TRIGGER_KEYWORD": "",
-        "HELDOUT_KEYWORD": "",
         "GITHUB_OUTPUT": str(out),
     }
     env.update(env_overrides)
@@ -553,6 +553,85 @@ def test_bad_pytest_target_fails_red(tmp_path: Path) -> None:
     )
     assert r.returncode != 0, r.stdout
     assert "import closure" in r.stderr
+
+
+SHELL_TARGET = ".github/scripts/run-hook-lifecycle.sh"
+# The lifecycle script EXECUTES this rather than sourcing it, and no gate regex
+# in the tree names it — so it is only watched because the closure derives it.
+SHELL_CLOSURE_MEMBER = ".hooks/lib-gate.sh"
+
+
+def test_shell_targets_fire_on_a_script_the_regex_does_not_name(
+    tmp_path: Path,
+) -> None:
+    """A file the entry point reaches triggers the gate even though no alternative
+    of the regex names it. Non-vacuity — the same diff with shell-targets unset
+    must NOT fire, which is the silent green this input removes."""
+    diff = _flood(tmp_path / "diff.txt", SHELL_CLOSURE_MEMBER)
+    skipped = _run(tmp_path, PATHS_REGEX="^docs/", FAKE_DIFF_FILE=str(diff))
+    assert "run=false" in skipped, skipped
+    fired = _run(
+        tmp_path,
+        PATHS_REGEX="^docs/",
+        SHELL_TARGETS=SHELL_TARGET,
+        FAKE_DIFF_FILE=str(diff),
+    )
+    assert "run=true" in fired, fired
+
+
+def test_shell_targets_reach_a_path_built_from_a_root_variable(
+    tmp_path: Path,
+) -> None:
+    """`.hooks/pre-push` names check-symlinks.sh only as `"$git_root/…"`, so the
+    closure finds it through the token's path SUFFIX. Without that the gate would
+    skip exactly when the script it runs changed."""
+    diff = _flood(tmp_path / "diff.txt", ".github/scripts/check-symlinks.sh")
+    output = _run(
+        tmp_path,
+        SHELL_TARGETS=SHELL_TARGET,
+        FAKE_DIFF_FILE=str(diff),
+    )
+    assert "run=true" in output, output
+
+
+def test_shell_targets_do_not_fire_on_an_unrelated_file(tmp_path: Path) -> None:
+    diff = _flood(tmp_path / "diff.txt", "docs/readme.md")
+    output = _run(tmp_path, SHELL_TARGETS=SHELL_TARGET, FAKE_DIFF_FILE=str(diff))
+    assert "run=false" in output, output
+
+
+def test_shell_targets_alone_satisfy_the_trigger_check(tmp_path: Path) -> None:
+    """A caller may derive ALL its paths, so shell-targets counts as a configured
+    trigger — without this the no-trigger guard would red every such gate."""
+    diff = _flood(tmp_path / "diff.txt", SHELL_CLOSURE_MEMBER)
+    output = _run(tmp_path, SHELL_TARGETS=SHELL_TARGET, FAKE_DIFF_FILE=str(diff))
+    assert "run=true" in output, output
+
+
+def test_untracked_shell_target_fails_red(tmp_path: Path) -> None:
+    """A closure that cannot be derived must red the decide job, never fall back
+    to the regex alone."""
+    diff = _flood(tmp_path / "diff.txt", SHELL_CLOSURE_MEMBER)
+    r = _run_raw(
+        tmp_path,
+        PATHS_REGEX="^docs/",
+        SHELL_TARGETS=".github/scripts/does-not-exist.sh",
+        FAKE_DIFF_FILE=str(diff),
+    )
+    assert r.returncode != 0, r.stdout
+    assert "shell run closure" in r.stderr
+
+
+def test_both_closures_contribute_together(tmp_path: Path) -> None:
+    """pytest-targets and shell-targets are a union: a member of either fires."""
+    diff = _flood(tmp_path / "diff.txt", CLOSURE_MEMBER)
+    output = _run(
+        tmp_path,
+        PYTEST_TARGETS=PYTEST_TARGET,
+        SHELL_TARGETS=SHELL_TARGET,
+        FAKE_DIFF_FILE=str(diff),
+    )
+    assert "run=true" in output, output
 
 
 def test_regex_and_pytest_targets_both_contribute(tmp_path: Path) -> None:


### PR DESCRIPTION
## What & why

`paths-regex` is a hand-written second spelling of a fact the scripts already state in their own text, and when the two disagree nothing fails: the decide job says `run=false`, the work job skips, and the reporter counts the skip as a pass. `pytest-targets` removed that copy for Python. **`shell-targets` does it for shell.**

`shell-run-closure.py` walks every in-repo file a shell entry point can reach, and `hook-lifecycle` now derives 14 watched paths instead of listing them.

Two things the obvious implementation gets wrong, both observed on this tree's own entry point:

- It follows what a script **executes**, not only what it sources. `run-hook-lifecycle.sh` runs `.hooks/pre-commit` rather than sourcing it, so a source-only walk returns the entry point and nothing else.
- It matches a token's path **suffixes**. `.hooks/pre-push` names its dependency as `"$git_root/.github/scripts/check-symlinks.sh"`, so the literal that survives expansion is never the whole token.

It over-approximates on purpose: a path named but never run costs one wasted job run, while a path built entirely from variables is invisible to it. So the input **combines** with `paths-regex` and never replaces it — `hook-lifecycle` keeps a regex for `setup.sh`, `pnpm-lock.yaml`, the two hook directories, and the composite action.

This also drops `heldout-keyword` and the `heldout` output, which the automated reviewer flagged on [#453](https://github.com/AlexanderMattTurner/claude-automation-template/pull/453): a knob wired to an eval job this template does not have, with no caller passing or reading it. That review landed after #453 auto-merged, so the change comes here.

## Review focus

`.github/scripts/shell-run-closure.py`, and specifically whether the over-approximation is really the safe direction — a path this walk invents costs a run, a path it misses costs a false green. Its failure mode is the one the whole gate exists to prevent, so it is worth checking that the `paths-regex` beside it still covers what the walk cannot see.

## Decisions made

- **A mention scan, not a command parser.** Following execution properly would mean resolving command position in bash, which needs a grammar and a `tree-sitter` dependency the decide job's bare runner does not have. Every dependency a script runs is written in the file, so scanning mentions finds a superset at zero dependency cost. The alternative buys precision this gate does not want.
- **`git ls-files` is the authority on what is in the repo**, so a build artifact sharing a name with a real script cannot enter a closure.
- **The `check-path-gate-deps` violation is suppressed, not satisfied.** That checker reads `paths-regex` only, so it cannot see a derived path and reports the entry point as uncovered. The `# path-gate-ok:` line names where the coverage actually comes from.

## How it was tested

`uv run pytest tests/test_decide_reusable_diff.py tests/test_decide_memo_base.py -q` — 51 passed, 5 of them new for `shell-targets`.

<details>
<summary>Detail</summary>

**Non-vacuity.** `test_shell_targets_fire_on_a_script_the_regex_does_not_name` asserts the same diff does NOT fire with the input unset, so the input is what flips the verdict. Its fixture is `check-symlinks.sh`, which carries both properties at once: this PR drops it from `hook-lifecycle`'s regex, and the closure reaches it only through the `"$git_root/…"` token suffix, so a whole-token match fails the case.

**That claim has its own checker.** The first version of the fixture used `.hooks/lib-gate.sh`, which the gate's `\.hooks/` alternative matches — the comment was wrong and the reviewer caught it. `test_the_hook_lifecycle_gate_watches_its_closure_member_only_by_derivation` now parses `hook-lifecycle.yaml` and requires that its `paths-regex` does not match the member and that its `shell-targets` names the entry point.

**Observed closure** for `.github/scripts/run-hook-lifecycle.sh`, 14 files: `.claude/hooks/pre-push-check.sh`, `.claude/hooks/session-setup.sh`, `.github/scripts/check-symlinks.sh`, `.github/scripts/run-hook-lifecycle.sh`, `.github/workflows/hook-lifecycle.yaml`, `.github/workflows/pre-commit.yaml`, `.hooks/lib-gate.sh`, `.hooks/pre-commit`, `.hooks/pre-push`, `.pre-commit-config.yaml`, `package.json`, `pyproject.toml`, `tests/test_version_sync.py`, `uv.lock`. The last is an over-inclusion — the lifecycle never runs that test — and it costs a run, which is the direction this is built to fail in.

**A fixture bug this surfaced.** The tests' fake `git` sat first on PATH and answered every subcommand with exit 0, so `git ls-files` came back empty and every closure was empty. It now passes `ls-files` through to the real binary and keeps the catch-all for the rest, which is what lets the fake `base`/`head` SHAs still pass the script's range checks.

**Not run here:** the `lychee` pre-commit hook, for the reason recorded on #453 — its `cargo-binstall` install resolves through `api.github.com/graphql`, which this session's egress proxy answers 403. CI runs `pre-commit run --all-files`.

</details>
