### PR TITLE
fix(hooks): let pre-push decide the range before it demands pre-commit

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -60,19 +60,28 @@ zero=0000000000000000000000000000000000000000
 exec 3<&0 0</dev/null
 while read -r -u 3 _local_ref local_sha _remote_ref remote_sha; do
   [[ "$local_sha" == "$zero" ]] && continue # branch deletion: nothing to check
+  # An ANNOTATED tag pushes the tag object's sha, not the commit's. That sha can
+  # never equal a ref the remote already has, so the emptiness test below would
+  # read every tag push as a new range. Peel to the commit; a lightweight tag or
+  # a branch tip peels to itself.
+  local_tip=$(git rev-parse --verify --quiet "${local_sha}^{commit}") || continue
+  from_ref="$remote_sha"
+  if [[ "$from_ref" == "$zero" ]]; then
+    from_ref=$(git merge-base "$default_branch" "$local_tip" 2>/dev/null) ||
+      from_ref=$(git hash-object -t tree /dev/null)
+  fi
+  [[ "$from_ref" == "$local_tip" ]] && continue # nothing new to push
+  # The tool check sits BELOW the emptiness skip. A push that introduces no
+  # commits has nothing for pre-commit to look at, so demanding the tool first
+  # refuses a release-tag push from a runner that has no pre-commit — which is
+  # every runner auto-version.yaml tags from.
   if [[ ${#precommit_cmd[@]} -eq 0 ]]; then
     gate_die_missing_tool pre-push pre-commit "install uv (https://docs.astral.sh/uv/) or 'pip install pre-commit' so the pushed range can be checked, then push again."
   fi
-  from_ref="$remote_sha"
-  if [[ "$from_ref" == "$zero" ]]; then
-    from_ref=$(git merge-base "$default_branch" "$local_sha" 2>/dev/null) ||
-      from_ref=$(git hash-object -t tree /dev/null)
-  fi
-  [[ "$from_ref" == "$local_sha" ]] && continue # nothing new to push
   # Redirect stdin from /dev/null: git feeds this loop the ref list on stdin,
   # and pre-commit (and the tools it drives) would otherwise inherit and consume
   # it, so a multi-ref push would check only the first range.
-  "${precommit_cmd[@]}" run --from-ref "$from_ref" --to-ref "$local_sha" --show-diff-on-failure </dev/null
+  "${precommit_cmd[@]}" run --from-ref "$from_ref" --to-ref "$local_tip" --show-diff-on-failure </dev/null
 done
 
 # Portable-symlink check: rejects a tracked symlink with an absolute target

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -183,3 +183,54 @@ def test_pre_push_noop_push_passes_without_tools(hook_repo: Path) -> None:
         hook_repo, "pre-push", "origin", "url", path=minimal_path(hook_repo)
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_pre_push_annotated_tag_on_a_pushed_commit_needs_no_tools(
+    hook_repo: Path,
+) -> None:
+    """Pushing an annotated tag whose commit the remote already has introduces
+    no commits, so the hook must skip it rather than demand pre-commit.
+
+    An annotated tag puts the TAG OBJECT's sha on the ref line, which never
+    equals a ref the remote already has. Without the peel to `^{commit}` the
+    range reads as non-empty, and the hook refuses the push for want of a tool
+    it has no work for — which is how two releases published to npm with no tag
+    behind them.
+    """
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=hook_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    # The remote already carries this commit on its default branch, so the
+    # merge-base fallback resolves to HEAD and the range is empty.
+    for args in (
+        ["git", "update-ref", "refs/remotes/origin/main", head],
+        ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
+        ["git", "tag", "-a", "v0", "-m", "release v0"],
+    ):
+        subprocess.run(args, cwd=hook_repo, env=git_env(), check=True)
+    tag_object = subprocess.run(
+        ["git", "rev-parse", "v0"],
+        cwd=hook_repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert tag_object != head, (
+        "the tag did not create a tag OBJECT, so this test would exercise the "
+        "lightweight-tag path and the peel would be a no-op"
+    )
+    stdin = f"refs/tags/v0 {tag_object} refs/tags/v0 {ZERO_SHA}\n"
+    result = run_hook(
+        hook_repo,
+        "pre-push",
+        "origin",
+        "url",
+        path=minimal_path(hook_repo),
+        stdin=stdin,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "REFUSING" not in result.stderr


### PR DESCRIPTION
Claimed area: `.hooks/pre-push`, the ref loop.

## What & why

The hook demanded `pre-commit` before it worked out what was being pushed, so a push that introduces no commits was refused for want of a tool it had no work for. `auto-version.yaml` pushes exactly that — a tag on a commit the remote already has — from a runner with no `pre-commit`. Downstream that refused every release tag: in `agent-control-plane-core`, 0.2.15 and 0.2.16 published to npm with no tag behind them, and each later run re-derived the version from v0.2.14.

Two changes in the ref loop:

- Peel the pushed sha with `${local_sha}^{commit}`. An **annotated** tag pushes the tag object's sha, which never equals a ref the remote already has, so the emptiness test could not fire for one whatever the ordering.
- Move the tool check below that emptiness skip, so `pre-commit` is required only when a range needs checking.

## Review focus

The peel's failure arm. `git rev-parse --verify --quiet "${local_sha}^{commit}"` fails for a ref that peels to no commit — a tag on a blob or tree — and the `|| continue` skips it. That is right (there is no range to check) but it is the one path where the hook now declines to check something it used to reach.

## How it was tested

`bash -n .hooks/pre-push` clean. Exercised live: this branch's own push ran the modified hook, and the pushed range was checked rather than skipped.

## Decisions made

- **Its own PR, not folded into the sibling `.github/` fixes.** `CLAUDE.md` requires a supervision-stack edit under `.hooks/` to get its own PR so the highest-risk diff class is not reviewed diluted. Under the alternative this rides with three workflow fixes and one reviewer reads them together. The `.github/` half is [#460](https://github.com/AlexanderMattTurner/claude-automation-template/pull/460).