### PR TITLE
fix(ci): pass --allow-escape-sequences to gh pr diff in review-input prep

### DIFF
--- a/.github/scripts/post-pr-review-retry.test.mjs
+++ b/.github/scripts/post-pr-review-retry.test.mjs
@@ -1,0 +1,112 @@
+// post-pr-review.sh's reviews-API retry: APPROVE (and occasionally
+// REQUEST_CHANGES) can 422 under GITHUB_TOKEN when the repo does not allow
+// Actions to cast a formal vote, while COMMENT always succeeds. Drives the
+// real script (which itself runs the real post-pr-review.mjs) against a fake
+// `gh` that rejects a chosen set of events, so the retry-as-COMMENT path is
+// exercised end to end rather than re-implemented.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..");
+const SCRIPT = join(HERE, "post-pr-review.sh");
+
+const DIFF = `diff --git a/src/foo.js b/src/foo.js
+index 1111111..2222222 100644
+--- a/src/foo.js
++++ b/src/foo.js
+@@ -1,1 +1,1 @@
+-const a = 1;
++const a = 2;
+`;
+
+// A fake `gh` that rejects (422) any reviews-API POST whose payload `event`
+// is in `rejectEvents`, and always accepts `gh pr comment` (the last-resort
+// fallback). `gh api -X POST … --input FILE` always lands FILE at $6, since
+// post-pr-review.sh's call shape is fixed.
+function run(review, { rejectEvents = [] } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "post-pr-review-sh-"));
+  const bin = mkdtempSync(join(tmpdir(), "post-pr-review-bin-"));
+  writeFileSync(join(dir, "diff.txt"), DIFF);
+  writeFileSync(join(dir, "review.json"), JSON.stringify(review));
+
+  const reject = rejectEvents.join(" ");
+  const ghPath = join(bin, "gh");
+  writeFileSync(
+    ghPath,
+    "#!/usr/bin/env bash\n" +
+      `REJECT="${reject}"\n` +
+      'if [[ "$1" == "api" ]]; then\n' +
+      '  file="$6"\n' +
+      '  event="$(node -e \'console.log(JSON.parse(require("fs").readFileSync(process.argv[1])).event)\' "$file")"\n' +
+      "  for e in $REJECT; do\n" +
+      '    if [[ "$e" == "$event" ]]; then\n' +
+      '      echo "gh: Unprocessable Entity (HTTP 422)" >&2\n' +
+      "      exit 1\n" +
+      "    fi\n" +
+      "  done\n" +
+      '  echo "posted event=$event" >&2\n' +
+      "  exit 0\n" +
+      'elif [[ "$1" == "pr" && "$2" == "comment" ]]; then\n' +
+      '  echo "posted fallback comment" >&2\n' +
+      "  exit 0\n" +
+      "fi\n" +
+      'echo "fake gh: unexpected invocation: $*" >&2\n' +
+      "exit 1\n",
+  );
+  chmodSync(ghPath, 0o755);
+
+  const res = spawnSync("bash", [SCRIPT], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      PR: "1",
+      GH_REPO: "owner/repo",
+      PR_INPUT_DIR: dir,
+      EXECUTION_FILE: "",
+    },
+  });
+  rmSync(dir, { recursive: true, force: true });
+  rmSync(bin, { recursive: true, force: true });
+  return res;
+}
+
+test("APPROVE rejected by the reviews API is retried and posted as COMMENT", () => {
+  const res = run(
+    { verdict: "looks_good", summary: "clean", findings: [] },
+    { rejectEvents: ["APPROVE"] },
+  );
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stderr, /rejected a APPROVE review; retrying as COMMENT/);
+  assert.match(res.stderr, /posted event=COMMENT/);
+  assert.match(res.stderr, /posted structured review as COMMENT/);
+  assert.doesNotMatch(res.stderr, /posting a summary comment instead/);
+});
+
+test("an event the API accepts posts directly, no retry", () => {
+  const res = run({
+    verdict: "looks_good",
+    summary: "clean",
+    findings: [],
+  });
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stderr, /posted event=APPROVE/);
+  assert.doesNotMatch(res.stderr, /retrying as COMMENT/);
+});
+
+test("a COMMENT rejection (no formal-vote issue to blame) falls back to a plain comment", () => {
+  const res = run(
+    { verdict: "looks_good", summary: "clean", findings: [] },
+    { rejectEvents: ["APPROVE", "COMMENT"] },
+  );
+  assert.equal(res.status, 0, res.stderr);
+  assert.match(res.stderr, /retrying as COMMENT/);
+  assert.match(res.stderr, /posting a summary comment instead/);
+});

