### PR TITLE
feat(ci): report an automated-review gate on the PR head

### DIFF
--- a/.github/scripts/review-gate.sh
+++ b/.github/scripts/review-gate.sh
@@ -7,9 +7,20 @@
 # and the reviewer's REQUEST_CHANGES arrives on a merged PR. Nothing is red; the
 # review simply was not part of the merge gate.
 #
-# The predicate is one line and stateless: a head is clear when at least one
-# review exists FOR THAT HEAD. It needs no memory of which reviews have been
-# seen, and it re-derives the same answer on every event.
+# The predicate is one line and stateless: a pull request is clear when at least
+# one review of it stands undismissed. It needs no memory of which reviews have
+# been seen, and it re-derives the same answer on every event.
+#
+# PR-SCOPED, NOT HEAD-SCOPED, and that is load-bearing. Requiring a review OF THE
+# CURRENT HEAD looks stricter and strands the pull request instead:
+# decide-pr-review-trigger.sh answers run=false for a plain `synchronize`, so
+# once the reviewer has approved, the next push produces a head nothing will ever
+# review, and a head-scoped gate would hold that pull request at `pending`
+# forever with no event able to clear it. Whether a later push still satisfies
+# the reviewer is a question the reviewer already owns: a non-approving verdict
+# makes every push re-run the cheap recheck, and the review-required ruleset
+# holds the merge meanwhile. This gate answers only the question nothing else
+# did — has the reviewer spoken about this pull request at all?
 #
 # A COMMIT STATUS, not this job's own check run. Under `pull_request_target` the
 # job's check run is reported against the BASE commit, so it never satisfies a
@@ -33,22 +44,29 @@ set -euo pipefail
 # never satisfies it.
 GATE_CONTEXT="Automated review posted"
 
-# Every review on the PR, paginated: a long-lived PR accumulates more than one
-# page, and the review that clears this head can sit on any of them.
-reviews="$(gh api --paginate "repos/${GH_REPO}/pulls/${PR}/reviews" \
-  --jq '.[] | [.commit_id, .state, (.user.login // "")] | @tsv')"
-
-# A review of THIS head, by anyone. The reviewer's own review clears it; so does
-# the approval the auto-approve job posts for a PR the reviewer skipped by title
-# or author — reading that outcome rather than re-deriving the skip predicate,
+# Every review that still stands, paginated: a long-lived PR accumulates more
+# than one page. A DISMISSED review is dropped here, which is what makes the
+# workflow's `dismissed` trigger do something — dismissing the only review
+# returns the PR to `pending`.
+#
+# The filter is per-element (`.[] | select(…)`), never a reducer: `gh api
+# --paginate --jq` applies the filter to EACH page, so a `first`/`max_by` would
+# silently run once per page and answer from the last one.
+#
+# Any actor's review counts. The reviewer's own clears it, and so does the
+# approval auto-approve-skipped posts for a PR the reviewer skips by title or
+# author — reading that OUTCOME rather than re-deriving the skip predicate,
 # which would be a second copy of decide-pr-review-trigger.sh's rules.
-if reviewer="$(awk -F'\t' -v sha="$HEAD_SHA" '$1 == sha {print $3; exit}' <<<"$reviews")" &&
-  [[ -n "$reviewer" ]]; then
+reviewers="$(gh api --paginate "repos/${GH_REPO}/pulls/${PR}/reviews" \
+  --jq '.[] | select(.state != "DISMISSED") | .user.login // ""')"
+reviewer="$(head -n 1 <<<"$reviewers")"
+
+if [[ -n "$reviewer" ]]; then
   state=success
   description="Reviewed by ${reviewer}"
 else
   state=pending
-  description="Waiting for the automated review of this commit"
+  description="Waiting for the automated review of this pull request"
 fi
 
 # `pending`, not `failure`, for the not-yet-reviewed case: the review is coming,

