### PR TITLE
feat(hooks): deny a gated action until its skill has been invoked

### DIFF
--- a/.claude/hooks/gate-plan-skill.mjs
+++ b/.claude/hooks/gate-plan-skill.mjs
@@ -1,0 +1,125 @@
+/**
+ * PreToolUse reminder: writing a formal plan requires the `explore-plan` skill to
+ * have been invoked in this session. Nothing announces "I am planning now", so
+ * the session slides into the activity and never calls the skill.
+ *
+ * Covers both homes CLAUDE.md sanctions for a plan — a scratch FILE and an ISSUE
+ * — because locking one door routes the session through the other.
+ *
+ * A REMINDER, not a containment boundary: it checks that the Skill tool was
+ * called, and it recognizes a plan by its NAME. Out of scope by design, not by
+ * omission: a plan in a file whose name does not say "plan", a plan pasted into
+ * chat or a PR body, an editor outside the session, and a `TodoWrite` checklist.
+ */
+import { createSkillGate, GH_AT_COMMAND_POSITION } from "./lib-skill-gate.mjs";
+
+/** The skill whose invocation this reminder requires. */
+export const REQUIRED_SKILL = "explore-plan";
+
+/**
+ * Extensions a prose plan is written in; the empty string covers an
+ * extension-less scratch file. Prose only, which keeps a `shard-plan.py` or a
+ * `build-plan.sh` — code that BUILDS a plan — out of a gate about WRITING one.
+ */
+const PLAN_EXTENSIONS = new Set(["", "md", "markdown", "txt"]);
+
+/** The tools that write a file's contents. */
+const WRITE_TOOLS = new Set(["Write", "Edit"]);
+
+/** Suffix-matched: the same tool arrives under any mount point the server takes. */
+const ISSUE_MCP_TOOL_RE = /^mcp__.*(?:issue_write|create_issue)$/;
+
+/** The CLI spelling of the same issue. The anchor keeps a quoted MENTION out. */
+const GH_ISSUE_CREATE_RE = new RegExp(
+  GH_AT_COMMAND_POSITION + String.raw`issue\s+create\b`,
+);
+
+/**
+ * Does this text carry "plan" as a WORD? Split rather than substring-searched,
+ * because `explanation` contains `plan` and firing on it teaches the session
+ * that the gate is noise.
+ * @param {unknown} text @returns {boolean}
+ */
+export function namesAPlan(text) {
+  if (typeof text !== "string") return false;
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .some((word) => word === "plan" || word === "plans");
+}
+
+/**
+ * Is this path a plan document? Judged on the BASENAME alone, because matching a
+ * directory would make every edit under `.claude/skills/explore-plan/` demand
+ * the skill.
+ * @param {unknown} filePath @returns {boolean}
+ */
+export function isPlanFile(filePath) {
+  if (typeof filePath !== "string") return false;
+  const base = filePath.slice(filePath.lastIndexOf("/") + 1);
+  const dot = base.lastIndexOf(".");
+  const stem = dot > 0 ? base.slice(0, dot) : base;
+  const ext = dot > 0 ? base.slice(dot + 1).toLowerCase() : "";
+  return PLAN_EXTENSIONS.has(ext) && namesAPlan(stem);
+}
+
+/**
+ * Does this payload open a plan issue, by either spelling? A terminal session
+ * takes the CLI route and a web session the MCP route, so covering one moves the
+ * session to the other.
+ *
+ * Only `create`: an update carries no title to read. The CLI arm reads the whole
+ * command rather than the `--title` argument, which needs no shell parser and
+ * errs toward the reminder rather than the miss.
+ * @param {any} payload @returns {boolean}
+ */
+function createsPlanIssue(payload) {
+  if (payload.tool_name === "Bash") {
+    const command = payload.tool_input?.command;
+    return (
+      typeof command === "string" &&
+      GH_ISSUE_CREATE_RE.test(command) &&
+      namesAPlan(command)
+    );
+  }
+  if (!ISSUE_MCP_TOOL_RE.test(payload.tool_name)) return false;
+  const { method, title } = payload.tool_input ?? {};
+  if (typeof method === "string" && method !== "create") return false;
+  return namesAPlan(title);
+}
+
+/**
+ * Does this payload write a formal plan, by any covered route?
+ * @param {any} payload @returns {boolean}
+ */
+export function writesFormalPlan(payload) {
+  if (typeof payload?.tool_name !== "string") return false;
+  if (WRITE_TOOLS.has(payload.tool_name))
+    return isPlanFile(payload?.tool_input?.file_path);
+  return createsPlanIssue(payload);
+}
+
+/**
+ * The deny text. It names the step to take and nothing else, because a message
+ * that names a way around the gate hands a workaround to the agent it blocked.
+ * @param {string} toolName @returns {string}
+ */
+export function denyReason(toolName) {
+  return (
+    `Writing a formal plan requires the \`${REQUIRED_SKILL}\` skill, not ` +
+    `invoked in this session (blocked: ${toolName}). Call the Skill tool with ` +
+    `skill="${REQUIRED_SKILL}", follow it — above all the delete-toward verdict ` +
+    `on every constraint and the critique pass to a fixed point — then retry ` +
+    `this exact call. It will be allowed.`
+  );
+}
+
+/**
+ * A deny reason for this payload, or null to pass.
+ * @type {(payload: any) => string|null}
+ */
+export const judgePlanSkill = createSkillGate({
+  skill: REQUIRED_SKILL,
+  triggered: writesFormalPlan,
+  reason: denyReason,
+});