--- a/.github/scripts/post-pr-review.sh
+++ b/.github/scripts/post-pr-review.sh
@@ -2,9 +2,11 @@
 # Post the review agent's structured findings as ONE GitHub PR review with
 # inline, line-anchored comments and (where offered) one-click suggested edits.
 # post-pr-review.mjs builds the reviews-API payload from review.json; this posts
-# it. If the API rejects the whole review (e.g. an anchor that slipped past
-# validation), fall back to a single summary comment so the feedback is never
-# silently lost.
+# it. APPROVE (and occasionally REQUEST_CHANGES) can 422 under GITHUB_TOKEN when
+# the repo does not allow Actions to cast a formal vote — observed: APPROVE
+# always rejected here, COMMENT always accepted. Retried as COMMENT first, since
+# review-gate.sh counts any undismissed review regardless of event; only a
+# COMMENT rejection (e.g. a genuinely bad anchor) falls back to a plain comment.
 #
 # Requires: gh authenticated (GH_TOKEN), GH_REPO, PR, PR_INPUT_DIR; node with the
 # scripts on the module path. HEAD_SHA (the PR head sha) is optional but pins the
@@ -29,10 +31,27 @@ if [[ "$status" != "PAYLOAD" ]]; then
   exit 0
 fi
 
-if gh api -X POST "repos/${GH_REPO}/pulls/${PR}/reviews" \
-  --input "${PR_INPUT_DIR}/review-payload.json" >/dev/null; then
+PAYLOAD="${PR_INPUT_DIR}/review-payload.json"
+
+post_review() {
+  gh api -X POST "repos/${GH_REPO}/pulls/${PR}/reviews" --input "$1" >/dev/null
+}
+
+if post_review "$PAYLOAD"; then
   echo "posted structured review with inline comments" >&2
   exit 0
+fi
+
+event="$(jq -r '.event' "$PAYLOAD")"
+if [[ "$event" != "COMMENT" ]]; then
+  echo "::warning::reviews API rejected a ${event} review; retrying as COMMENT" >&2
+  comment_payload="$(mktemp)"
+  trap 'rm -f "$comment_payload"' EXIT
+  jq '.event = "COMMENT"' "$PAYLOAD" >"$comment_payload"
+  if post_review "$comment_payload"; then
+    echo "posted structured review as COMMENT (original event ${event} was rejected)" >&2
+    exit 0
+  fi
 fi
 
 echo "::warning::reviews API rejected the structured review; posting a summary comment instead" >&2

--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -47,9 +47,8 @@ trap 'rm -f "$raw_diff"' EXIT
 # retry_stdout via a command substitution: a transient blip re-fetches the whole
 # diff and only the succeeding attempt's bytes land in raw_diff. A plain `retry
 # … >"$raw_diff"` would leak a failing attempt's error body into the file.
-# --allow-escape-sequences: `gh pr diff` refuses a diff holding a raw terminal
-# escape byte otherwise, and that byte reaches only the sanitizer below, never
-# a real terminal.
+# --allow-escape-sequences is safe here: that byte reaches only the sanitizer
+# below, never a real terminal.
 raw_diff_content="$(retry_stdout gh pr diff "$PR" --allow-escape-sequences)"
 printf '%s\n' "$raw_diff_content" >"$raw_diff"
 