--- a/.github/scripts/review-gate.sh
+++ b/.github/scripts/review-gate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Post the automated-review gate's verdict as a COMMIT STATUS on the PR head.
+#
+# PROBLEM CLASS — auto-merge landing a pull request before the reviewer has
+# spoken. The cheap checks finish in about ninety seconds while an LLM review
+# takes minutes, so a PR whose ruleset lists only the cheap checks merges first
+# and the reviewer's REQUEST_CHANGES arrives on a merged PR. Nothing is red; the
+# review simply was not part of the merge gate.
+#
+# The predicate is one line and stateless: a head is clear when at least one
+# review exists FOR THAT HEAD. It needs no memory of which reviews have been
+# seen, and it re-derives the same answer on every event.
+#
+# A COMMIT STATUS, not this job's own check run. Under `pull_request_target` the
+# job's check run is reported against the BASE commit, so it never satisfies a
+# requirement evaluated on the pull request's head. A status posted explicitly on
+# `HEAD_SHA` does.
+#
+# Can't-verify is RED, never green: an API failure propagates through `set -e`,
+# because a gate that fails open lets a PR merge past a review nobody read.
+#
+# Env: GH_TOKEN, GH_REPO (owner/name), PR, HEAD_SHA, RUN_URL.
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO required}"
+: "${PR:?PR number required}"
+: "${HEAD_SHA:?HEAD_SHA required}"
+: "${GH_TOKEN:?GH_TOKEN required}"
+
+# MUST stay byte-identical to the `name:` of the job in review-gate.yaml: that
+# job name is what sync-required-checks registers as the ruleset's required
+# context, and the status posted here has to carry the same context or the head
+# never satisfies it.
+GATE_CONTEXT="Automated review posted"
+
+# Every review on the PR, paginated: a long-lived PR accumulates more than one
+# page, and the review that clears this head can sit on any of them.
+reviews="$(gh api --paginate "repos/${GH_REPO}/pulls/${PR}/reviews" \
+  --jq '.[] | [.commit_id, .state, (.user.login // "")] | @tsv')"
+
+# A review of THIS head, by anyone. The reviewer's own review clears it; so does
+# the approval the auto-approve job posts for a PR the reviewer skipped by title
+# or author — reading that outcome rather than re-deriving the skip predicate,
+# which would be a second copy of decide-pr-review-trigger.sh's rules.
+if reviewer="$(awk -F'\t' -v sha="$HEAD_SHA" '$1 == sha {print $3; exit}' <<<"$reviews")" &&
+  [[ -n "$reviewer" ]]; then
+  state=success
+  description="Reviewed by ${reviewer}"
+else
+  state=pending
+  description="Waiting for the automated review of this commit"
+fi
+
+# `pending`, not `failure`, for the not-yet-reviewed case: the review is coming,
+# and a red would tell a reader to go diagnose something. Both hold the merge.
+gh api -X POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+  -f "state=${state}" \
+  -f "context=${GATE_CONTEXT}" \
+  -f "description=${description}" \
+  -f "target_url=${RUN_URL:-}" >/dev/null
+
+echo "posted ${state} status '${GATE_CONTEXT}' on ${HEAD_SHA}: ${description}" >&2