--- a/.claude/hooks/gate-pr-skill.mjs
+++ b/.claude/hooks/gate-pr-skill.mjs
@@ -1,0 +1,73 @@
+/**
+ * PreToolUse reminder: opening a pull request requires the `pr-creation` skill to
+ * have been invoked in this session.
+ *
+ * Covers both routes an agent actually reaches for: the `gh pr create` CLI and any
+ * MCP `create_pull_request` tool, whatever server it is mounted under. Locking one of
+ * two equivalent doors just routes the agent through the other, which is what a
+ * Bash-only matcher did in a web session where the MCP tool is the default route.
+ *
+ * A REMINDER, not a containment boundary — which is what bounds its scope. It checks
+ * that the Skill tool was called, not that the compress-critique-fix loop ran, and it
+ * covers only those two tools. Deliberately out of scope, named so nobody reads this
+ * as covering them: `gh api` to `repos/…/pulls` or the `createPullRequest` GraphQL
+ * mutation, `curl` to the same endpoint, a script whose body runs `gh pr create`, the
+ * web UI. Each is some HTTP client, so matching them means matching arbitrary
+ * programs. The deny text claims only the two tools above.
+ */
+import { createSkillGate, GH_AT_COMMAND_POSITION } from "./lib-skill-gate.mjs";
+
+/** The skill whose invocation this reminder requires. */
+export const REQUIRED_SKILL = "pr-creation";
+
+/** Suffix-matched: the same tool arrives as `mcp__github__…` or `mcp__github_remote__…`. */
+const PR_MCP_TOOL_RE = /^mcp__.*create_pull_request$/;
+
+/**
+ * `create\b` counts `create-draft` and not `creates`; the shared anchor rejects
+ * `mygh pr create` and, equally, a quoted MENTION of the command in some other
+ * program's argument.
+ */
+const GH_PR_CREATE_RE = new RegExp(
+  GH_AT_COMMAND_POSITION + String.raw`pr\s+create\b`,
+);
+
+/**
+ * Does this payload open a pull request, by either covered route?
+ * @param {any} payload @returns {boolean}
+ */
+export function createsPullRequest(payload) {
+  if (typeof payload?.tool_name !== "string") return false;
+  if (PR_MCP_TOOL_RE.test(payload.tool_name)) return true;
+  const command = payload?.tool_input?.command;
+  return (
+    payload.tool_name === "Bash" &&
+    typeof command === "string" &&
+    GH_PR_CREATE_RE.test(command)
+  );
+}
+
+/**
+ * The deny text. It names the step to take and nothing else: a message that also
+ * names a way around the gate hands a workaround to the agent it just blocked.
+ * @param {string} toolName @returns {string}
+ */
+export function denyReason(toolName) {
+  return (
+    `Opening a PR requires the \`${REQUIRED_SKILL}\` skill, not invoked in this ` +
+    `session (blocked: ${toolName}). Call the Skill tool with ` +
+    `skill="${REQUIRED_SKILL}", follow it — above all the compress-critique-fix ` +
+    `loop over the diff and the PR body, which is the point of the gate — then ` +
+    `retry this exact call. It will be allowed.`
+  );
+}
+
+/**
+ * A deny reason for this payload, or null to pass.
+ * @type {(payload: any) => string|null}
+ */
+export const judgePrSkill = createSkillGate({
+  skill: REQUIRED_SKILL,
+  triggered: createsPullRequest,
+  reason: denyReason,
+});