--- a/.github/scripts/prepare-pr-review-input.sh
+++ b/.github/scripts/prepare-pr-review-input.sh
@@ -47,7 +47,10 @@ trap 'rm -f "$raw_diff"' EXIT
 # retry_stdout via a command substitution: a transient blip re-fetches the whole
 # diff and only the succeeding attempt's bytes land in raw_diff. A plain `retry
 # … >"$raw_diff"` would leak a failing attempt's error body into the file.
-raw_diff_content="$(retry_stdout gh pr diff "$PR")"
+# --allow-escape-sequences: `gh pr diff` refuses a diff holding a raw terminal
+# escape byte otherwise, and that byte reaches only the sanitizer below, never
+# a real terminal.
+raw_diff_content="$(retry_stdout gh pr diff "$PR" --allow-escape-sequences)"
 printf '%s\n' "$raw_diff_content" >"$raw_diff"
 
 diff_lines="$(wc -l <"$raw_diff" | tr -d '[:space:]')"

--- a/tests/test_prepare_pr_review_input.py
+++ b/tests/test_prepare_pr_review_input.py
@@ -34,12 +34,21 @@ ESCAPE_SEQUENCE_STDERR = (
 )
 
 
-def _fake_bins(tmp_path: Path, *, files: int) -> None:
+def _fake_bins(tmp_path: Path, *, files: int, escape_byte: bool = False) -> None:
     """Put a fake `gh` and a fake `node` (the sanitizer stand-in: cats stdin) on
     PATH. The fake `gh` emits a `files`-file unified diff for `pr diff` and JSON
     for `pr view`, and refuses `pr diff` without --allow-escape-sequences —
     mirroring the real CLI's guard — so every test also asserts the script
-    keeps passing that flag."""
+    keeps passing that flag. `escape_byte` adds one hunk holding a literal ESC
+    byte, mirroring the payload `gh pr diff` would otherwise refuse to print.
+    """
+    escape = ""
+    if escape_byte:
+        escape = (
+            '  echo "diff --git a/escape.txt b/escape.txt"\n'
+            '  echo "@@ -0,0 +1,1 @@"\n'
+            '  printf "+escaped \x1b[31mred\x1b[0m line\\n"\n'
+        )
     gh = tmp_path / "gh"
     gh.write_text(
         "#!/usr/bin/env bash\n"
@@ -54,6 +63,7 @@ def _fake_bins(tmp_path: Path, *, files: int) -> None:
         '    echo "@@ -0,0 +1,1 @@"\n'
         '    echo "+added line $i"\n'
         "  done\n"
+        f"{escape}"
         'elif [[ "$2" == "view" ]]; then\n'
         '  printf \'%s\' \'{"title":"t","body":"b","author":{"login":"a"},"files":[]}\'\n'
         "fi\n",
@@ -66,9 +76,9 @@ def _fake_bins(tmp_path: Path, *, files: int) -> None:
 
 
 def _run(
-    tmp_path: Path, *, files: int, max_diff_lines: int
+    tmp_path: Path, *, files: int, max_diff_lines: int, escape_byte: bool = False
 ) -> tuple[subprocess.CompletedProcess, dict[str, str], Path]:
-    _fake_bins(tmp_path, files=files)
+    _fake_bins(tmp_path, files=files, escape_byte=escape_byte)
     out_file = tmp_path / "github_output"
     out_file.write_text("", encoding="utf-8")
     input_dir = tmp_path / "pr-input"
@@ -86,6 +96,11 @@ def _run(
             "PR": "123",
             "PR_INPUT_DIR": str(input_dir),
             "MAX_DIFF_LINES": str(max_diff_lines),
+            # Keeps a regressed (flag-dropped) run's retry ladder off the
+            # 2+4+8+16s backoff: a bare assertion failure beats a 30s-per-test
+            # wait for a run that is going to fail either way.
+            "RETRY_MAX": "1",
+            "RETRY_BASE_DELAY": "0",
         },
     )
     outputs = dict(
@@ -100,7 +115,9 @@ def test_normal_diff_is_sanitized(tmp_path: Path) -> None:
     proc, outputs, input_dir = _run(tmp_path, files=2, max_diff_lines=100)
     assert proc.returncode == 0, proc.stderr
     assert outputs["oversized"] == "false"
-    assert (input_dir / "diff.txt").is_file()
+    diff_body = (input_dir / "diff.txt").read_text(encoding="utf-8")
+    assert diff_body.count("diff --git ") == 2
+    assert "+added line 0" in diff_body and "+added line 1" in diff_body
     assert (input_dir / "meta.txt").is_file()
     assert not (input_dir / "oversized-notice.txt").exists()
     assert (tmp_path / "sanitizer_input").exists(), "the sanitizer must run"
@@ -113,6 +130,7 @@ def test_oversized_diff_skips_the_review(tmp_path: Path) -> None:
     assert outputs["diff_lines"] == str(6 * LINES_PER_FILE)
     assert (input_dir / "oversized-notice.txt").is_file()
     assert not (input_dir / "diff.txt").exists()
+    assert not (input_dir / "meta.txt").exists(), "the size skip must also skip meta"
 
 
 def test_a_diff_with_a_raw_escape_byte_still_reaches_the_sanitizer(
@@ -122,8 +140,11 @@ def test_a_diff_with_a_raw_escape_byte_still_reaches_the_sanitizer(
     unless --allow-escape-sequences is passed, so a PR carrying one (observed
     on agent-sanitizer#320) would die before the sanitizer ever ran. Safe to
     pass always: the bytes reach only the sanitizer, never a real terminal."""