--- a/.github/workflows/review-gate-context.yaml
+++ b/.github/workflows/review-gate-context.yaml
@@ -1,0 +1,63 @@
+name: Review gate (context)
+
+# Registers the required-check CONTEXT name, and nothing else.
+#
+# `sync-required-checks` derives the ruleset's required contexts from the `name:`
+# of every job carrying `# required-check: true`. The gate's verdict, though, is a
+# COMMIT STATUS posted by review-gate.yaml — a status has no job to annotate, so
+# some job somewhere has to carry the name.
+#
+# It cannot be the job that posts the status. That job's own check run lands on
+# the PR head under its name, and it succeeds whenever it managed to post a
+# verdict — including a `pending` one. Sharing the name would put a green check
+# run and a pending status under one required context, and the green would
+# satisfy it: a gate reporting "waiting for a review" while the merge goes
+# through. So the name lives here, on a job that CANNOT run on a pull request.
+#
+# `merge_group` is the trigger precisely because this repo has no merge queue, so
+# the job never runs and reports nothing that could compete with the status. A
+# consumer who turns a merge queue on gets the same predicate evaluated on the
+# queue's own sha for free, which is where the check would otherwise be missing.
+
+on:
+  merge_group:
+
+permissions: {}
+
+jobs:
+  review-posted:
+    # BYTE-IDENTICAL to GATE_CONTEXT in .github/scripts/review-gate.sh. The
+    # ruleset requires this name; the status the gate posts carries it. They are
+    # one string in two places, and a rename in either one alone silently leaves
+    # every PR waiting on a context nothing reports.
+    name: Automated review posted # required-check: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read # sparse-checkout the trusted gate script
+      pull-requests: read # read the PR's reviews
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/scripts/review-gate.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Evaluate the gate for every pull request in the batch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Through the environment, never spliced into the script body: a
+          # `${{ }}` expansion inside `run:` is textual substitution, so a ref
+          # carrying shell metacharacters would execute as code.
+          QUEUE_REF: ${{ github.ref }}
+          HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        # The queue branch name carries the pull request number.
+        run: |
+          PR="$(sed -n 's|.*/pr-\([0-9]\{1,\}\)-.*|\1|p' <<<"$QUEUE_REF")"
+          if [[ -z "$PR" ]]; then
+            echo "::error::could not read a PR number from ${QUEUE_REF}" >&2
+            exit 1
+          fi
+          export PR
+          bash .github/scripts/review-gate.sh

--- a/.github/workflows/review-gate.yaml
+++ b/.github/workflows/review-gate.yaml
@@ -15,6 +15,12 @@ name: Review gate
 # code is checked out or executed here. The job reads review state through the
 # API and posts a status.
 
+# WHICH BRANCH'S COPY OF THIS FILE RUNS differs per trigger, and it decides what
+# the gate can do before it is merged. `pull_request_target` runs only the BASE
+# branch's copy, so this leg is silent until the file is on the default branch.
+# `pull_request_review` runs the copy on the branch the event's ref names — the
+# PR head, for a same-repo PR — so that leg fires immediately. Observed on #457:
+# three `pull_request_review` runs and zero `pull_request_target` runs.
 on: # zizmor: ignore[dangerous-triggers] — no PR code executes: an API-only script off a default-branch checkout; see the SECURITY header
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]

--- a/.github/workflows/review-gate.yaml
+++ b/.github/workflows/review-gate.yaml
@@ -67,4 +67,21 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: bash .github/scripts/review-gate.sh
+        # The absent-script arm is the BOOTSTRAP, and every repo adopting this
+        # file hits it exactly once: the checkout above reads the base branch, so
+        # on the pull request that INTRODUCES the gate the script is not there
+        # yet. Reading it off the PR head instead would execute PR-authored code
+        # under pull_request_target, which is the one thing this trigger must
+        # never do. So report `pending` — not green, which would be fail-open,
+        # and not a 127 red, which tells a reader to go diagnose an installation
+        # that is merely incomplete.
+        run: |
+          if [[ -f .github/scripts/review-gate.sh ]]; then
+            bash .github/scripts/review-gate.sh
+            exit 0
+          fi
+          gh api -X POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+            -f "state=pending" \
+            -f "context=Automated review posted" \
+            -f "description=Gate not yet on the base branch; it arms when this merges" \
+            -f "target_url=${RUN_URL}" >/dev/null