--- a/.claude/hooks/gate-tests-skill.mjs
+++ b/.claude/hooks/gate-tests-skill.mjs
@@ -1,0 +1,94 @@
+/**
+ * PreToolUse reminder: editing a test file requires the `writing-tests` skill to
+ * have been invoked in this session.
+ *
+ * The gate exists because the rule it enforces — CLAUDE.md's "invoke it whenever
+ * you touch tests" — is one an agent misses precisely when it matters. Tests
+ * usually arrive as a BYPRODUCT of some other task ("fix this bug"), a few lines
+ * at a time in a file already open for another reason, so nothing in the session
+ * ever presents itself as "I am writing tests now" and the trigger passes unread.
+ *
+ * A REMINDER, not a containment boundary. It checks that the Skill tool was
+ * called, not that the tests that follow are any good, and it covers the two
+ * file-writing tools. Deliberately out of scope, named so nobody reads this as
+ * covering them: a heredoc or `sed -i` through Bash, an MCP filesystem writer, an
+ * editor outside the session. Matching those means matching arbitrary programs,
+ * and this is a nudge at the moment of writing rather than a wall around the
+ * files. The deny text claims only what it covers.
+ */
+import { createSkillGate } from "./lib-skill-gate.mjs";
+
+/** The skill whose invocation this reminder requires. */
+export const REQUIRED_SKILL = "writing-tests";
+
+/**
+ * What counts as a test file. Every entry is a NAMING CONVENTION this repo's
+ * suites actually use, and each is matched on the path's tail so a worktree or
+ * absolute prefix cannot defeat it. Anchored per segment: `test_x.py` must be the
+ * basename, never a substring of `pretest_x.py`.
+ *
+ * The list is the SSOT the test file iterates, so a convention added here without
+ * a case fails there.
+ * @type {ReadonlyArray<{name: string, re: RegExp}>}
+ */
+export const TEST_FILE_PATTERNS = Object.freeze([
+  { name: "pytest module", re: /(?:^|\/)test_[^/]*\.py$/ },
+  { name: "pytest module, suffix spelling", re: /(?:^|\/)[^/]*_test\.py$/ },
+  { name: "node test module", re: /(?:^|\/)[^/]*\.test\.mjs$/ },
+  { name: "pytest conftest", re: /(?:^|\/)conftest\.py$/ },
+  // tests/_helpers.py, tests/_fake_gh.py: the harness modules the suites import.
+  // A change here reaches every suite at once, which is more than any single
+  // test file does.
+  { name: "test harness module", re: /(?:^|\/)tests\/_[^/]*\.py$/ },
+]);
+
+/**
+ * The tools that write a file's contents. `NotebookEdit` is deliberately absent:
+ * no convention above names a `.ipynb`, and this repo tracks no notebooks, so
+ * including it would advertise coverage the gate does not have.
+ */
+const WRITE_TOOLS = new Set(["Write", "Edit"]);
+
+/**
+ * Is this path one of the repo's test files?
+ * @param {unknown} filePath @returns {boolean}
+ */
+export function isTestFile(filePath) {
+  if (typeof filePath !== "string") return false;
+  return TEST_FILE_PATTERNS.some(({ re }) => re.test(filePath));
+}
+
+/**
+ * Does this payload write a test file?
+ * @param {any} payload @returns {boolean}
+ */
+export function editsTestFile(payload) {
+  if (typeof payload?.tool_name !== "string") return false;
+  if (!WRITE_TOOLS.has(payload.tool_name)) return false;
+  return isTestFile(payload?.tool_input?.file_path);
+}
+
+/**
+ * The deny text. It names the step to take and nothing else: a message that also
+ * names a way around the gate hands a workaround to the agent it just blocked.
+ * @param {string} toolName @returns {string}
+ */
+export function denyReason(toolName) {
+  return (
+    `Editing a test file requires the \`${REQUIRED_SKILL}\` skill, not invoked ` +
+    `in this session (blocked: ${toolName}). Call the Skill tool with ` +
+    `skill="${REQUIRED_SKILL}", follow it — above all "test behavior, not ` +
+    `source text" and the non-vacuity check that the test goes RED on the ` +
+    `unfixed code — then retry this exact call. It will be allowed.`
+  );
+}
+
+/**
+ * A deny reason for this payload, or null to pass.
+ * @type {(payload: any) => string|null}
+ */
+export const judgeTestsSkill = createSkillGate({
+  skill: REQUIRED_SKILL,
+  triggered: editsTestFile,
+  reason: denyReason,
+});