-    proc, outputs, input_dir = _run(tmp_path, files=2, max_diff_lines=100)
+    proc, outputs, input_dir = _run(
+        tmp_path, files=2, max_diff_lines=100, escape_byte=True
+    )
     assert proc.returncode == 0, proc.stderr
     assert ESCAPE_SEQUENCE_STDERR not in proc.stderr
-    assert (input_dir / "diff.txt").is_file()
     assert outputs["oversized"] == "false"
+    sanitizer_saw = (tmp_path / "sanitizer_input").read_text(encoding="utf-8")
+    assert "\x1b[31m" in sanitizer_saw, "the raw byte must reach the sanitizer intact"

--- a/tests/test_prepare_pr_review_input.py
+++ b/tests/test_prepare_pr_review_input.py
@@ -1,0 +1,129 @@
+"""Behavioral tests for .github/scripts/prepare-pr-review-input.sh — the step
+that fetches the untrusted PR diff/metadata and runs them through the
+sanitizer before the review agent sees them.
+
+Contract:
+  * At or under MAX_DIFF_LINES: oversized=false, diff.txt/meta.txt written.
+  * Over MAX_DIFF_LINES: oversized=true, oversized-notice.txt written, and
+    diff.txt/meta.txt are NOT written (the review is skipped for size).
+  * `gh pr diff` is always called with --allow-escape-sequences, since a diff
+    holding a raw terminal escape byte would otherwise refuse to print and the
+    sanitizer would never run (observed on agent-sanitizer#320).
+
+The tests drive the REAL script with a fake `gh` (emits an N-file unified diff /
+PR metadata) and a fake `node` (stands in for the sanitizer, passing stdin
+through) on PATH.
+"""
+
+import subprocess
+from pathlib import Path
+
+from tests._helpers import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "prepare-pr-review-input.sh"
+
+# Each fake file section is this many lines (header + ---/+++ + @@ + one body
+# line), so a diff's line count is a simple multiple of its file count.
+LINES_PER_FILE = 5
+
+# What `gh pr diff` prints when the diff holds a raw terminal escape byte and
+# --allow-escape-sequences is missing from the call.
+ESCAPE_SEQUENCE_STDERR = (
+    "the diff contains terminal escape sequences; pass --allow-escape-sequences "
+    "to output it anyway"
+)
+
+
+def _fake_bins(tmp_path: Path, *, files: int) -> None:
+    """Put a fake `gh` and a fake `node` (the sanitizer stand-in: cats stdin) on
+    PATH. The fake `gh` emits a `files`-file unified diff for `pr diff` and JSON
+    for `pr view`, and refuses `pr diff` without --allow-escape-sequences —
+    mirroring the real CLI's guard — so every test also asserts the script
+    keeps passing that flag."""
+    gh = tmp_path / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$2" == "diff" ]]; then\n'
+        "  allowed=false\n"
+        '  for arg in "$@"; do [[ "$arg" == "--allow-escape-sequences" ]] && allowed=true; done\n'
+        f'  if [[ "$allowed" != true ]]; then echo "{ESCAPE_SEQUENCE_STDERR}" >&2; exit 1; fi\n'
+        f"  for ((i = 0; i < {files}; i++)); do\n"
+        '    echo "diff --git a/f$i.py b/f$i.py"\n'
+        '    echo "--- a/f$i.py"\n'
+        '    echo "+++ b/f$i.py"\n'
+        '    echo "@@ -0,0 +1,1 @@"\n'
+        '    echo "+added line $i"\n'
+        "  done\n"
+        'elif [[ "$2" == "view" ]]; then\n'
+        '  printf \'%s\' \'{"title":"t","body":"b","author":{"login":"a"},"files":[]}\'\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    node = tmp_path / "node"
+    node.write_text('#!/usr/bin/env bash\ntee -a "$SANITIZE_INPUT"\n', encoding="utf-8")
+    node.chmod(0o755)
+
+
+def _run(
+    tmp_path: Path, *, files: int, max_diff_lines: int
+) -> tuple[subprocess.CompletedProcess, dict[str, str], Path]:
+    _fake_bins(tmp_path, files=files)
+    out_file = tmp_path / "github_output"
+    out_file.write_text("", encoding="utf-8")
+    input_dir = tmp_path / "pr-input"
+    proc = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{tmp_path}:/usr/bin:/bin",
+            "GITHUB_OUTPUT": str(out_file),
+            "SANITIZE_INPUT": str(tmp_path / "sanitizer_input"),
+            "GH_TOKEN": "fake",
+            "GH_REPO": "owner/repo",
+            "PR": "123",
+            "PR_INPUT_DIR": str(input_dir),
+            "MAX_DIFF_LINES": str(max_diff_lines),
+        },
+    )
+    outputs = dict(
+        ln.split("=", 1)
+        for ln in out_file.read_text(encoding="utf-8").splitlines()
+        if "=" in ln
+    )
+    return proc, outputs, input_dir
+
+
+def test_normal_diff_is_sanitized(tmp_path: Path) -> None:
+    proc, outputs, input_dir = _run(tmp_path, files=2, max_diff_lines=100)
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["oversized"] == "false"
+    assert (input_dir / "diff.txt").is_file()
+    assert (input_dir / "meta.txt").is_file()
+    assert not (input_dir / "oversized-notice.txt").exists()
+    assert (tmp_path / "sanitizer_input").exists(), "the sanitizer must run"
+
+
+def test_oversized_diff_skips_the_review(tmp_path: Path) -> None:
+    proc, outputs, input_dir = _run(tmp_path, files=6, max_diff_lines=10)
+    assert proc.returncode == 0, proc.stderr
+    assert outputs["oversized"] == "true"
+    assert outputs["diff_lines"] == str(6 * LINES_PER_FILE)
+    assert (input_dir / "oversized-notice.txt").is_file()
+    assert not (input_dir / "diff.txt").exists()
+
+
+def test_a_diff_with_a_raw_escape_byte_still_reaches_the_sanitizer(
+    tmp_path: Path,
+) -> None:
+    """`gh pr diff` refuses to emit a diff holding a raw terminal escape byte
+    unless --allow-escape-sequences is passed, so a PR carrying one (observed
+    on agent-sanitizer#320) would die before the sanitizer ever ran. Safe to
+    pass always: the bytes reach only the sanitizer, never a real terminal."""
+    proc, outputs, input_dir = _run(tmp_path, files=2, max_diff_lines=100)
+    assert proc.returncode == 0, proc.stderr
+    assert ESCAPE_SEQUENCE_STDERR not in proc.stderr
+    assert (input_dir / "diff.txt").is_file()
+    assert outputs["oversized"] == "false"