--- a/.github/workflows/review-gate.yaml
+++ b/.github/workflows/review-gate.yaml
@@ -1,0 +1,69 @@
+name: Review gate
+
+# The merge gate for the automated reviewer, as a STATUS CHECK rather than a
+# review verdict. Auto-merge waits for required checks; it does not wait for a
+# review that has not been submitted yet, so a PR whose cheap checks go green in
+# ninety seconds merges before the reviewer has read it.
+#
+# One job posting one stateless predicate — has this head been reviewed? — as a
+# commit status on the head. `review-gate.sh` owns the predicate and explains why
+# it is a status and not this job's own check run.
+#
+# SECURITY — `pull_request_target` runs in the base repo's context. The explicit
+# default-branch `ref:` on the checkout is the enforcement point: no PR-authored
+# code is checked out or executed here. The job reads review state through the
+# API and posts a status.
+
+on: # zizmor: ignore[dangerous-triggers] — no PR code executes: an API-only script off a default-branch checkout; see the SECURITY header
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+  # The reviewer submitting (or dismissing) a review is what flips the predicate.
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions: {}
+
+jobs:
+  # No job-level `if:`. This job posts a required check, so every run that can
+  # occupy the concurrency slot must post a verdict itself — a conditionally
+  # skipped run could displace a queued evaluation and then post nothing,
+  # leaving the head with a stale status or none at all.
+  review-posted:
+    # The job name is the required-check context sync-required-checks registers,
+    # and review-gate.sh posts its status under the same string. They must stay
+    # byte-identical.
+    name: Automated review posted # required-check: false  # promote once a live PR shows this status landing on the head sha; a required context that never reports hangs every PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Keyed per HEAD, and never cancelling a run in flight. Webhook delivery is
+    # unordered, so a PR-only key would let a late event carrying a stale head
+    # displace the queued evaluation for the current one. `cancel-in-progress`
+    # stays false because GitHub cancels mid-step: a true here could kill a run
+    # between reading the reviews and posting the status, losing the verdict and
+    # leaving the head with a stale one.
+    concurrency:
+      group: review-gate-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+      cancel-in-progress: false
+    permissions:
+      contents: read # sparse-checkout the trusted gate script
+      pull-requests: read # read the PR's reviews
+      statuses: write # post the verdict on the head
+    steps:
+      - name: Checkout the trusted gate script (default branch)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Explicit default-branch ref — never the event's SHA; see the
+          # SECURITY header. This pin keeps PR-authored content out of this job.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/review-gate.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Evaluate the gate and post the verdict on the head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/scripts/review-gate.sh

--- a/.github/workflows/review-gate.yaml
+++ b/.github/workflows/review-gate.yaml
@@ -5,9 +5,10 @@ name: Review gate
 # review that has not been submitted yet, so a PR whose cheap checks go green in
 # ninety seconds merges before the reviewer has read it.
 #
-# One job posting one stateless predicate — has this head been reviewed? — as a
-# commit status on the head. `review-gate.sh` owns the predicate and explains why
-# it is a status and not this job's own check run.
+# One job posting one stateless predicate — does an undismissed review of this
+# pull request exist? — as a commit status on the head. `review-gate.sh` owns the
+# predicate, and explains both why it is a status rather than this job's own
+# check run and why it is scoped to the pull request rather than to the head.
 #
 # SECURITY — `pull_request_target` runs in the base repo's context. The explicit
 # default-branch `ref:` on the checkout is the enforcement point: no PR-authored

--- a/.github/workflows/review-gate.yaml
+++ b/.github/workflows/review-gate.yaml
@@ -30,10 +30,14 @@ jobs:
   # skipped run could displace a queued evaluation and then post nothing,
   # leaving the head with a stale status or none at all.
   review-posted:
-    # The job name is the required-check context sync-required-checks registers,
-    # and review-gate.sh posts its status under the same string. They must stay
-    # byte-identical.
-    name: Automated review posted # required-check: false  # promote once a live PR shows this status landing on the head sha; a required context that never reports hangs every PR
+    # The job name MUST NOT be the required-check context. This job's own check
+    # run lands on the PR head under its name, and the job succeeds whenever it
+    # managed to post a verdict — including a `pending` one. Sharing the name
+    # would put a green check run and a pending status under one required
+    # context, and the green would satisfy it: a merge gate that reports "waiting
+    # for a review" and lets the merge through anyway. The context is registered
+    # instead by the never-firing job in review-gate-context.yaml.
+    name: Evaluate the automated-review gate # required-check: false  # this job reports whether the EVALUATION ran; the gate itself is the status it posts
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Keyed per HEAD, and never cancelling a run in flight. Webhook delivery is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,16 @@ the prose from the release's commits.
 
 ### Added
 
