### PR TITLE
fix(ci): close two silent-skip paths and an unscoped auth header in the decide gate

### DIFF
--- a/.github/scripts/decide-reusable-diff.sh
+++ b/.github/scripts/decide-reusable-diff.sh
@@ -121,7 +121,9 @@ fi
 # the collection-time import closure of a test; shell-targets gives what a shell
 # entry point can run. Both fail RED on a bad target and never fall back to the
 # regex alone: a silently empty closure would drop exactly the paths the input
-# exists to cover, which is the false green the caller opted in to prevent.
+# exists to cover, which is the false green the caller opted in to prevent. A
+# derivation that exits 0 with NO paths is caught below instead, by
+# path_gate_matching_members' empty-list arm.
 DERIVED_CLOSURE=""
 derive() {
   local _script="$1" _targets="$2" _what="$3" _out
@@ -157,7 +159,7 @@ paths_trigger() {
   fi
   if [[ -n "$DERIVED_CLOSURE" ]]; then
     mapfile -t -O "${#_matched[@]}" _matched < <(
-      grep -Fxf <(printf '%s\n' "$DERIVED_CLOSURE") <<<"$_changed" || true
+      path_gate_matching_members "$DERIVED_CLOSURE" "$_changed"
     )
   fi
   ((${#_matched[@]} > 0)) || return 0

--- a/.github/scripts/decide-reusable-diff.sh
+++ b/.github/scripts/decide-reusable-diff.sh
@@ -85,8 +85,12 @@ fi
 # no BASE_REF and keep their exact ranges. Fail-open: any fetch/resolve failure leaves
 # BASE_SHA at the webhook value — today's safe over-run, never an under-run.
 if [[ -n "${BASE_REF:-}" && -n "${GH_TOKEN:-}" ]]; then
+  # Scope the header to github.com, never bare `http.extraheader`: an unscoped
+  # header rides along to EVERY host this git process contacts, so a redirect or
+  # a submodule URL pointing elsewhere receives the token. The scoped key is the
+  # repo's one auth idiom (auto-resolve/lib.sh, prepare-merge-delta-input.sh).
   auth="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
-  if git -c "http.extraheader=AUTHORIZATION: basic $auth" \
+  if git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth" \
     fetch --no-tags --quiet origin "$BASE_REF" 2>/dev/null; then
     live_base="$(git rev-parse FETCH_HEAD 2>/dev/null || true)"
     # Only advance the base FORWARD along history: require the live tip to be a

--- a/.github/scripts/lib-path-match.sh
+++ b/.github/scripts/lib-path-match.sh
@@ -10,8 +10,8 @@
 # echo false` — all collapse 2 into "no". The job then skips, its always()
 # reporter greens the skip, and nothing looked at the diff.
 #
-# Both helpers fail OPEN on every status except a clean 1: a wasted run is safe,
-# a silently skipped gate is not. They fail open rather than abort because one
+# All three helpers fail OPEN on every status except a clean 1: a wasted run is
+# safe, a silently skipped gate is not. They fail open rather than abort because one
 # decide job computes many verdicts, and a hard exit there blocks every gate it
 # feeds instead of just over-running one.
 
@@ -31,6 +31,29 @@ path_gate_matches() {
 path_gate_matching_lines() {
   local rc=0 out=""
   out=$(grep -E "$1" <<<"$2") || rc=$?
+  if ((rc > 1)); then
+    out="$2"
+  fi
+  if [[ -n "$out" ]]; then
+    printf '%s\n' "$out"
+  fi
+  return 0
+}
+
+# path_gate_matching_members LIST TEXT — the lines of TEXT that are exact members
+# of the newline-separated LIST, or ALL of TEXT when grep failed or LIST is empty.
+# A clean no-match prints nothing. Always returns 0, like the helper above.
+#
+# The empty LIST is its own arm because a derivation that produced nothing is a
+# derivation that failed: reading it as "no member changed" is the silent skip
+# this file exists to prevent.
+path_gate_matching_members() {
+  local rc=0 out=""
+  if [[ -z "${1//[[:space:]]/}" ]]; then
+    printf '%s\n' "$2"
+    return 0
+  fi
+  out=$(grep -xFf <(printf '%s\n' "$1") <<<"$2") || rc=$?
   if ((rc > 1)); then
     out="$2"
   fi

--- a/tests/test_decide_reusable_diff.py
+++ b/tests/test_decide_reusable_diff.py
@@ -789,3 +789,39 @@ def test_memo_shadow_judges_comment_only_churn_over_the_memo_range(
     )
     assert "run=true" in output, output
     assert "would_run=false acting_run=true" in result.stdout, result.stdout
+
+
+# --- an empty derivation, and the auth header the re-anchor fetch carries ----
+
+
+def _empty_closure_python(tmp_path: Path) -> None:
+    """A `python3` that exits 0 printing nothing, standing in for a closure script
+    whose derivation succeeded but named no file."""
+    stub = tmp_path / "python3"
+    stub.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    stub.chmod(0o755)
+
+
+def test_an_empty_derived_closure_fails_open(tmp_path: Path) -> None:
+    """A closure script that exits 0 naming NO path is a derivation that failed.
+    Reading it as "no watched file changed" skips the job the input exists to
+    trigger and greens its required check, so the gate must run instead."""
+    _empty_closure_python(tmp_path)
+    diff = _flood(tmp_path / "diff.txt", CLOSURE_MEMBER)
+    output = _run(
+        tmp_path,
+        PATHS_REGEX="^docs/",
+        PYTEST_TARGETS=PYTEST_TARGET,
+        FAKE_DIFF_FILE=str(diff),
+    )
+    assert "run=true" in output, output
+
+
+def test_an_empty_derived_closure_is_what_flips_that_verdict(tmp_path: Path) -> None:
+    """Non-vacuity for the case above: the SAME diff and regex with no targets
+    configured still yields run=false, so the fail-open comes from the empty
+    closure rather than from the diff matching something."""
+    _empty_closure_python(tmp_path)
+    diff = _flood(tmp_path / "diff.txt", CLOSURE_MEMBER)
+    output = _run(tmp_path, PATHS_REGEX="^docs/", FAKE_DIFF_FILE=str(diff))
+    assert "run=false" in output, output

--- a/tests/test_decide_reusable_diff.py
+++ b/tests/test_decide_reusable_diff.py
@@ -825,3 +825,41 @@ def test_an_empty_derived_closure_is_what_flips_that_verdict(tmp_path: Path) -> 
     diff = _flood(tmp_path / "diff.txt", CLOSURE_MEMBER)
     output = _run(tmp_path, PATHS_REGEX="^docs/", FAKE_DIFF_FILE=str(diff))
     assert "run=false" in output, output
+
+
+def test_the_reanchor_fetch_scopes_its_auth_header_to_github(tmp_path: Path) -> None:
+    """The token rides an http.extraheader on the live-base fetch. A BARE
+    `http.extraheader` attaches it to every host this git process contacts, so a
+    redirect or a submodule URL elsewhere would receive it — the header must name
+    github.com."""
+    repo = tmp_path / "r"
+    stale_base, _live, head = _merge_conflict_pr(repo)
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "git-argv.log"
+    real_git = shutil.which("git")
+    assert real_git, "the fixture drives real git through the wrapper"
+    wrapper = bindir / "git"
+    wrapper.write_text(
+        f'#!/usr/bin/env bash\nprintf "%s\\n" "$*" >> {log}\nexec {real_git} "$@"\n',
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+
+    _run_realgit_out(
+        repo,
+        PATH=f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        BASE_SHA=stale_base,
+        HEAD_SHA=head,
+        BASE_REF="main",
+        GH_TOKEN="x",
+        PATHS_REGEX=r"^\.claude/hooks/",
+    )
+    fetches = [
+        line
+        for line in log.read_text(encoding="utf-8").splitlines()
+        if " fetch " in f" {line} "
+    ]
+    assert fetches, "the re-anchor fetch must have run, or this pins nothing"
+    assert all("http.https://github.com/.extraheader=" in line for line in fetches)
+    assert not any(re.search(r"(?<![.\w])http\.extraheader=", line) for line in fetches)

--- a/tests/test_lib_path_match.py
+++ b/tests/test_lib_path_match.py
@@ -1,0 +1,147 @@
+"""Behavioral tests for .github/scripts/lib-path-match.sh.
+
+Every helper here answers one question for a path gate: did anything watched
+change? A gate that reads a TOOL FAILURE as "no" skips its expensive job, and the
+job's always() reporter greens the skip — a required check that verified nothing.
+So each helper must fail OPEN (report the widest match) on anything except a
+clean "grep looked and found no line".
+
+The cases below drive the helpers through real bash, with a stub `grep` on PATH
+for the failure arms, because grep's exit 2 is not reachable from a well-formed
+call.
+"""
+
+import os
+from pathlib import Path
+
+from tests._helpers import REPO_ROOT, run_capture
+
+LIB = REPO_ROOT / ".github" / "scripts" / "lib-path-match.sh"
+
+CHANGED = "src/app.js\ntests/_fake_gh.py\ndocs/readme.md"
+
+
+def _bash(
+    snippet: str, *args: str, path_prepend: Path | None = None
+) -> tuple[int, str]:
+    """Source the lib and run `snippet`; returns (exit status, stdout)."""
+    env = {**os.environ}
+    if path_prepend is not None:
+        env["PATH"] = f"{path_prepend}{os.pathsep}{env['PATH']}"
+    res = run_capture(["bash", "-c", f'. "{LIB}"\n{snippet}', "bash", *args], env=env)
+    assert "not found" not in res.stderr, res.stderr
+    return res.returncode, res.stdout
+
+
+def _failing_grep(tmp_path: Path) -> Path:
+    """A `grep` that exits 2 — grep's own "I failed", not "no line matched"."""
+    stub = tmp_path / "grep"
+    stub.write_text("#!/usr/bin/env bash\nexit 2\n", encoding="utf-8")
+    stub.chmod(0o755)
+    return tmp_path
+
+
+# --- path_gate_matches ------------------------------------------------------
+
+
+def test_matches_reports_a_hit() -> None:
+    assert _bash('path_gate_matches "$1" "$2"', r"^src/", CHANGED)[0] == 0
+
+
+def test_matches_reports_a_clean_no_match() -> None:
+    assert _bash('path_gate_matches "$1" "$2"', r"^nope/", CHANGED)[0] == 1
+
+
+def test_matches_fails_open_when_grep_fails(tmp_path: Path) -> None:
+    status, _ = _bash(
+        'path_gate_matches "$1" "$2"',
+        r"^nope/",
+        CHANGED,
+        path_prepend=_failing_grep(tmp_path),
+    )
+    assert status == 0, "a grep failure must read as a match, never as no-match"
+
+
+# --- path_gate_matching_lines -----------------------------------------------
+
+
+def test_matching_lines_prints_only_the_matches() -> None:
+    status, out = _bash('path_gate_matching_lines "$1" "$2"', r"^src/", CHANGED)
+    assert (status, out) == (0, "src/app.js\n")
+
+
+def test_matching_lines_prints_nothing_on_a_clean_no_match() -> None:
+    assert _bash('path_gate_matching_lines "$1" "$2"', r"^nope/", CHANGED) == (0, "")
+
+
+def test_matching_lines_fails_open_to_every_line_when_grep_fails(
+    tmp_path: Path,
+) -> None:
+    status, out = _bash(
+        'path_gate_matching_lines "$1" "$2"',
+        r"^nope/",
+        CHANGED,
+        path_prepend=_failing_grep(tmp_path),
+    )
+    assert (status, out) == (0, CHANGED + "\n")
+
+
+# --- path_gate_matching_members ---------------------------------------------
+
+MEMBERS = "tests/_fake_gh.py\ntests/conftest.py"
+
+
+def test_matching_members_prints_the_exact_members() -> None:
+    status, out = _bash('path_gate_matching_members "$1" "$2"', MEMBERS, CHANGED)
+    assert (status, out) == (0, "tests/_fake_gh.py\n")
+
+
+def test_matching_members_is_whole_line_not_a_prefix() -> None:
+    """A longer path sharing a member's prefix is not a member: a substring match
+    would over-run every gate that derives its watched paths."""
+    changed = "tests/_fake_gh.py.orig"
+    assert _bash('path_gate_matching_members "$1" "$2"', MEMBERS, changed) == (0, "")
+
+
+def test_matching_members_prints_nothing_on_a_clean_no_match() -> None:
+    assert _bash('path_gate_matching_members "$1" "$2"', "docs/nope.md", CHANGED) == (
+        0,
+        "",
+    )
+
+
+def test_matching_members_fails_open_to_every_line_when_grep_fails(
+    tmp_path: Path,
+) -> None:
+    status, out = _bash(
+        'path_gate_matching_members "$1" "$2"',
+        MEMBERS,
+        CHANGED,
+        path_prepend=_failing_grep(tmp_path),
+    )
+    assert (status, out) == (0, CHANGED + "\n")
+
+
+def test_matching_members_fails_open_on_an_empty_list() -> None:
+    """A derivation that produced nothing is a derivation that failed. Reading it
+    as "no member changed" is the silent skip this file exists to prevent."""
+    status, out = _bash('path_gate_matching_members "$1" "$2"', "", CHANGED)
+    assert (status, out) == (0, CHANGED + "\n")
+
+
+def test_matching_members_fails_open_on_a_blank_only_list() -> None:
+    """The shape a real caller produces: a closure script that exits 0 printing
+    nothing leaves the accumulator holding only its separator newlines."""
+    status, out = _bash('path_gate_matching_members "$1" "$2"', "\n\n", CHANGED)
+    assert (status, out) == (0, CHANGED + "\n")
+
+
+def test_the_replaced_idiom_would_have_matched_nothing() -> None:
+    """Non-vacuity for the two arms above: the inline `grep -xFf … || true` these
+    helpers replace answers "nothing matched" for BOTH an empty list and a failed
+    grep — the false green, reproduced here against real grep so the assertions
+    above pin a behavior change rather than a restatement."""
+    status, out = _bash(
+        'grep -xFf <(printf \'%s\\n\' "$1") <<<"$2" || true', "\n\n", CHANGED
+    )
+    assert (status, out) == (0, "")


### PR DESCRIPTION
## What & why

Close two ways `.github/scripts/decide-reusable-diff.sh` and its path-match library can green a required check that scanned nothing, and one credential-scope hole in the same script.

1. **A grep failure read as "no watched path changed."** The derived-closure match was an inline `grep -Fxf <(…) <<<"$_changed" || true`. `grep` exits 1 for "no line matched" but 2 for a failure of its own, and `|| true` collapses both into "no". The gate then emits `run=false`, its `always()` reporter greens the skip, and nothing looked at the diff — the exact defect class `lib-path-match.sh` was written to remove. The match now goes through `path_gate_matching_members`.
2. **An empty derived list read as "nothing matched."** `path_gate_matching_members` is ported from the `agent-glovebox` fork, where it was added. A closure script that exits 0 naming no file is a derivation that failed, so the helper reports every changed line and the gated job runs. The template is where that arm belongs: every repo that syncs from here inherits it.
3. **An unscoped auth header.** The live-base re-anchor fetch passed the token as a bare `http.extraheader`. Git attaches an unscoped header to every host it contacts during that fetch, so a redirect or a submodule URL pointing elsewhere receives the token. It is now `http.https://github.com/.extraheader`, the form every other auth site in `.github/scripts` already uses.

One commit per item.

## Review focus

`path_gate_matching_members` is the shape downstream repos inherit, so it matches the two helpers beside it: always returns 0, prints nothing on a clean no-match, and fails OPEN (prints all of TEXT) on a grep error, on an empty list, and on a blank-only list. Blank-only is the shape a real caller produces — `derive` appends a separator newline per target, so two empty closures leave the accumulator holding only newlines.

## How it was tested

- New `tests/test_lib_path_match.py`: 13 cases over the three helpers, with a stub `grep` that exits 2 for the failure arms (grep's exit 2 is not reachable from a well-formed call). The last case runs the replaced `grep -Fxf … || true` idiom against real grep and pins that it answers "nothing matched" — so the fail-open assertions record a behavior change, not a restatement.
- New cases in `tests/test_decide_reusable_diff.py`: an empty derivation (a stub `python3` that exits 0 printing nothing) makes the gate run, plus a non-vacuity twin with no targets configured that still yields `run=false`; and a `git` wrapper that logs its argv proves the re-anchor fetch carries the github.com-scoped header and no bare one.
- Non-vacuity, measured: with the three fixes reverted, exactly the four new fail-open/scope cases fail and the other 52 pass.
- `pytest -q` — 562 passed. Two failures are unrelated to this diff and reproduce on `main` in this container: `tests/test_drop_superseded_ci_events.py` and `tests/test_pnpm_supply_chain.py::test_exempted_packages_are_first_party` both need `node_modules`, which is not installed here.
- `pre-commit run --files <the four files>` — all hooks pass except `check-proto-pollution`, which cannot import `typescript` for the same missing-`node_modules` reason.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VvuJNE8pEstzwvSmir592V)_