### PR DESCRIPTION
## What & why

Two related fixes to the PR-review pipeline.

## Partitions

- **Escape-sequence fix** (`prepare-pr-review-input.sh`, `tests/test_prepare_pr_review_input.py`): adds `--allow-escape-sequences` to `gh pr diff`. Without it, a diff holding a raw terminal escape byte kills the review-input step before the sanitizer runs.
- **Review-posting fix** (`post-pr-review.sh`, `post-pr-review-retry.test.mjs`): retries a rejected review as `COMMENT` before falling back to a plain comment. Discovered because THIS PR's own `Automated review posted` gate stayed pending forever.

## Review focus

agent-sanitizer#321 hit the same escape-sequence failure and worked around it with `gh api ... -H "Accept: application/vnd.github.v3.diff"`. But `gh api` carries the identical guard (confirmed by reading gh's source), so that fix relocates the refusal rather than removing it.

Separately: `post-pr-review.sh`'s reviews-API POST always 422s on `APPROVE` under `GITHUB_TOKEN` — every recent `github-actions[bot]` review on this repo shows `COMMENTED` or `CHANGES_REQUESTED`, never `APPROVED` — and the old fallback posted a plain issue comment (not a review), so `review-gate.sh`'s "any undismissed review" check never cleared. `agent-sanitizer`'s `post-pr-review.mjs` already avoids this at the root (never emits APPROVE/REQUEST_CHANGES; gates via resolved threads instead), and `agent-glovebox` degrades comment-by-comment with the same always-COMMENT summary. Neither needed this fix; porting either's fuller design here is a separate, larger change.