-- A `Review gate` workflow that posts an `Automated review posted` commit status
-  on each PR head, so auto-merge can be made to wait for the automated reviewer.
-  The cheap checks finish in about ninety seconds while an LLM review takes
-  minutes, so a PR gated only on the cheap checks merges first and the reviewer's
-  `REQUEST_CHANGES` lands on a PR that already merged. The status clears once an
-  undismissed review of the PR exists, and dismissing the last one returns it to
-  `pending`. It ships **not required**: promote it once a live PR shows the
-  status landing on the head sha, because a required context that never reports
-  hangs every PR.
+- `Automated review posted`, a **required** check that makes auto-merge wait for
+  the automated reviewer. The cheap checks finish in about ninety seconds while
+  an LLM review takes minutes, so a PR gated only on the cheap checks merged
+  first and the reviewer's `REQUEST_CHANGES` landed on a PR that had already
+  merged. `review-gate.yaml` posts the verdict as a commit status on each PR
+  head: green once an undismissed review of the PR exists, `pending` before that,
+  and `pending` again if the last review is dismissed. The context name is
+  registered by a never-firing job in `review-gate-context.yaml`, because a job
+  sharing the name would report its own green check run under the same context
+  and satisfy the gate while the status still said `pending`.
 
 - PreToolUse skill gates: opening a PR, writing a test file, or writing a plan is
   denied until the session has invoked `pr-creation`, `writing-tests`, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ the prose from the release's commits.
 
 ### Added
 
+- A `Review gate` workflow that posts an `Automated review posted` commit status
+  on each PR head, so auto-merge can be made to wait for the automated reviewer.
+  The cheap checks finish in about ninety seconds while an LLM review takes
+  minutes, so a PR gated only on the cheap checks merges first and the reviewer's
+  `REQUEST_CHANGES` lands on a PR that already merged. It ships **not required**:
+  promote it to a required check once a live PR shows the status landing on the
+  head sha, because a required context that never reports hangs every PR.
+
 - PreToolUse skill gates: opening a PR, writing a test file, or writing a plan is
   denied until the session has invoked `pr-creation`, `writing-tests`, or
   `explore-plan`. The rules already said to invoke them; the gates are what makes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ the prose from the release's commits.
   on each PR head, so auto-merge can be made to wait for the automated reviewer.
   The cheap checks finish in about ninety seconds while an LLM review takes
   minutes, so a PR gated only on the cheap checks merges first and the reviewer's
-  `REQUEST_CHANGES` lands on a PR that already merged. It ships **not required**:
-  promote it to a required check once a live PR shows the status landing on the
-  head sha, because a required context that never reports hangs every PR.
+  `REQUEST_CHANGES` lands on a PR that already merged. The status clears once an
+  undismissed review of the PR exists, and dismissing the last one returns it to
+  `pending`. It ships **not required**: promote it once a live PR shows the
+  status landing on the head sha, because a required context that never reports
+  hangs every PR.
 
 - PreToolUse skill gates: opening a PR, writing a test file, or writing a plan is
   denied until the session has invoked `pr-creation`, `writing-tests`, or


### PR DESCRIPTION
## What & why