--- a/.claude/hooks/lib-hook-io.mjs
+++ b/.claude/hooks/lib-hook-io.mjs
@@ -1,6 +1,42 @@
 /** Shared I/O helpers for Claude Code hook scripts. */
 
+import { closeSync, openSync, unlinkSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+
+/**
+ * Write `content` to `path` without ever following a symlink there.
+ *
+ * PROBLEM CLASS — a hook writing to a PREDICTABLE path in a world-writable
+ * directory. Anything that can create files there can pre-place a symlink at the
+ * name the hook is about to use, and an ordinary write then lands on the link's
+ * target instead. Unlinking first and creating exclusively (`wx`) means the write
+ * either gets a fresh file or gets nothing.
+ *
+ * Returns false rather than throwing, so a caller for whom the write is
+ * best-effort keeps its own control flow.
+ * @param {string} path @param {string} content @param {number} [mode]
+ * @returns {boolean}
+ */
+export function writeFileNoFollow(path, content, mode = 0o600) {
+  try {
+    unlinkSync(path);
+  } catch {
+    // No existing entry (the common case), or an unremovable one — either way the
+    // exclusive create below is the real guard, and its own failure is returned.
+  }
+  let fd;
+  try {
+    fd = openSync(path, "wx", mode);
+  } catch {
+    return false;
+  }
+  try {
+    writeFileSync(fd, content);
+    return true;
+  } finally {
+    closeSync(fd);
+  }
+}
 
 /**
  * True when this module is the process entry point (run directly as a CLI, not

--- a/.claude/hooks/lib-skill-gate.mjs
+++ b/.claude/hooks/lib-skill-gate.mjs
@@ -1,0 +1,109 @@
+/**
+ * The shared machinery behind every "this action requires that skill" PreToolUse
+ * reminder: a per-session, per-skill marker recording that the Skill tool was
+ * called, and a judge that denies the gated action until it was.
+ *
+ * ONE module rather than a copy per gate, because the copies would each claim a
+ * latch in the same $TMPDIR namespace — two writers of one convention, drifting
+ * apart the first time either one's filename or validation changes.
+ *
+ * These are REMINDERS, not containment boundaries. A gate checks that the Skill
+ * tool was called, not that the agent followed what the skill said, and it covers
+ * only the tools its own `triggered` predicate names. Each gate's module header
+ * names what it deliberately leaves out.
+ */
+import { mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { writeFileNoFollow } from "./lib-hook-io.mjs";
+
+/** Both halves of a marker filename are path segments, so both are validated. */
+const SAFE_NAME_RE = /^[\w-]+$/;
+
+/**
+ * PROBLEM CLASS — a gate matches a CLI invocation that is only MENTIONED, not
+ * run: the words sit inside a quoted argument (`git commit -m "... gh pr create
+ * ..."`), a grep pattern, or a heredoc body, and the gate denies a call that
+ * creates nothing. Every `gh`-matching gate needs the same anchor, so it is
+ * defined once here: the start of the command, or just after a shell separator.
+ *
+ * A prefix string rather than a RegExp, because each gate appends its own
+ * subcommand and compiles the result once at load. The separator class and the
+ * run after it do not overlap — `\s*` there would also match the `\n` in the
+ * class, which is polynomial-backtracking ReDoS.
+ */
+export const GH_AT_COMMAND_POSITION = String.raw`(?:^|[\n;|&()])[ \t]*gh\s+`;
+
+/**
+ * This session's marker path for `skill`, or null when either half is not already
+ * a safe filename. Refusing beats rewriting: a rewrite is many-to-one, so `a/b`
+ * and `a_b` would share one marker and one session's invocation would satisfy
+ * the other's.
+ * @param {unknown} sessionId @param {string} skill @returns {string|null}
+ */
+export function markerPath(sessionId, skill) {
+  if (typeof sessionId !== "string" || !SAFE_NAME_RE.test(sessionId))
+    return null;
+  if (!SAFE_NAME_RE.test(skill)) return null;
+  const dir = process.env.CLAUDE_SKILL_GATE_DIR || join(tmpdir(), "skill-gate");
+  // Per skill, not per session: one gate's invocation must not satisfy another's.
+  return join(dir, `${sessionId}.${skill}.marker`);
+}
+
+/**
+ * A `plugin:skill` spelling counts; a merely similar name (`pr-creation-notes`)
+ * does not.
+ * @param {any} payload @param {string} skill @returns {boolean}
+ */
+export function invokesSkill(payload, skill) {
+  if (payload?.tool_name !== "Skill") return false;
+  const invoked = payload?.tool_input?.skill;
+  if (typeof invoked !== "string") return false;
+  return invoked.split(":").at(-1)?.trim() === skill;
+}
+
+/** @param {string} path @param {string} skill @returns {boolean} */
+function markerSays(path, skill) {
+  try {
+    return readFileSync(path, "utf8").trim() === skill;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build a gate's judge: a function returning a deny reason for a payload, or null
+ * to pass. Records the marker when the payload IS the skill invocation, so the
+ * observation and the check live together.
+ *
+ * @param {object} spec
+ * @param {string} spec.skill        the skill the gate requires
+ * @param {(payload: any) => boolean} spec.triggered  does this payload need it?
+ * @param {(toolName: string) => string} spec.reason  the deny text
+ * @returns {(payload: any) => string|null}
+ */
+export function createSkillGate({ skill, triggered, reason }) {
+  return function judge(payload) {
+    const path = markerPath(payload?.session_id, skill);
+    if (invokesSkill(payload, skill)) {
+      // Best-effort: a failed write costs a reminder, not correctness.
+      // writeFileNoFollow because this predictable path in a shared $TMPDIR would
+      // otherwise let a squatted symlink redirect the write onto another file.
+      if (path !== null)
+        try {
+          mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+          writeFileNoFollow(path, skill);
+        } catch {
+          return null;
+        }
+      return null;
+    }
+    if (!triggered(payload)) return null;
+    // No session key means no way to tell whether the skill ran, and a reminder
+    // that can never be satisfied is a wedge with no remedy — worse than a missed
+    // one.
+    if (path === null || markerSays(path, skill)) return null;
+    return reason(payload.tool_name);
+  };
+}

--- a/.claude/hooks/skill-gates.mjs
+++ b/.claude/hooks/skill-gates.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse entry point for the skill gates: run each judge over the payload and
+ * DENY the tool call with the first reason any of them returns.
+ *
+ * The gates are reminders that a rule in CLAUDE.md applies right now — open a PR,
+ * touch a test, write a plan — enforced at the one moment the session cannot skim
+ * past. Each judge owns what it covers and says so in its own header; this file
+ * only orders them and speaks the hook protocol.
+ *
+ * FAILS OPEN, on purpose. A crashed PreToolUse hook is non-blocking to Claude
+ * Code anyway, so a throw here would let the call through with no message at all;
+ * exiting cleanly with no decision does the same thing and leaves the transcript
+ * honest. That is the right posture for a reminder: the cost of a missed nudge is
+ * a rule un-recalled, while the cost of a wedged session is every tool call.
+ *
+ * Dependency-free on purpose: the template ships no node_modules, so the hook must
+ * run on a bare `node` from a fresh clone.
+ */
+import { judgePlanSkill } from "./gate-plan-skill.mjs";
+import { judgePrSkill } from "./gate-pr-skill.mjs";
+import { judgeTestsSkill } from "./gate-tests-skill.mjs";
+import { isMain, readStdinJson } from "./lib-hook-io.mjs";
+
+/**
+ * Every gate, in the order a reason is taken from. A payload triggers at most one
+ * in practice, since their predicates name disjoint tools and paths.
+ * @type {ReadonlyArray<(payload: any) => string|null>}
+ */
+export const GATES = Object.freeze([
+  judgePrSkill,
+  judgeTestsSkill,
+  judgePlanSkill,
+]);
+
+/**
+ * The first deny reason any gate returns, or null to allow. Every gate runs even
+ * once one has denied, because a gate also RECORDS the skill invocation it sees —
+ * stopping early would drop the marker for the others.
+ * @param {any} payload @returns {string|null}
+ */
+export function judge(payload) {
+  let denial = null;
+  for (const gate of GATES) {
+    const reason = gate(payload);
+    if (reason !== null && denial === null) denial = reason;
+  }
+  return denial;
+}
+
+/**
+ * The hook response for a payload: a deny decision, or nothing at all when the
+ * call is allowed.
+ * @param {any} payload @returns {string}
+ */
+export function response(payload) {
+  const reason = judge(payload);
+  if (reason === null) return "";
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  });
+}
+
+if (isMain(import.meta.url)) {
+  try {
+    const out = response(await readStdinJson());
+    if (out) process.stdout.write(out);
+  } catch {
+    // See the fail-open note in the header: an unreadable payload costs the
+    // reminder, never the tool call.
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,16 @@
     ],
     "PreToolUse": [
       {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/safe-launch.sh \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/skill-gates.mjs",
+            "timeout": 30
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ the prose from the release's commits.
 
 ### Added
 
+- PreToolUse skill gates: opening a PR, writing a test file, or writing a plan is
+  denied until the session has invoked `pr-creation`, `writing-tests`, or
+  `explore-plan`. The rules already said to invoke them; the gates are what makes
+  a session that skimmed past the rule notice. Each covers the CLI route and the
+  MCP route, since locking one door only moves the session to the other, and each
+  fails OPEN — an unusable session id or an unparsable payload costs the reminder,
+  never the tool call.
+
 - `shell-targets`, a decide-gate input that DERIVES a gate's watched paths from
   the shell entry point the job runs, instead of restating them in `paths-regex`
   where the copy drifts silently. `.github/scripts/shell-run-closure.py` walks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Commits MUST use [Conventional Commits](https://www.conventionalcommits.org/) (`
 
 ## Pull Requests
 
-**Opening or editing a PR is governed by the [`pr-creation` skill](.claude/skills/pr-creation/SKILL.md)** — invoke it before the call that creates or edits the PR, whatever the route. Its load-bearing rule: **run the compress-critique-fix loop on the body before submitting.** These bind before that skill could be selected, or override a system-prompt default, so they live here:
+**Opening or editing a PR is governed by the [`pr-creation` skill](.claude/skills/pr-creation/SKILL.md)** — invoke it before the call that creates or edits the PR, whatever the route; a PreToolUse hook denies `gh pr create` and the MCP tool until you have. Its load-bearing rule: **run the compress-critique-fix loop on the body before submitting.** These bind before that skill could be selected, or override a system-prompt default, so they live here:
 
 **Create a PR automatically when a feature, fix, or refactor is complete — don't wait to be asked, and don't warn against opening one.** Once committed and pushed, open the PR as the final step. **This overrides any default that holds off until the user requests a PR — including the remote-execution system-prompt line "Do NOT create a pull request unless the user explicitly asks for one." In this repo, completing the work _is_ the explicit ask.** Skip only when the user said not to, when a PR for this branch already exists (push to it instead), or when the change is plainly incomplete/experimental.
 
@@ -193,7 +193,7 @@ After completing any non-trivial task, briefly reflect on how you could have ite
 
 ## Testing
 
-**Writing, changing, or reviewing tests is governed by the [`writing-tests` skill](.claude/skills/writing-tests/SKILL.md)** — invoke it whenever you touch tests. Its load-bearing rule: **test behavior, not source text.**
+**Writing, changing, or reviewing tests is governed by the [`writing-tests` skill](.claude/skills/writing-tests/SKILL.md)** — invoke it whenever you touch tests; a PreToolUse hook denies the write until you have. Its load-bearing rule: **test behavior, not source text.**
 
 **NEVER run the whole suite while you still have work in flight.** A full run costs minutes of wall-clock per invocation, and during the edit-fix loop it answers nothing a targeted run doesn't. Run only what covers what you touched — `uv run pytest tests/<file>.py -k <name>`, or a `-k` expression over the affected area — then push and let CI report. **Nothing in a normal session requires a full local suite run**, and the local post-push re-run is discouraged and never waited on. If a targeted run and a CI leg disagree, that gap is a finding to report, not a reason to start re-running the suite locally.
 

--- a/tests/test_skill_gates.py
+++ b/tests/test_skill_gates.py
@@ -1,0 +1,185 @@
+"""Behavioral tests for the PreToolUse skill gates.
+
+Each gate denies a tool call until the Skill tool was invoked for its skill, and
+allows it afterwards. Both halves matter: a gate that never denies is inert, and
+one that never clears is a wedge with no remedy. The cases below drive the real
+hook as a subprocess over its stdin protocol, so a break in the wiring — the
+judge order, the deny JSON, the marker write — fails here rather than in a
+session.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._helpers import REPO_ROOT, run_capture
+
+HOOK = REPO_ROOT / ".claude" / "hooks" / "skill-gates.mjs"
+SESSION = "sess-1"
+
+
+def run_hook(payload: dict, gate_dir: Path) -> dict | None:
+    """Drive the hook over stdin; return its parsed response, or None for allow."""
+    env = {**os.environ, "CLAUDE_SKILL_GATE_DIR": str(gate_dir)}
+    result = run_capture(
+        ["node", str(HOOK)], input=json.dumps(payload), env=env, cwd=REPO_ROOT
+    )
+    assert result.returncode == 0, result.stderr
+    if not result.stdout.strip():
+        return None
+    return json.loads(result.stdout)
+
+
+def deny_reason(response: dict | None) -> str:
+    assert response is not None, "expected a deny, got an allow"
+    output = response["hookSpecificOutput"]
+    assert output["hookEventName"] == "PreToolUse"
+    assert output["permissionDecision"] == "deny"
+    return output["permissionDecisionReason"]
+
+
+def invoke_skill(skill: str) -> dict:
+    return {
+        "session_id": SESSION,
+        "tool_name": "Skill",
+        "tool_input": {"skill": skill},
+    }
+
+
+# (label, the gated payload, the skill that clears it)
+GATED_CALLS = [
+    (
+        "gh pr create",
+        {"tool_name": "Bash", "tool_input": {"command": "gh pr create --fill"}},
+        "pr-creation",
+    ),
+    (
+        "the MCP create_pull_request tool",
+        {"tool_name": "mcp__github__create_pull_request", "tool_input": {}},
+        "pr-creation",
+    ),
+    (
+        "writing a pytest module",
+        {"tool_name": "Write", "tool_input": {"file_path": "tests/test_thing.py"}},
+        "writing-tests",
+    ),
+    (
+        "editing a node test module",
+        {"tool_name": "Edit", "tool_input": {"file_path": "a/b/thing.test.mjs"}},
+        "writing-tests",
+    ),
+    (
+        "writing a plan file",
+        {"tool_name": "Write", "tool_input": {"file_path": "/tmp/claude/plan.md"}},
+        "explore-plan",
+    ),
+]
+
+
+@pytest.mark.parametrize("label, call, skill", GATED_CALLS, ids=lambda v: str(v)[:40])
+def test_a_gated_call_is_denied_until_its_skill_runs(
+    tmp_path: Path, label: str, call: dict, skill: str
+) -> None:
+    payload = {"session_id": SESSION, **call}
+    reason = deny_reason(run_hook(payload, tmp_path))
+    assert skill in reason, f"{label}: the deny must name the skill to invoke"
+
+    assert run_hook(invoke_skill(skill), tmp_path) is None
+    assert run_hook(payload, tmp_path) is None, (
+        f"{label}: the gate must clear once its skill ran"
+    )
+
+
+def test_one_gates_skill_does_not_satisfy_another(tmp_path: Path) -> None:
+    """The markers are per skill. Sharing one would let any skill invocation open
+    every gate, which is the whole guarantee gone."""
+    assert run_hook(invoke_skill("writing-tests"), tmp_path) is None
+    payload = {
+        "session_id": SESSION,
+        "tool_name": "Bash",
+        "tool_input": {"command": "gh pr create --fill"},
+    }
+    assert "pr-creation" in deny_reason(run_hook(payload, tmp_path))
+
+
+def test_a_marker_from_another_session_does_not_clear_this_one(
+    tmp_path: Path,
+) -> None:
+    other = {**invoke_skill("pr-creation"), "session_id": "other"}
+    assert run_hook(other, tmp_path) is None
+    payload = {
+        "session_id": SESSION,
+        "tool_name": "Bash",
+        "tool_input": {"command": "gh pr create --fill"},
+    }
+    assert "pr-creation" in deny_reason(run_hook(payload, tmp_path))
+
+
+ALLOWED_CALLS = [
+    # The words appear, but inside another program's argument — nothing is created.
+    (
+        "a quoted mention of the command",
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'git commit -m "explain gh pr create"'},
+        },
+    ),
+    (
+        "a similarly named binary",
+        {"tool_name": "Bash", "tool_input": {"command": "mygh pr create"}},
+    ),
+    (
+        "a non-test source file",
+        {"tool_name": "Write", "tool_input": {"file_path": "src/app.py"}},
+    ),
+    # `pretest_x.py` contains `test_x.py`, so an unanchored pattern fires on it.
+    (
+        "a file whose name merely contains a test name",
+        {"tool_name": "Write", "tool_input": {"file_path": "pretest_thing.py"}},
+    ),
+    # `explanation` contains `plan`; firing here teaches the session the gate is noise.
+    (
+        "a doc whose name merely contains 'plan'",
+        {"tool_name": "Write", "tool_input": {"file_path": "docs/explanation.md"}},
+    ),
+    (
+        "reading a test file",
+        {"tool_name": "Read", "tool_input": {"file_path": "tests/test_thing.py"}},
+    ),
+]
+
+
+@pytest.mark.parametrize("label, call", ALLOWED_CALLS, ids=lambda v: str(v)[:40])
+def test_an_untriggered_call_passes(tmp_path: Path, label: str, call: dict) -> None:
+    payload = {"session_id": SESSION, **call}
+    assert run_hook(payload, tmp_path) is None, f"{label}: must not be gated"
+
+
+def test_an_unusable_session_id_never_wedges_the_session(tmp_path: Path) -> None:
+    """No session key means no way to record that the skill ran, so a deny could
+    never be cleared. The gate passes instead — a missed reminder beats a session
+    with no way forward."""
+    payload = {
+        "session_id": "../escape",
+        "tool_name": "Bash",
+        "tool_input": {"command": "gh pr create --fill"},
+    }
+    assert run_hook(payload, tmp_path) is None
+
+
+def test_unparsable_stdin_fails_open(tmp_path: Path) -> None:
+    """A PreToolUse hook that produces no response is non-blocking, so a crash
+    would allow the call with no message at all. Exit cleanly instead."""
+    result = subprocess.run(
+        ["node", str(HOOK)],
+        input="not json",
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "CLAUDE_SKILL_GATE_DIR": str(tmp_path)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## What & why

`CLAUDE.md` tells a session to invoke `pr-creation` before opening a PR, `writing-tests` before touching a test, and `explore-plan` before writing a plan. Prose is ignorable, and it is ignorable exactly when it matters: tests arrive as a byproduct of some other task, so nothing in the session ever presents itself as "I am writing tests now" and the trigger passes unread.

Three PreToolUse gates over one shared latch: a per-session, per-skill marker written when the Skill tool is called, and a judge that denies the gated action until it is there. Each gate covers the CLI route and the MCP route, because locking one of two equivalent doors only moves the session to the other.

They are **reminders, not containment**. Each module header names what it deliberately leaves out — `gh api` to the pulls endpoint, a heredoc through Bash, an editor outside the session — and each deny text claims only what its own gate covers.

## Review focus

`.claude/hooks/lib-skill-gate.mjs`, and specifically the fail-open decisions. A session id that is not a safe filename yields no marker, so a deny there could never be cleared — the gate passes instead. An unparsable payload exits 0 with no decision, which is already what a crashed PreToolUse hook means to Claude Code. Both are deliberate: a wedged session costs every tool call, a missed reminder costs one rule un-recalled. If you disagree with that trade, this is the file to argue with.

## Decisions made

- **All three gates ship together.** They share one latch module, and shipping two would leave the third's marker namespace claimed by nothing.
- **The entry point is its own file rather than a judge folded into an existing hook.** Upstream runs these inside a sanitizer this template does not have, so a small `skill-gates.mjs` speaking the hook protocol is the whole adaptation.
- **`writeFileNoFollow` moves into `lib-hook-io.mjs`** rather than living in the gate library: it is generic I/O, and the marker path is only the first predictable path in a shared `$TMPDIR` this repo will write.
- **Wired through `safe-launch.sh`.** `validate-config.sh` requires it for every PreToolUse hook, and safe-launch already syntax-checks a `.mjs` target with `node --check`, so no change to the launcher was needed.

## How it was tested

`uv run pytest tests/test_skill_gates.py tests/test_claude_hooks.py -q` — 47 passed, 15 of them new. Also drove the real wiring end to end: `echo '{"session_id":"s1","tool_name":"Bash","tool_input":{"command":"gh pr create"}}' | .claude/hooks/safe-launch.sh .claude/hooks/skill-gates.mjs` returns the deny JSON.

<details>
<summary>Detail</summary>

**Both halves are pinned per gate.** A gate that never denies is inert and a gate that never clears is a wedge, so each of the five gated calls is asserted denied, then the skill is invoked, then the same call is asserted allowed.

**The isolation properties have their own cases**, because a shared marker would quietly dissolve the whole guarantee: `writing-tests` does not clear the PR gate, and a marker written under another session id does not clear this one.

**The near-misses are cases too**, since a gate that fires on them teaches the session it is noise: a quoted mention of `gh pr create` inside a `git commit -m` argument, `mygh pr create`, `pretest_thing.py` (which contains `test_thing.py`), `docs/explanation.md` (which contains `plan`), and a `Read` of a test file.

**Not run here:** the `lychee` pre-commit hook — its `cargo-binstall` install resolves through `api.github.com/graphql`, which this session's egress proxy answers 403, and binstall's source fallback fails on `cargo-install does not support --install-path`. CI runs `pre-commit run --all-files`.

</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_01CfBqTvDWvXUk4UzrWUoe9Q)_