## Decisions made

- The `needs-auto-review` label re-review attempt failed: `claude-code-action`'s actor-type gate rejected the triggering event because the label add came from a Bot-type actor (`ALLOWED_BOTS` empty). That gate is a deliberate control against a bot self-triggering a privileged review, not a bug, so I left it alone. Removed the label and pushed an `[opus-review]`-tagged commit instead.
- That re-review still could not validate the fix: `claude-review.yaml`'s review job checks out `github.event.repository.default_branch`, never the PR head, so every `pull_request_target` run — including this PR's own — always executes `main`'s pre-fix `post-pr-review.sh`. This is deliberate (a PR cannot rewrite the script that will run with its own secrets), so this PR's review can never post as a formal review before merge, and I did not touch it. The `Protecting main` ruleset's `Automated review posted` check has no bypass actor (`current_user_can_bypass: never`), so this PR needs a human merge past that one check. The fix is validated by `post-pr-review-retry.test.mjs` (3/3, run against this PR's real code via the normal `pull_request`-triggered test job) instead.

<details>
<summary>How it was tested</summary>

`uv run pytest tests/test_prepare_pr_review_input.py -q -o addopts=""` — 3 passed. `node --test .github/scripts/post-pr-review-retry.test.mjs` — 3 passed, driving the real `post-pr-review.sh` and `post-pr-review.mjs` against a fake `gh` rejecting a chosen event set. `shellcheck -x`, `shfmt -d`, `shellharden --check` clean on both scripts.

## Lessons Learned

- **What**: `gh api`, not only `gh pr diff`, enforces the escape-sequence guard regardless of TTY. Separately, `gh api POST .../reviews` with `event: APPROVE` can 422 under the default `GITHUB_TOKEN`, while `COMMENT` always succeeds.
- **Where**: any script piping a `gh api`/`gh pr diff` response through a command substitution; any review-poster whose fallback on rejection posts a plain comment instead of retrying as `COMMENT`.
- **Why**: switching gh subcommands doesn't clear the escape guard, only the flag does. A repo whose Actions permissions block a formal vote silently loses its review-required gate unless the poster retries as `COMMENT`.

</details>