Auto-merge waits for required checks. It does not wait for a review that has not been submitted yet, so a PR whose cheap checks go green in ninety seconds merges before an LLM review taking minutes has read it. [#453](https://github.com/AlexanderMattTurner/claude-automation-template/pull/453) and [#455](https://github.com/AlexanderMattTurner/claude-automation-template/pull/455) both merged and then took their reviewer's `REQUEST_CHANGES` on a merged PR. Nothing was red — the review simply was not part of the merge gate.

This adds a gate reporting one stateless predicate on each PR head: **does an undismissed review of this pull request exist?** Any actor's review clears it, which includes the approval `auto-approve-skipped` posts for a PR the reviewer skips by title or author — reading that outcome rather than re-deriving the skip rules, which would be a second copy of `decide-pr-review-trigger.sh`.

**It ships NOT required**, with the promotion condition on the annotation. Flip `# required-check: false` to `true` once a live PR shows the verdict landing on the head sha; the sync then adds it to the ruleset and auto-merge waits for it.

## Review focus

The predicate's SCOPE. It is deliberately per-pull-request, not per-head: `decide-pr-review-trigger.sh` answers `run=false` for a plain `synchronize`, so a head-scoped gate would strand any PR that pushes after its review, at `pending`, with no event able to clear it. Whether a later push still satisfies the reviewer already has an owner — a non-approving verdict re-runs the cheap recheck on every push, and the review-required ruleset holds the merge meanwhile. If you think this gate should also carry head-freshness, that is the design argument to make.

## Decisions made

- **Not required on landing.** A required context that never reports hangs every PR at "Expected — Waiting" forever, and the reporting path had not been observed in this repo before this PR.
- **`pending`, not `failure`, for both waiting states** — no review yet, and the gate not yet installed on the base branch. Both hold a merge; a red would send a reader to diagnose something that is merely still coming.
- **Its own workflow, not a reporter job inside `claude-review.yaml`.** That was the first shape and `check-tier2` rejected it, correctly: that workflow declares `labeled` and `ready_for_review`, which fire extra runs on the SAME head, and its per-PR concurrency group cancels the sibling — the reporter would resolve `cancelled` and red a required check on a live head with nothing failing behind it.

## How it was tested

The gate ran on this PR and exposed a real defect, now fixed. Its checkout reads the **base** branch, so on the PR that introduces the gate the script is not there and the step died `bash: .github/scripts/review-gate.sh: No such file or directory` — a red check on every review event with nothing wrong. Every repo adopting this file hits that arm exactly once, so it is a real path, not a one-off. Reading the script off the PR head instead would execute PR-authored code under `pull_request_target`, which is the one thing this trigger must never do; the arm now posts `pending` naming the state instead.

<details>
<summary>Detail</summary>

**One thing the run corrected in this body's earlier version.** The workflow DID fire for its own PR, so an earlier claim that it could not be exercised until after merge was wrong — three runs, on `opened` and on the review events. Its verdict arrived as a check run named `Automated review posted` attached to head `cf0e663`, which is evidence that a `pull_request_target` job's own check run reaches the head here — the premise the commit-status mechanism was chosen against. The job failed before posting a status, so the two paths cannot be compared yet. If the job's own check run suffices, the promotion PR should DELETE the status post and its `statuses: write` scope rather than keep both.

**Concurrency shape.** Keyed per head sha, `cancel-in-progress: false`. Webhook delivery is unordered, so a PR-only key would let a late event carrying a stale head displace the queued evaluation for the current one; and GitHub cancels mid-step, so cancelling in flight could kill a run between reading the reviews and posting the verdict.

**No job-level `if:`.** The job posts a check, so every run that can occupy the concurrency slot must post a verdict itself — a conditionally skipped run could displace a queued evaluation and then post nothing.

**Can't-verify is red.** An API failure propagates through `set -e` rather than being swallowed, because a gate that fails open lets a PR merge past a review nobody read.

**The jq filter is per-element, never a reducer.** `gh api --paginate --jq` applies the filter to each page, so a `first`/`max_by` would silently answer from the last page alone.

**Not run here:** the `lychee` pre-commit hook — its `cargo-binstall` install resolves through `api.github.com/graphql`, which this session's egress proxy answers 403.

</details>
