### PR TITLE
ci: gate synced workflows on the root scaffolding they need

### DIFF
--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -1,5 +1,5 @@
 name: "Setup Base Environment"
-description: "Sets up Node.js with pnpm and caching when a package.json is present (no-op otherwise). Optionally sets up Python with uv."
+description: "Sets up Node.js with pnpm and caching when a package.json is present, and Python with uv when a pyproject.toml is present. Each half no-ops when its root project file is absent."
 inputs:
   node-version:
     description: "Node.js version to use"
@@ -52,21 +52,29 @@ runs:
       run: pnpm install
       shell: bash
 
+    # The Python half is gated on root scaffolding for the same reason the Node
+    # half above is. `uv python install` and `uv sync` both need a project to
+    # act on, and template-sync delivers neither pyproject.toml nor uv.lock — so
+    # a consumer that never had a Python project would otherwise hard-fail every
+    # workflow that passes setup-python: true, on its very first sync PR.
     - name: Set up uv
-      if: inputs.setup-python == 'true'
+      if: inputs.setup-python == 'true' && hashFiles('pyproject.toml') != ''
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
     - name: Set up Python
-      if: inputs.setup-python == 'true'
+      if: inputs.setup-python == 'true' && hashFiles('pyproject.toml') != ''
       run: uv python install "$PYTHON_VERSION"
       shell: bash
       env:
         PYTHON_VERSION: ${{ inputs.python-version }}
 
+    # `--frozen` is an error when there is no lockfile, so this needs uv.lock
+    # and not just pyproject.toml. A project with one and not the other still
+    # gets uv and Python, and resolves at `uv run` time.
     - name: Install Python Dependencies
-      if: inputs.setup-python == 'true'
+      if: inputs.setup-python == 'true' && hashFiles('uv.lock') != ''
       run: uv sync --frozen
       shell: bash

--- a/.github/actions/setup-base-env/action.yaml
+++ b/.github/actions/setup-base-env/action.yaml
@@ -71,10 +71,12 @@ runs:
       env:
         PYTHON_VERSION: ${{ inputs.python-version }}
 
-    # `--frozen` is an error when there is no lockfile, so this needs uv.lock
-    # and not just pyproject.toml. A project with one and not the other still
-    # gets uv and Python, and resolves at `uv run` time.
+    # Needs BOTH files. pyproject.toml because the two steps above install uv
+    # itself only when it is present, so gating on uv.lock alone would run
+    # `uv sync` with no uv on PATH; uv.lock because `--frozen` is an error
+    # without a lockfile. A project with one and not the other still gets uv and
+    # Python, and resolves at `uv run` time.
     - name: Install Python Dependencies
-      if: inputs.setup-python == 'true' && hashFiles('uv.lock') != ''
+      if: inputs.setup-python == 'true' && hashFiles('pyproject.toml') != '' && hashFiles('uv.lock') != ''
       run: uv sync --frozen
       shell: bash

--- a/.github/scripts/release-canary.sh
+++ b/.github/scripts/release-canary.sh
@@ -20,6 +20,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 log() { echo "$@" >&2; }
 
+# No package.json at all: not a package, so there is nothing to canary. Kept
+# separate from the fail-closed arm below, which must keep treating a
+# package.json that EXISTS but does not parse as an error. Without this arm the
+# daily canary alerts forever in a synced consumer that has no Node project.
+if [[ ! -f package.json ]]; then
+  log "No package.json; this repo does not publish to npm. Nothing to canary."
+  exit 0
+fi
+
 # Self-check guard: a repo that does not publish to npm (package.json
 # "private": true — e.g. the template itself) has no release pipeline to canary,
 # so skip. Fails CLOSED on an unreadable package.json, matching version-bump.sh.

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,6 +13,12 @@ permissions:
   contents: read
 
 jobs:
+  # Every step is gated on the root file it needs, so the whole job is a no-op —
+  # not a hard failure — in a consumer that has none of them. template-sync
+  # delivers this workflow but delivers no .pre-commit-config.yaml, package.json
+  # or .nvmrc, so a repo that never had them would otherwise go red on every PR
+  # from its first sync onwards. An absent .pre-commit-config.yaml means there
+  # are no hooks to run, which is not-applicable rather than unverifiable.
   pre-commit:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -25,28 +31,42 @@ jobs:
       # pre-commit itself; the two versions are kept in sync by
       # tests/test_version_sync.py.
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        if: hashFiles('.pre-commit-config.yaml') != ''
         with:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        if: hashFiles('.pre-commit-config.yaml') != ''
       # Node deps must be installed for the node-based `language: system` hooks:
       # check-proto-pollution does `import ts from "typescript"`, which resolves
       # from the repo's node_modules (ESM ignores NODE_PATH), so the module is
       # absent until `pnpm install` runs.
+      #
+      # `node-version-file` is a hard error when the file is missing, so this
+      # step needs .nvmrc too. Without one the runner's preinstalled Node serves
+      # pnpm fine.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: hashFiles('.pre-commit-config.yaml') != '' && hashFiles('.nvmrc') != ''
         with:
           node-version-file: ".nvmrc"
+      # pnpm/action-setup takes no version here, so it resolves one from
+      # package.json's `packageManager` field and errors when there is no
+      # package.json to read.
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        if: hashFiles('.pre-commit-config.yaml') != '' && hashFiles('package.json') != ''
       - name: Install node deps
+        if: hashFiles('.pre-commit-config.yaml') != '' && hashFiles('package.json') != ''
         # No --frozen-lockfile: the repo gitignores pnpm-lock.yaml, so CI resolves
         # from package.json against the registry.
         run: pnpm install --no-frozen-lockfile
       - name: Restore pre-commit cache
+        if: hashFiles('.pre-commit-config.yaml') != ''
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: pre-commit-${{ runner.os }}-
       - name: Run pre-commit
+        if: hashFiles('.pre-commit-config.yaml') != ''
         run: uvx pre-commit==4.6.0 run --all-files --show-diff-on-failure
 
   # Stable Required check: runs even when `pre-commit` is cancelled/skipped, so

--- a/.github/workflows/security-vulnerability-scan.yaml
+++ b/.github/workflows/security-vulnerability-scan.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup base environment
         uses: ./.github/actions/setup-base-env
         with:
-          setup-python: ${{ hashFiles('uv.lock') != '' && 'true' || 'false' }}
+          setup-python: "true"
 
       - name: Check for existing security PR branch
         id: existing-pr

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -30,6 +30,18 @@ name: Sync from Template
 # 5. A workflow that must never be introduced into a repo that has its own
 #    equivalent (the release flow) belongs in OPT_IN_PATHS.
 # =============================================================================
+#
+# ROOT SCAFFOLDING A SYNCED WORKFLOW MAY ASSUME
+#
+# SYNC_PATHS delivers no root project file: package.json, .nvmrc, pyproject.toml,
+# uv.lock and .pre-commit-config.yaml all stay with the consumer. So a synced
+# workflow step that needs one must be gated on `hashFiles('<file>') != ''` and
+# skip when it is absent. Ungated, it hard-fails on every PR in a consumer that
+# never had that scaffolding — a shell-only dotfiles repo, say — and names
+# neither the template nor the missing file in the failure. Adding a workflow to
+# EXCLUDE_PATHS is the consumer's escape hatch, not the fix; gate the step here
+# instead, so a new consumer needs no escape hatch at all.
+# =============================================================================
 
 on:
   workflow_dispatch:

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -31,8 +31,16 @@ jobs:
       - name: Validate configuration
         run: bash .github/scripts/validate-config.sh
 
+      # `uv run` needs a pyproject.toml to run in, and `pytest tests/` exits 4 on
+      # a missing directory. template-sync delivers neither file, so a consumer
+      # with no Python project runs nothing here instead of failing.
+      # validate-config.sh above stays ungated — it needs only the .claude/ tree
+      # the sync delivers.
       - name: Test Claude hooks
-        run: uv run --extra dev pytest tests/
+        if: hashFiles('pyproject.toml') != ''
+        run: |
+          [[ -d tests ]] || { echo "No tests/ directory; nothing to run."; exit 0; }
+          uv run --extra dev pytest tests/
 
   # Stable Required check: runs even when `validate` is cancelled/skipped, so a
   # protected branch never gets stuck on a check that never reports.


### PR DESCRIPTION
## What & why

