### PR TITLE
docs(doctrine): carry the file-dependency lifecycle lesson from the sanitizer

### DIFF
--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -32,6 +32,8 @@ and drive cases from that claim rather than the single input that first triggere
 the bug. "Comment promises more generality than the test exercises" is the
 cheapest reviewer tell for a hollow regression test.
 
+**A CI step's comment claiming a property owes the same test, and a green pipeline is not that test.** Build a fixture that violates the property — a lifecycle script that exits non-zero, a file outside the packed set — and assert the step still behaves. A claim like "`--ignore-scripts` keeps the install hermetic" can be false from the day it is written and stay green until an unrelated runner-image change exposes it.
+
 ## Never skip or weaken a test unless asked
 
 Including silently dropping an assertion while refactoring, and including

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -7,6 +7,7 @@
 - **Pin every third-party action to a commit SHA** with a `# vX.Y` comment. A mutable tag lets a compromised maintainer replace the code you reviewed. Example: `uses: actions/checkout@9c091bb…9 # v7.0.0`.
 - Use `uv` (not `pip`) for Python tool installs in CI, and `uv python install <version>` instead of `actions/setup-python`'s tool cache when pinning a version — that removes the runner-image dependency entirely.
 - When `.pre-commit-config.yaml` pins `default_language_version`, the workflow must install that exact Python version. Runner images drop versions on their own schedule; keep the two in sync.
+- **`--ignore-scripts` does not stop a `file:` dependency's own `prepare`/`prepack`.** npm packs a local path dependency by running that package's lifecycle scripts anyway (npm 10.9), so a job that installs a checkout as `file:${PWD}` runs that checkout's `prepare` — here a package-manager call and a type build — and dies at the install step in any job that skipped the full dev install. Install a staged copy instead: `git archive HEAD` into a temp dir, delete `scripts.prepare` and `scripts.prepack` from its manifest, install from there. npm still does the packing, so the installed tree stays exactly what `files` publishes.
 
 ## Path filtering for required checks
 


### PR DESCRIPTION
## What & why

Incorporates the two lessons from [agent-sanitizer#272](https://github.com/AlexanderMattTurner/agent-sanitizer/pull/272) into the doctrine surfaces that fire when they apply.

- `.github/CLAUDE.md` (loads on any `.github/` file, scripts included) gains the npm fact: `--ignore-scripts` does not stop a `file:` dependency's own `prepare`/`prepack`, so a job that installs a checkout as `file:${PWD}` runs that checkout's `prepare` and dies at the install step. The bullet carries the staged-copy fix.
- `.claude/skills/writing-tests/SKILL.md` extends the existing "a fix's own comment is the spec its test must be driven from" bullet to a CI step's comment: a claim like "`--ignore-scripts` keeps the install hermetic" needs a fixture that violates the property, not a green pipeline.

## Review focus

`.github/CLAUDE.md` — the added bullet sits under **Structure**, next to the other CI-install rules. The judgement to check is placement: this is the only surface that loads for `.github/scripts/install-*.sh`.

## How it was tested

Doctrine text only, no executable change. `pre-commit` ran on push: markdownlint, prettier, `lint-skills.sh` and lychee all passed.

## Decisions made

- **No change to `.github/scripts/install-input-sanitizer.sh`.** The template installs the sanitizer from the registry pin, never as a `file:` dependency, so the defect is not reachable here. The sanitizer repo added the local-checkout path itself; the transferable part is the rule, not the script.
- **Doctrine only, no guard.** A lint that detects a `file:` install under `--ignore-scripts` would run on every commit forever to catch a class this tree cannot currently hit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EBKruh7A2XF8JkKnaErRD3)_