Gate every synced workflow step that reads a root project file on `hashFiles('<file>') != ''`, so it skips instead of hard-failing when the file is absent. `SYNC_PATHS` delivers `.github/workflows` but no `package.json`, `.nvmrc`, `pyproject.toml`, `uv.lock` or `.pre-commit-config.yaml` — those stay with the consumer. A consumer that never had that scaffolding went red on every PR from its first sync, naming neither the template nor the missing file.

Four ungated sites, all YAML: `setup-base-env`'s Python half (`uv sync --frozen`), `pre-commit.yaml` (`setup-node`, `pnpm/action-setup`), `validate-config.yaml` (`uv run … pytest`), and `release-canary.sh`'s `package.json` read, which alerts on a daily cron. Fixing `setup-base-env` covers `validate-config`, `hook-lifecycle` and `auto-version` at once. `template-sync.yaml` gains a header section stating the rule for the next workflow added.

## Review focus

`.github/actions/setup-base-env/action.yaml` is the single definition the other callers inherit. The invariant: in this repo every gate is true, so the template's own CI is unchanged — only a consumer missing a file behaves differently. Least sure of `validate-config.yaml`'s `[[ -d tests ]]` guard.

## Decisions made

- **Gate rather than document** (the prompt's option 1). Every synced `.hooks/` and `.claude/hooks/` script already gates on exactly these files in shell; only the YAML surface had missed it. Under option 2 every new consumer still owes an `EXCLUDE_PATHS` edit before its first sync.
- **`validate-config.yaml` uses `[[ -d tests ]]`, not `hashFiles('tests/**/*.py')`.** A wrong glob would silently skip this repo's own suite behind a green required check — the vacuous green `.github/CLAUDE.md` singles out. Cost: a `tests/` rename greens silently.
- **`release-canary.sh` gets a separate missing-file arm**, so the existing fallback keeps failing closed on a `package.json` that exists and does not parse.
- **A skip reports success.** No `.pre-commit-config.yaml` means there are no hooks to run — not-applicable, matching `lint.yaml` and `node-tests.yaml`, which already green when no script is configured.

## Proposed guards

Not shipped. `tests/test_synced_deps.py` already enforces this class for **shell**: every path a synced script names must be one `SYNC_PATHS` delivers. It parses bash, so the YAML twin was invisible to it. The guard extends it to workflow YAML — a step naming a root path outside `SYNC_PATHS` needs a `hashFiles` gate on that path or an `allow-unsynced` annotation. Cost: a YAML walker plus a per-step path extractor, running on every commit forever, with false positives on paths in comments or reached through `env:`. Benefit: the class shipped four times here and cost a consumer two PRs to diagnose. My read is that it clears the bar; the extraction heuristic wants its own design pass.

<details>
<summary>Verification and the sites already gated</summary>

- **The gate is not vacuous here.** The `validate` job on `ece6c98` ran the suite behind the new `if:` and printed `555 passed in 18.53s`. That is the failure mode the `[[ -d tests ]]` decision above guards against, observed rather than assumed.
- `uvx pre-commit==4.6.0 run --files <the 6 changed files>` — all hooks pass, including `actionlint` and `zizmor`, which parse the new `if:` expressions.
- Locally, `uv run --extra dev pytest tests/test_validate_config.py tests/test_version_sync.py tests/test_synced_deps.py tests/test_template_sync.py tests/test_release_canary.py -q` — 129 passed. Predicted no change (these assert path and pin contracts, not gating) and saw none.
- **Not verified**: the consumer-side skip, which needs a runner with the files absent. Reasoned from `hashFiles` semantics.
- `security-vulnerability-scan.yaml` drops its now-duplicated `setup-python: ${{ hashFiles('uv.lock') != '' && 'true' || 'false' }}`, since the action owns the gate.

Checked and already gated: `lint.yaml` and `node-tests.yaml` (`script-configured.sh` exits 1 with no `package.json`), `format-check.yaml` (`hashFiles('package.json')`), `zizmor.yaml` (`uvx`, needs no project), `auto-resolve-conflicts.yaml` (`resolve-generated.mjs` imports node builtins only), `.hooks/pre-commit`, `.claude/hooks/pre-push-check.sh`, `.claude/hooks/session-setup.sh`. `auto-version.yaml` is `OPT_IN_PATHS` and is an npm publish flow, so `package.json` is inherent.

</details>
