### PR TITLE
fix(review-gate): stop a pull request from clearing its own review gate

### DIFF
--- a/.github/scripts/append-haiku-cost.sh
+++ b/.github/scripts/append-haiku-cost.sh
@@ -15,13 +15,16 @@ set -euo pipefail
 
 : "${GH_REPO:?GH_REPO required}"
 : "${PR:?PR number required}"
-REVIEWER_LOGIN="${REVIEWER_LOGIN:-github-actions[bot]}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/reviewer-login.bash disable=SC1091
+source "$SCRIPT_DIR/lib/reviewer-login.bash"
+reviewer_login_init
 
 # The reviewer's most recent costed review. Paginated so a PR with >100 reviews
 # still finds the newest match: the per-page --jq emits each matching review as
 # NDJSON, the slurp picks the last (newest — the API returns reviews oldest-first).
-target="$(REVIEWER_LOGIN="$REVIEWER_LOGIN" gh api --paginate "repos/${GH_REPO}/pulls/${PR}/reviews" \
-  --jq '.[] | select(.user.login == env.REVIEWER_LOGIN and (.body | test("<!-- review-cost usd="))) | {id, body}' |
+target="$(gh api --paginate "repos/${GH_REPO}/pulls/${PR}/reviews" \
+  --jq ".[] | ${REVIEWER_MATCH_USER} | select(.body | test(\"<!-- review-cost usd=\")) | {id, body}" |
   jq -s 'last // empty')"
 
 if [[ -z "$target" ]]; then

--- a/.github/scripts/approve-if-reviewer-hold-clear.sh
+++ b/.github/scripts/approve-if-reviewer-hold-clear.sh
@@ -52,15 +52,15 @@ GH_TOKEN="$(github_token_with_quota)" || {
   exit 1
 }
 export GH_TOKEN
-REVIEWER_LOGIN="${REVIEWER_LOGIN:-github-actions[bot]}"
-# GitHub's GraphQL API returns an app bot's `login` WITHOUT the `[bot]` suffix the
-# REST API appends (REST `github-actions[bot]` ↔ GraphQL `github-actions`). Both
-# reviewer lookups below run through `gh api graphql`, so they compare against the
-# BARE login — strip a trailing `[bot]` from the configured value (and, in the jq,
-# from each node's login) so either spelling matches. Comparing the REST-shaped
-# `github-actions[bot]` against GraphQL's `github-actions` matched zero reviews, so
-# the script always concluded "no live hold" and never posted the clearing approval.
-REVIEWER_LOGIN_BARE="${REVIEWER_LOGIN%'[bot]'}"
+# Both reviewer lookups below run through `gh api graphql`, which spells an app
+# bot's login WITHOUT the `[bot]` suffix the REST API appends (REST
+# `github-actions[bot]` ↔ GraphQL `github-actions`). Comparing the REST-shaped
+# value against GraphQL's matched zero reviews, so this script always concluded
+# "no live hold" and never posted the clearing approval; reviewer_login_init owns
+# that normalization now, for every reviewer script (lib/reviewer-login.bash).
+# shellcheck source=lib/reviewer-login.bash disable=SC1091
+source "$SCRIPT_DIR/lib/reviewer-login.bash"
+reviewer_login_init
 
 owner="${GH_REPO%%/*}"
 name="${GH_REPO##*/}"
@@ -87,11 +87,11 @@ remaining_query='query($owner: String!, $name: String!, $pr: Int!, $endCursor: S
 # "unresolved == 0" (trivially true with no threads) would merge the reviewer's
 # concern unaddressed.
 # shellcheck disable=SC2016 # jq program is literal, not shell ($p is a jq var)
-counts="$(REVIEWER_LOGIN_BARE="$REVIEWER_LOGIN_BARE" gh api graphql --paginate \
+counts="$(gh api graphql --paginate \
   -f query="$remaining_query" -f owner="$owner" -f name="$name" -F pr="$PR" \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-         | select((.comments.nodes[0].author.login // "" | sub("\\[bot\\]$"; "")) == env.REVIEWER_LOGIN_BARE)]
-        | {total: length, unresolved: (map(select(.isResolved == false)) | length)}' |
+  --jq "[.data.repository.pullRequest.reviewThreads.nodes[]
+         | ${REVIEWER_MATCH_THREAD_ROOT}]
+        | {total: length, unresolved: (map(select(.isResolved == false)) | length)}" |
   jq -s 'reduce .[] as $p ({total: 0, unresolved: 0};
            {total: (.total + $p.total), unresolved: (.unresolved + $p.unresolved)})')"
 unresolved="$(jq -r '.unresolved' <<<"$counts")"
@@ -139,11 +139,11 @@ reviews_query='query($owner: String!, $name: String!, $pr: Int!, $endCursor: Str
     }
   }
 }'
-latest_state="$(REVIEWER_LOGIN_BARE="$REVIEWER_LOGIN_BARE" gh api graphql --paginate \
+latest_state="$(gh api graphql --paginate \
   -f query="$reviews_query" -f owner="$owner" -f name="$name" -F pr="$PR" \
-  --jq '.data.repository.pullRequest.reviews.nodes[]
-        | select((.author.login // "" | sub("\\[bot\\]$"; "")) == env.REVIEWER_LOGIN_BARE)
-        | {state, submittedAt}' |
+  --jq ".data.repository.pullRequest.reviews.nodes[]
+        | ${REVIEWER_MATCH_AUTHOR}
+        | {state, submittedAt}" |
   jq -rs 'if length == 0 then "" else (sort_by(.submittedAt) | last | .state) end')"
 
 if [[ "$latest_state" != "CHANGES_REQUESTED" && "$latest_state" != "COMMENTED" ]]; then
@@ -175,12 +175,12 @@ dismiss_stale_hold() {
   # CHANGES_REQUESTED keeps blocking until dismissed or superseded by an APPROVED
   # from the same reviewer, and a later COMMENTED review does not clear it. So the
   # blocking review is routinely not the latest one.
-  review_id="$(REVIEWER_LOGIN_BARE="$REVIEWER_LOGIN_BARE" gh api graphql --paginate \
+  review_id="$(gh api graphql --paginate \
     -f query="$reviews_query" -f owner="$owner" -f name="$name" -F pr="$PR" \
-    --jq '.data.repository.pullRequest.reviews.nodes[]
-          | select((.author.login // "" | sub("\\[bot\\]$"; "")) == env.REVIEWER_LOGIN_BARE)
-          | select(.state == "CHANGES_REQUESTED")
-          | {databaseId, submittedAt}' |
+    --jq ".data.repository.pullRequest.reviews.nodes[]
+          | ${REVIEWER_MATCH_AUTHOR}
+          | select(.state == \"CHANGES_REQUESTED\")
+          | {databaseId, submittedAt}" |
     jq -rs 'if length == 0 then "" else (sort_by(.submittedAt) | last | .databaseId) end')"
 
   if [[ -z "$review_id" ]]; then

--- a/.github/scripts/decide-pr-review-trigger.sh
+++ b/.github/scripts/decide-pr-review-trigger.sh
@@ -33,14 +33,20 @@
 # eval). A transient API failure yields run=false (no review, no red) rather than
 # a spurious re-review.
 #
-# Env: GH_TOKEN, ACTION, REPO, HEAD_SHA, PR, LABEL (LABEL set only on `labeled`).
+# Env: GH_TOKEN, ACTION, REPO, HEAD_SHA, PR, LABEL (LABEL set only on `labeled`);
+# REVIEWER_LOGIN optional.
 set -euo pipefail
 
 KEYWORD="[opus-review]"
 REVIEW_LABEL="needs-auto-review"
 # The reviewer posts with GITHUB_TOKEN, so its reviews are authored by this bot;
 # the latest review it left is the effective verdict that gates the PR.
-REVIEWER="github-actions[bot]"
+# reviewer_login_init owns that identity for every reviewer script, including the
+# REST/GraphQL `[bot]`-suffix mismatch (lib/reviewer-login.bash).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/reviewer-login.bash disable=SC1091
+source "$SCRIPT_DIR/lib/reviewer-login.bash"
+reviewer_login_init
 OPUS_MODEL="claude-opus-4-8"
 HAIKU_MODEL="claude-haiku-4-5"
 
@@ -106,9 +112,9 @@ fi
 # `--paginate` would run the filter per page and concatenate. A transient API
 # failure yields empty -> no re-review.
 state="$(gh api "repos/$REPO/pulls/${PR:-}/reviews" --paginate --slurp \
-  --jq "[.[][] | select(.user.login == \"$REVIEWER\")] | last | .state // empty" 2>/dev/null || true)"
+  --jq "[.[][] | ${REVIEWER_MATCH_USER}] | last | .state // empty" 2>/dev/null || true)"
 if [[ "$state" == "CHANGES_REQUESTED" || "$state" == "COMMENTED" ]]; then
-  emit true "outstanding $REVIEWER hold ($state) — re-checking on Haiku" "$HAIKU_MODEL"
+  emit true "outstanding $REVIEWER_LOGIN hold ($state) — re-checking on Haiku" "$HAIKU_MODEL"
 else
   emit false "no $KEYWORD opt-in and no outstanding reviewer hold"
 fi

--- a/.github/scripts/detect-reviewer-body-hold.sh
+++ b/.github/scripts/detect-reviewer-body-hold.sh
@@ -24,12 +24,13 @@ set -euo pipefail
 : "${GH_REPO:?GH_REPO required}"
 : "${PR:?PR number required}"
 : "${PR_INPUT_DIR:?PR_INPUT_DIR required}"
-REVIEWER_LOGIN="${REVIEWER_LOGIN:-github-actions[bot]}"
-# GraphQL returns an app bot's `login` WITHOUT the REST `[bot]` suffix
-# (`github-actions`, not `github-actions[bot]`); both queries below run through
-# `gh api graphql`, so match against the BARE login (and strip `[bot]` from each
-# node's login in the jq) — the same normalization the sibling reviewer scripts do.
-REVIEWER_LOGIN_BARE="${REVIEWER_LOGIN%'[bot]'}"
+# Both queries below run through `gh api graphql`, which spells an app bot's
+# login without the REST `[bot]` suffix; reviewer_login_init owns that
+# normalization for every reviewer script (lib/reviewer-login.bash).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/reviewer-login.bash disable=SC1091
+source "$SCRIPT_DIR/lib/reviewer-login.bash"
+reviewer_login_init
 
 mkdir -p "$PR_INPUT_DIR"
 owner="${GH_REPO%%/*}"
@@ -56,11 +57,11 @@ threads_query='query($owner: String!, $name: String!, $pr: Int!, $endCursor: Str
     }
   }
 }'
-reviewer_threads="$(REVIEWER_LOGIN_BARE="$REVIEWER_LOGIN_BARE" gh api graphql --paginate \
+reviewer_threads="$(gh api graphql --paginate \
   -f query="$threads_query" -f owner="$owner" -f name="$name" -F pr="$PR" \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-         | select((.comments.nodes[0].author.login // "" | sub("\\[bot\\]$"; "")) == env.REVIEWER_LOGIN_BARE)]
-        | length' | jq -s 'add // 0')"
+  --jq "[.data.repository.pullRequest.reviewThreads.nodes[]
+         | ${REVIEWER_MATCH_THREAD_ROOT}]
+        | length" | jq -s 'add // 0')"
 
 if [[ "${reviewer_threads:-0}" -ne 0 ]]; then
   no_hold "reviewer opened ${reviewer_threads} thread(s); the thread resolver owns this hold — not a body-only hold"
@@ -80,11 +81,11 @@ reviews_query='query($owner: String!, $name: String!, $pr: Int!, $endCursor: Str
     }
   }
 }'
-latest="$(REVIEWER_LOGIN_BARE="$REVIEWER_LOGIN_BARE" gh api graphql --paginate \
+latest="$(gh api graphql --paginate \
   -f query="$reviews_query" -f owner="$owner" -f name="$name" -F pr="$PR" \
-  --jq '.data.repository.pullRequest.reviews.nodes[]
-        | select((.author.login // "" | sub("\\[bot\\]$"; "")) == env.REVIEWER_LOGIN_BARE)
-        | {state, body, submittedAt}' |
+  --jq ".data.repository.pullRequest.reviews.nodes[]
+        | ${REVIEWER_MATCH_AUTHOR}
+        | {state, body, submittedAt}" |
   jq -rs 'if length == 0 then empty else (sort_by(.submittedAt) | last) end')"
 
 [[ -n "$latest" ]] || no_hold "reviewer never reviewed this PR; no body hold"

--- a/.github/scripts/fetch-unresolved-review-threads.sh
+++ b/.github/scripts/fetch-unresolved-review-threads.sh
@@ -18,22 +18,22 @@
 # Env: GH_TOKEN, GH_REPO (owner/name), PR, PR_INPUT_DIR; REVIEWER_LOGIN optional.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/lib-ci-retry.sh
-source "$(dirname "${BASH_SOURCE[0]}")/lib-ci-retry.sh"
+source "$SCRIPT_DIR/lib-ci-retry.sh"
+# shellcheck source=lib/reviewer-login.bash disable=SC1091
+source "$SCRIPT_DIR/lib/reviewer-login.bash"
 
 : "${GH_REPO:?GH_REPO required}"
 : "${PR:?PR number required}"
 : "${PR_INPUT_DIR:?PR_INPUT_DIR required}"
-REVIEWER_LOGIN="${REVIEWER_LOGIN:-github-actions[bot]}"
-# GraphQL returns an app bot's `login` WITHOUT the REST `[bot]` suffix
-# (`github-actions`, not `github-actions[bot]`), and the thread query below runs
-# through `gh api graphql`; compare against the BARE login so the reviewer's own
-# threads are actually matched. Comparing the REST-shaped `github-actions[bot]`
-# matched zero threads, so has_threads was always false and the Haiku resolver
-# never ran.
-# Exported so the gh child inside retry_stdout's subshell sees it — the --jq
-# filter below reads env.REVIEWER_LOGIN_BARE.
-export REVIEWER_LOGIN_BARE="${REVIEWER_LOGIN%'[bot]'}"
+# The thread query below runs through `gh api graphql`, which spells an app bot's
+# login WITHOUT the REST `[bot]` suffix. Comparing the REST-shaped
+# `github-actions[bot]` matched zero threads, so has_threads was always false and
+# the Haiku resolver never ran; reviewer_login_init owns that normalization now
+# for every reviewer script, and EXPORTS the bare login so the gh child inside
+# retry_stdout's subshell sees the env.REVIEWER_LOGIN_BARE the --jq filter reads.
+reviewer_login_init
 
 mkdir -p "$PR_INPUT_DIR"
 owner="${GH_REPO%%/*}"
@@ -70,10 +70,10 @@ GRAPHQL
 ndjson="${PR_INPUT_DIR}/threads.ndjson"
 threads_ndjson="$(retry_stdout gh api graphql --paginate \
   -f query="$QUERY" -f owner="$owner" -f name="$name" -F pr="$PR" \
-  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+  --jq ".data.repository.pullRequest.reviewThreads.nodes[]
         | select(.isResolved == false)
-        | select((.comments.nodes[0].author.login // "" | sub("\\[bot\\]$"; "")) == env.REVIEWER_LOGIN_BARE)
-        | {id, path, line, body: .comments.nodes[0].body}')"
+        | ${REVIEWER_MATCH_THREAD_ROOT}
+        | {id, path, line, body: .comments.nodes[0].body}")"
 printf '%s\n' "$threads_ndjson" >"$ndjson"
 
 # Slurp the NDJSON into an array and stamp a 1-based index onto each thread.

--- a/.github/scripts/lib/reviewer-login.bash
+++ b/.github/scripts/lib/reviewer-login.bash
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+# One source of truth for "is this review / thread / comment the automated
+# reviewer's?" — the identity predicate four scripts key their safety on.
+#
+# PROBLEM CLASS — two API dialects spell the same bot two ways. REST returns an
+# app bot's login WITH the `[bot]` suffix (`github-actions[bot]`); GraphQL
+# returns it WITHOUT (`github-actions`). A script that compares the configured
+# REVIEWER_LOGIN verbatim matches nothing in one of the two dialects, and a
+# reviewer filter that matches nothing does not fail loudly — it silently answers
+# "no reviewer thread", "no live hold", or "any actor will do". Both directions
+# already shipped as live bugs here: the hold-clear script never posted its
+# clearing approval, and the thread fetcher always reported zero threads.
+#
+# The fix each script grew independently was the same three lines — default the
+# login, strip a trailing `[bot]`, and compare against a login the jq filter also
+# strips. Three copies of a security predicate is three chances for one of them to
+# drift; this file is the fourth caller's reason to exist as a library instead.
+#
+# Usage:
+#   source "$SCRIPT_DIR/lib/reviewer-login.bash"
+#   reviewer_login_init
+#   … --jq "[.data.…nodes[] | ${REVIEWER_MATCH_THREAD_ROOT}] | length"
+#
+# reviewer_login_init exports REVIEWER_LOGIN_BARE because the select clauses read
+# it as `env.REVIEWER_LOGIN_BARE`: jq sees the environment, not the shell's
+# unexported variables.
+
+[[ -n "${_REVIEWER_LOGIN_SOURCED:-}" ]] && return 0
+_REVIEWER_LOGIN_SOURCED=1
+
+# reviewer_login_select <jq-path> — a jq `select(…)` that keeps only the elements
+# whose login at <jq-path> is the reviewer's, in either dialect's spelling.
+#
+# `// ""` covers a null author (a deleted account, or a GraphQL node the token
+# cannot see): it becomes the empty string, which never equals a bare login, so
+# an unattributable review is never credited to the reviewer.
+reviewer_login_select() {
+  local login_path="${1:?reviewer_login_select: a jq path to the login is required}"
+  printf '%s' "select(((${login_path}) // \"\" | sub(\"\\\\[bot\\\\]\$\"; \"\")) == env.REVIEWER_LOGIN_BARE)"
+}
+
+# reviewer_login_init — set and export REVIEWER_LOGIN / REVIEWER_LOGIN_BARE from
+# the caller's environment (default: the GITHUB_TOKEN identity every reviewer
+# script posts under), then define the three select clauses in use.
+reviewer_login_init() {
+  REVIEWER_LOGIN="${REVIEWER_LOGIN:-github-actions[bot]}"
+  REVIEWER_LOGIN_BARE="${REVIEWER_LOGIN%'[bot]'}"
+  export REVIEWER_LOGIN REVIEWER_LOGIN_BARE
+
+  # GraphQL review / comment node.
+  REVIEWER_MATCH_AUTHOR="$(reviewer_login_select .author.login)"
+  # GraphQL review THREAD: the root comment's author owns the thread.
+  REVIEWER_MATCH_THREAD_ROOT="$(reviewer_login_select .comments.nodes[0].author.login)"
+  # REST review object.
+  REVIEWER_MATCH_USER="$(reviewer_login_select .user.login)"
+  export REVIEWER_MATCH_AUTHOR REVIEWER_MATCH_THREAD_ROOT REVIEWER_MATCH_USER
+}

--- a/.github/scripts/review-gate.sh
+++ b/.github/scripts/review-gate.sh
@@ -8,8 +8,10 @@
 # review simply was not part of the merge gate.
 #
 # The predicate is one line and stateless: a pull request is clear when at least
-# one review of it stands undismissed. It needs no memory of which reviews have
-# been seen, and it re-derives the same answer on every event.
+# one undismissed review of it was written BY THE REVIEWER and carries a body.
+# It needs no memory of which reviews have been seen, and it re-derives the same
+# answer on every event. Both halves of "by the reviewer, with a body" are load-
+# bearing — see the filter below.
 #
 # PR-SCOPED, NOT HEAD-SCOPED, and that is load-bearing. Requiring a review OF THE
 # CURRENT HEAD looks stricter and strands the pull request instead:
@@ -30,13 +32,19 @@
 # Can't-verify is RED, never green: an API failure propagates through `set -e`,
 # because a gate that fails open lets a PR merge past a review nobody read.
 #
-# Env: GH_TOKEN, GH_REPO (owner/name), PR, HEAD_SHA, RUN_URL.
+# Env: GH_TOKEN, GH_REPO (owner/name), PR, HEAD_SHA, RUN_URL; REVIEWER_LOGIN
+# optional.
 set -euo pipefail
 
 : "${GH_REPO:?GH_REPO required}"
 : "${PR:?PR number required}"
 : "${HEAD_SHA:?HEAD_SHA required}"
 : "${GH_TOKEN:?GH_TOKEN required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/reviewer-login.bash disable=SC1091
+source "$SCRIPT_DIR/lib/reviewer-login.bash"
+reviewer_login_init
 
 # MUST stay byte-identical to the `name:` of the job in review-gate.yaml: that
 # job name is what sync-required-checks registers as the ruleset's required
@@ -53,12 +61,31 @@ GATE_CONTEXT="Automated review posted"
 # --paginate --jq` applies the filter to EACH page, so a `first`/`max_by` would
 # silently run once per page and answer from the last one.
 #
-# Any actor's review counts. The reviewer's own clears it, and so does the
-# approval auto-approve-skipped posts for a PR the reviewer skips by title or
-# author — reading that OUTCOME rather than re-deriving the skip predicate,
-# which would be a second copy of decide-pr-review-trigger.sh's rules.
+# ONLY THE REVIEWER'S OWN reviews count, and only ones carrying a body. The
+# gate's whole claim is "an automated review of this pull request exists", so
+# every actor it credits has to be one that actually reviews:
+#
+#   * Any actor at all is a self-clearing gate. The PR author can open their own
+#     pull request, submit a COMMENT review on it with one word, and the required
+#     "Automated review posted" context goes green with no reviewer having run.
+#     The reviewer identity filter closes that: the author's review is not the
+#     reviewer's, so it credits nothing.
+#   * A body-less review is not a review. GitHub SYNTHESIZES a body-less
+#     COMMENTED review around a standalone review comment, and this repo posts
+#     those under the reviewer's own identity — resolve-addressed-threads.sh
+#     replies in-thread with addPullRequestReviewThreadReply on every
+#     auto-resolved thread. Without the body filter, that reply alone greens the
+#     gate for a pull request the reviewer is still holding. Every writer of a
+#     REAL review here sends a non-empty body: post-pr-review.mjs falls back to
+#     "Automated review." when the model returns nothing, auto-approve-skipped-pr.sh
+#     and approve-if-reviewer-hold-clear.sh both hardcode theirs.
+#
+# The approval that auto-approve-skipped posts for a PR the reviewer skips by
+# title or author still clears the gate: it is posted with GITHUB_TOKEN, so it
+# carries the reviewer identity. Reading that OUTCOME beats re-deriving the skip
+# predicate, which would be a second copy of decide-pr-review-trigger.sh's rules.
 reviewers="$(gh api --paginate "repos/${GH_REPO}/pulls/${PR}/reviews" \
-  --jq '.[] | select(.state != "DISMISSED") | .user.login // ""')"
+  --jq ".[] | select(.state != \"DISMISSED\") | ${REVIEWER_MATCH_USER} | select((.body // \"\") != \"\") | .user.login // \"\"")"
 reviewer="$(head -n 1 <<<"$reviewers")"
 
 if [[ -n "$reviewer" ]]; then

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -71,6 +71,22 @@ jobs:
   #     fork PR touching CI, tests, or docs is exactly what a human wants a
   #     second read on. A PR whose title isn't a recognized skip-type is
   #     reviewed (fail toward reviewing).
+  #
+  # THE TITLE SKIP IS GATED ON A TRUSTED AUTHOR, and the same guard appears
+  # verbatim on auto-approve-skipped below. A PR title is written by the PR
+  # AUTHOR, so on its own it is an attacker-chosen string that decides whether
+  # this repo reviews the PR at all: an outside contributor titling a fork PR
+  # `chore: bump` skipped the review AND collected the auto-approval, clearing
+  # three merge levers with one string. The guard is the pair GitHub sets, not
+  # the author: `head.repo.full_name` (same-repo branch, so the author already
+  # has push access) or `author_association` in OWNER/MEMBER/COLLABORATOR.
+  #
+  # It must gate BOTH jobs or neither. Guarding only the approval leaves an
+  # untrusted `chore:` PR skipped here and approved by nobody — reviewed by
+  # nobody, with no event able to produce either outcome. Guarded on both, the
+  # skip set is simply EMPTY for an untrusted author: their PR always gets the
+  # real review, whatever its title.
+  #
   # This job `if:` carries the cheap payload-only skips (no runner boots for a
   # draft/bot/docs PR); the script then decides opened/ready (always, on Opus) vs
   # synchronize (the [opus-review] head-commit opt-in on Opus, or a Haiku
@@ -85,12 +101,20 @@ jobs:
       (
         github.event.pull_request.draft == false &&
         github.event.pull_request.user.type != 'Bot' &&
-        !startsWith(github.event.pull_request.title, 'chore:') &&
-        !startsWith(github.event.pull_request.title, 'chore(') &&
-        !startsWith(github.event.pull_request.title, 'style:') &&
-        !startsWith(github.event.pull_request.title, 'style(') &&
-        !startsWith(github.event.pull_request.title, 'release:') &&
-        !startsWith(github.event.pull_request.title, 'release(')
+        (
+          !(
+            github.event.pull_request.head.repo.full_name == github.repository ||
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+          ) ||
+          (
+            !startsWith(github.event.pull_request.title, 'chore:') &&
+            !startsWith(github.event.pull_request.title, 'chore(') &&
+            !startsWith(github.event.pull_request.title, 'style:') &&
+            !startsWith(github.event.pull_request.title, 'style(') &&
+            !startsWith(github.event.pull_request.title, 'release:') &&
+            !startsWith(github.event.pull_request.title, 'release(')
+          )
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -295,9 +319,18 @@ jobs:
   # on the ruleset NOT dismissing approvals on push (the same assumption the
   # reviewer makes by not re-reviewing every push).
   #
-  # Title/author come from the event payload (set by GitHub, unspoofable by the
-  # triggering actor). This posts a review only; it needs no checkout, runs no PR
-  # code, and holds pull-requests:write and nothing else.
+  # The author fields come from the event payload, which GitHub sets and the
+  # triggering actor cannot spoof: `user.type`, `author_association` and
+  # `head.repo.full_name` all mean what they say. THE TITLE DOES NOT — the PR
+  # author writes it and can rewrite it at will — so the title arm below is
+  # gated on the same trusted-author guard the `decide` job carries, and the two
+  # guards must stay identical (see decide's header for why guarding one alone
+  # strands the PR). The bot arm needs no such guard: `user.type == 'Bot'` is a
+  # payload fact, and `decide` skips bot PRs on exactly the same fact, so the two
+  # jobs agree on that class already.
+  #
+  # This posts a review only; it needs no checkout, runs no PR code, and holds
+  # pull-requests:write and nothing else.
   auto-approve-skipped:
     name: Auto-approve low-risk and bot PRs the reviewer skips
     if: >-
@@ -305,12 +338,20 @@ jobs:
       github.event.pull_request.draft == false &&
       (
         github.event.pull_request.user.type == 'Bot' ||
-        startsWith(github.event.pull_request.title, 'chore:') ||
-        startsWith(github.event.pull_request.title, 'chore(') ||
-        startsWith(github.event.pull_request.title, 'style:') ||
-        startsWith(github.event.pull_request.title, 'style(') ||
-        startsWith(github.event.pull_request.title, 'release:') ||
-        startsWith(github.event.pull_request.title, 'release(')
+        (
+          (
+            github.event.pull_request.head.repo.full_name == github.repository ||
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+          ) &&
+          (
+            startsWith(github.event.pull_request.title, 'chore:') ||
+            startsWith(github.event.pull_request.title, 'chore(') ||
+            startsWith(github.event.pull_request.title, 'style:') ||
+            startsWith(github.event.pull_request.title, 'style(') ||
+            startsWith(github.event.pull_request.title, 'release:') ||
+            startsWith(github.event.pull_request.title, 'release(')
+          )
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -109,7 +109,12 @@ jobs:
           # repo content; the PR head is only ever read as DATA via the API.
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
-          sparse-checkout: .github/scripts/decide-pr-review-trigger.sh
+          # The script sources the shared reviewer-identity library, so the
+          # library must land in the same sparse checkout; without it the script
+          # dies at its `source` line under `set -e`.
+          sparse-checkout: |
+            .github/scripts/decide-pr-review-trigger.sh
+            .github/scripts/lib/reviewer-login.bash
           sparse-checkout-cone-mode: false
       - name: Decide whether (and on which model) to review
         id: decide

--- a/.github/workflows/review-gate-context.yaml
+++ b/.github/workflows/review-gate-context.yaml
@@ -40,7 +40,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-          sparse-checkout: .github/scripts/review-gate.sh
+          # review-gate.sh sources the shared reviewer-identity library, so the
+          # library must land in the same sparse checkout; without it the script
+          # dies at its `source` line under `set -e`.
+          sparse-checkout: |
+            .github/scripts/review-gate.sh
+            .github/scripts/lib/reviewer-login.bash
           sparse-checkout-cone-mode: false
 
       - name: Evaluate the gate for every pull request in the batch

--- a/.github/workflows/review-gate.yaml
+++ b/.github/workflows/review-gate.yaml
@@ -67,7 +67,12 @@ jobs:
           # SECURITY header. This pin keeps PR-authored content out of this job.
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
-          sparse-checkout: .github/scripts/review-gate.sh
+          # review-gate.sh sources the shared reviewer-identity library, so the
+          # library must land in the same sparse checkout; without it the script
+          # dies at its `source` line under `set -e`.
+          sparse-checkout: |
+            .github/scripts/review-gate.sh
+            .github/scripts/lib/reviewer-login.bash
           sparse-checkout-cone-mode: false
 
       - name: Evaluate the gate and post the verdict on the head

--- a/tests/test_claude_review_fork_guard.py
+++ b/tests/test_claude_review_fork_guard.py
@@ -1,0 +1,271 @@
+"""The `decide` and `auto-approve-skipped` jobs in claude-review.yaml decide, from
+the event payload alone, whether a pull request gets an automated review and
+whether it collects an automated approval. A PR TITLE is written by the PR
+author, so a title-only skip hands an outside contributor both levers.
+
+These tests EVALUATE the two jobs' real `if:` expressions against synthetic
+payloads rather than grepping them for a guard string, so a guard that is present
+but wired into the wrong arm still reds. The evaluator below covers exactly the
+expression subset those two conditions use; anything outside it raises rather
+than guessing, so an `if:` that grows a new operator fails loudly here instead of
+being silently mis-evaluated.
+"""
+
+import json
+import re
+from functools import lru_cache
+
+import pytest
+import yaml
+
+from tests._helpers import REPO_ROOT
+
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "claude-review.yaml"
+
+SKIP_TITLES = [
+    "chore: bump deps",
+    "chore(deps): bump",
+    "style: reformat",
+    "style(css): reformat",
+    "release: v1.2.3",
+    "release(npm): v1.2.3",
+]
+REVIEWED_TITLES = ["feat: add a thing", "fix: a bug", "docs: rewrite the threat model"]
+TRUSTED = ["OWNER", "MEMBER", "COLLABORATOR"]
+UNTRUSTED = [
+    "CONTRIBUTOR",
+    "FIRST_TIME_CONTRIBUTOR",
+    "FIRST_TIMER",
+    "NONE",
+    "MANNEQUIN",
+]
+
+REPO = "owner/repo"
+
+# The conditions as they stood before the fork guard, kept verbatim so the
+# invariants below can prove they REJECT the old wiring. Without this, a test
+# asserting "an untrusted chore: PR is reviewed" would also pass against a
+# workflow that reviewed every PR for some unrelated reason.
+PRE_FIX_DECIDE = """
+github.event.action == 'labeled' ||
+(
+  github.event.pull_request.draft == false &&
+  github.event.pull_request.user.type != 'Bot' &&
+  !startsWith(github.event.pull_request.title, 'chore:') &&
+  !startsWith(github.event.pull_request.title, 'chore(') &&
+  !startsWith(github.event.pull_request.title, 'style:') &&
+  !startsWith(github.event.pull_request.title, 'style(') &&
+  !startsWith(github.event.pull_request.title, 'release:') &&
+  !startsWith(github.event.pull_request.title, 'release(')
+)
+"""
+PRE_FIX_APPROVE = """
+(github.event.action == 'opened' || github.event.action == 'ready_for_review') &&
+github.event.pull_request.draft == false &&
+(
+  github.event.pull_request.user.type == 'Bot' ||
+  startsWith(github.event.pull_request.title, 'chore:') ||
+  startsWith(github.event.pull_request.title, 'chore(') ||
+  startsWith(github.event.pull_request.title, 'style:') ||
+  startsWith(github.event.pull_request.title, 'style(') ||
+  startsWith(github.event.pull_request.title, 'release:') ||
+  startsWith(github.event.pull_request.title, 'release(')
+)
+"""
+
+
+# ── A small evaluator for the GitHub Actions expression subset in use ────────
+
+_CONTEXT_PATH = re.compile(r"\bgithub(?:\.[A-Za-z_][A-Za-z0-9_]*)+")
+
+
+def _lookup(context: dict, path: str):
+    node = context
+    for part in path.split("."):
+        assert isinstance(node, dict) and part in node, (
+            f"the workflow reads {path}, which the test payload does not model"
+        )
+        node = node[part]
+    return node
+
+
+def evaluate(expression: str, context: dict) -> bool:
+    """Evaluate a GitHub `if:` expression against a payload.
+
+    Supported: && || ! == != ( ), string literals, startsWith, contains,
+    fromJSON, and `github.*` context paths. Anything else raises.
+    """
+    # YAML's `>-` already folds the real conditions onto one line; fold the
+    # literals in this file the same way so both go through one code path.
+    src = " ".join(expression.split())
+    # `!=` must survive the `!` -> `not` rewrite, so park it first.
+    src = src.replace("!=", "\x00")
+    src = src.replace("&&", " and ").replace("||", " or ").replace("!", " not ")
+    src = src.replace("\x00", "!=")
+    src = _CONTEXT_PATH.sub(lambda m: f"_ctx({json.dumps(m.group(0))})", src)
+    src = src.replace("startsWith(", "_starts_with(").replace("contains(", "_contains(")
+    src = src.replace("fromJSON(", "_from_json(")
+    # Everything the workflow may name is now a call or a literal; a bare
+    # identifier means the expression used something this evaluator does not
+    # model, and guessing at it would be worse than failing.
+    outside_strings = re.sub(r"'[^']*'|\"[^\"]*\"", " ", src)
+    leftover = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", outside_strings)) - {
+        "_ctx",
+        "_starts_with",
+        "_contains",
+        "_from_json",
+        "and",
+        "or",
+        "not",
+        "true",
+        "false",
+    }
+    assert not leftover, f"unsupported tokens in the expression: {sorted(leftover)}"
+
+    env = {
+        "_ctx": lambda path: _lookup(context, path),
+        "_starts_with": lambda text, prefix: str(text).startswith(prefix),
+        "_contains": lambda haystack, needle: needle in haystack,
+        "_from_json": json.loads,
+        "true": True,
+        "false": False,
+    }
+    return bool(eval(src, {"__builtins__": {}}, env))  # noqa: S307 - fixed inputs
+
+
+def payload(
+    *,
+    action: str = "opened",
+    title: str = "feat: a thing",
+    association: str = "NONE",
+    same_repo: bool = False,
+    draft: bool = False,
+    bot: bool = False,
+    label: str = "",
+) -> dict:
+    return {
+        "github": {
+            "repository": REPO,
+            "event": {
+                "action": action,
+                "label": {"name": label},
+                "pull_request": {
+                    "title": title,
+                    "draft": draft,
+                    "author_association": association,
+                    "user": {"type": "Bot" if bot else "User"},
+                    "head": {"repo": {"full_name": REPO if same_repo else "fork/repo"}},
+                },
+            },
+        }
+    }
+
+
+@lru_cache(maxsize=None)
+def _job_condition(job: str) -> str:
+    jobs = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+    condition = jobs[job].get("if")
+    assert condition, f"job {job} lost its `if:` guard"
+    return condition
+
+
+def reviews(pl: dict) -> bool:
+    return evaluate(_job_condition("decide"), pl)
+
+
+def approves(pl: dict) -> bool:
+    return evaluate(_job_condition("auto-approve-skipped"), pl)
+
+
+# ── The invariants ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES + REVIEWED_TITLES)
+@pytest.mark.parametrize("association", UNTRUSTED)
+def test_an_untrusted_author_never_gets_a_free_approval(title, association):
+    """THE fix. A fork PR's title is attacker-chosen, so no title may buy the
+    automated approval that satisfies a review-required ruleset."""
+    pl = payload(title=title, association=association, same_repo=False)
+    assert not approves(pl), f"{association} bought an approval with {title!r}"
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES + REVIEWED_TITLES)
+@pytest.mark.parametrize("association", UNTRUSTED)
+def test_an_untrusted_author_always_gets_the_real_review(title, association):
+    """The other half, and the reason the guard cannot live on the approval
+    alone: guarding only the approval leaves the same PR skipped by `decide` and
+    approved by nobody — reviewed by nobody, with no event able to fix it."""
+    pl = payload(title=title, association=association, same_repo=False)
+    assert reviews(pl), f"{association}'s {title!r} PR is reviewed by nobody"
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES + REVIEWED_TITLES)
+@pytest.mark.parametrize("association", UNTRUSTED + TRUSTED)
+@pytest.mark.parametrize("same_repo", [True, False])
+def test_every_pull_request_is_either_reviewed_or_approved(
+    title, association, same_repo
+):
+    """The stranding invariant, over the whole payload space: a PR the reviewer
+    skips must be one the approver picks up, and vice versa. Exactly one of the
+    two jobs claims each `opened` PR."""
+    pl = payload(title=title, association=association, same_repo=same_repo)
+    assert reviews(pl) != approves(pl), (
+        f"{association}/{same_repo}/{title!r} is claimed by "
+        f"{'both' if reviews(pl) else 'neither'} job"
+    )
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES)
+@pytest.mark.parametrize("association", TRUSTED)
+def test_a_trusted_author_keeps_the_low_risk_skip(title, association):
+    """The feature the guard must not eat: a maintainer's chore/style/release PR
+    still skips the model spend and still collects its approval."""
+    pl = payload(title=title, association=association, same_repo=True)
+    assert not reviews(pl)
+    assert approves(pl)
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES)
+def test_a_same_repo_branch_is_trusted_on_its_own(title):
+    """A branch in this repo means the author already has push access, so the
+    skip holds even when author_association reads NONE (as it does for a PR
+    opened by an app on a same-repo branch)."""
+    pl = payload(title=title, association="NONE", same_repo=True)
+    assert not reviews(pl)
+    assert approves(pl)
+
+
+def test_a_bot_pull_request_is_skipped_and_approved_from_a_fork_too():
+    """`user.type` is a payload fact both jobs read the same way, so the bot
+    class agrees without the trust guard — pinned so a future edit that guards
+    one arm and not the other cannot strand a Dependabot PR."""
+    pl = payload(title="chore(deps): bump x", bot=True, same_repo=False)
+    assert not reviews(pl)
+    assert approves(pl)
+
+
+def test_a_label_forces_a_review_of_an_untrusted_pull_request():
+    pl = payload(action="labeled", title="chore: x", label="needs-auto-review")
+    assert reviews(pl)
+
+
+def test_a_draft_is_neither_reviewed_nor_approved():
+    pl = payload(title="feat: x", draft=True, same_repo=True)
+    assert not reviews(pl)
+    assert not approves(pl)
+
+
+# ── Non-vacuity: the same invariants must REJECT the pre-fix conditions ──────
+
+
+@pytest.mark.parametrize("title", SKIP_TITLES)
+def test_the_pre_fix_conditions_fail_the_fork_guard_invariant(title):
+    """If these ever pass, the invariants above stopped testing the fix."""
+    pl = payload(title=title, association="NONE", same_repo=False)
+    assert evaluate(PRE_FIX_APPROVE, pl), (
+        "the pre-fix approval condition must accept an untrusted chore: PR — "
+        "that was the bug"
+    )
+    assert not evaluate(PRE_FIX_DECIDE, pl), (
+        "the pre-fix decide condition must skip the same PR — that was the bug"
+    )

--- a/tests/test_review_gate.py
+++ b/tests/test_review_gate.py
@@ -1,0 +1,219 @@
+"""review-gate.sh decides whether the "Automated review posted" required check
+goes green, so the only thing that matters about it is WHICH reviews it credits.
+
+The `gh` stub here RUNS the script's own `--jq` filter over a canned reviews
+payload instead of returning a pre-filtered answer. The whole safety property
+lives inside that filter, so a stub that ignored `--jq` would report the gate
+working while testing nothing.
+
+Two invariants, both of which the pre-fix filter (`select(.state != "DISMISSED")
+| .user.login`) violated — each test that pins one also runs the pre-fix filter
+over the same payload and asserts it answered the other way, so the test cannot
+pass vacuously against a gate that never changed.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests._helpers import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "review-gate.sh"
+LIB_REL = ".github/scripts/lib/reviewer-login.bash"
+REVIEWER_SCRIPTS = (
+    "review-gate.sh",
+    "approve-if-reviewer-hold-clear.sh",
+    "detect-reviewer-body-hold.sh",
+    "fetch-unresolved-review-threads.sh",
+    "decide-pr-review-trigger.sh",
+    "append-haiku-cost.sh",
+)
+
+BOT = "github-actions[bot]"
+HEAD_SHA = "cafebabe"
+
+# The filter this gate shipped with. Kept verbatim so every invariant below can
+# show the fixture it rejects is one the old gate accepted.
+PRE_FIX_JQ = '.[] | select(.state != "DISMISSED") | .user.login // ""'
+
+
+def review(state: str, *, author: str = BOT, body: str = "Automated review.") -> dict:
+    return {"state": state, "body": body, "user": {"login": author}}
+
+
+def run_gate(tmp_path: Path, reviews: list[dict]) -> str:
+    """Run the gate over `reviews`; return the status state it posted."""
+    (tmp_path / "reviews.json").write_text(json.dumps(reviews), encoding="utf-8")
+    log = tmp_path / "gh-calls.txt"
+    stub = f"""#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "{log}"
+if [[ "$2" == "--paginate" ]]; then
+  filter=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --jq) filter="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  jq -r "$filter" "{tmp_path}/reviews.json"
+  exit 0
+fi
+exit 0
+"""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    (bin_dir / "gh").write_text(stub, encoding="utf-8")
+    (bin_dir / "gh").chmod(0o755)
+
+    res = subprocess.run(
+        ["bash", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+        env={
+            "PATH": f"{bin_dir}:/usr/bin:/bin:/usr/local/bin",
+            "GH_TOKEN": "t",
+            "GH_REPO": "o/r",
+            "PR": "438",
+            "HEAD_SHA": HEAD_SHA,
+        },
+    )
+    assert res.returncode == 0, res.stderr
+    calls = log.read_text(encoding="utf-8")
+    assert f"statuses/{HEAD_SHA}" in calls, f"the gate posted no status: {calls}"
+    states = [s for s in ("state=success", "state=pending") if s in calls]
+    assert len(states) == 1, f"expected exactly one verdict, got {states}: {calls}"
+    return states[0].removeprefix("state=")
+
+
+def pre_fix_verdict(reviews: list[dict]) -> str:
+    """What the gate's original filter answered for the same payload."""
+    out = subprocess.run(
+        ["jq", "-r", PRE_FIX_JQ],
+        input=json.dumps(reviews),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    return "success" if out else "pending"
+
+
+def test_the_reviewers_own_review_clears_the_gate(tmp_path: Path) -> None:
+    """The clean path: no fix may green a gate that stopped working."""
+    assert run_gate(tmp_path, [review("COMMENTED")]) == "success"
+
+
+def test_an_approval_clears_the_gate(tmp_path: Path) -> None:
+    """auto-approve-skipped-pr.sh and approve-if-reviewer-hold-clear.sh both post
+    an APPROVE under the reviewer's identity; both must still clear the gate."""
+    assert run_gate(tmp_path, [review("APPROVED")]) == "success"
+
+
+def test_a_dismissed_review_leaves_the_gate_pending(tmp_path: Path) -> None:
+    assert run_gate(tmp_path, [review("DISMISSED")]) == "pending"
+
+
+@pytest.mark.parametrize(
+    "author", ["pr-author", "outside-contributor", "dependabot[bot]"]
+)
+def test_a_non_reviewer_review_never_clears_the_gate(
+    tmp_path: Path, author: str
+) -> None:
+    """INVARIANT 1. The gate claims an AUTOMATED review exists. Any actor's review
+    counting made it self-clearing: a PR author submits a one-word COMMENT review
+    on their own PR and a required merge lever goes green with no reviewer run."""
+    payload = [review("COMMENTED", author=author)]
+    assert run_gate(tmp_path, payload) == "pending"
+    assert pre_fix_verdict(payload) == "success", (
+        "fixture no longer exercises the bug: the pre-fix filter must have "
+        "credited this review, or this test proves nothing"
+    )
+
+
+def test_a_body_less_reviewer_review_never_clears_the_gate(tmp_path: Path) -> None:
+    """INVARIANT 2. GitHub synthesizes a body-less COMMENTED review around every
+    standalone review comment, and resolve-addressed-threads.sh posts one under
+    the reviewer's own identity on each auto-resolved thread. Crediting it greens
+    the gate for a PR the reviewer is still holding."""
+    payload = [review("COMMENTED", body="")]
+    assert run_gate(tmp_path, payload) == "pending"
+    assert pre_fix_verdict(payload) == "success", (
+        "fixture no longer exercises the bug: the pre-fix filter must have "
+        "credited this body-less review, or this test proves nothing"
+    )
+
+
+def test_a_real_review_still_clears_a_gate_full_of_noise(tmp_path: Path) -> None:
+    """Both filters at once, in the order a live PR accumulates them."""
+    payload = [
+        review("COMMENTED", author="pr-author", body="looks fine to me"),
+        review("COMMENTED", body=""),
+        review("CHANGES_REQUESTED"),
+    ]
+    assert run_gate(tmp_path, payload) == "success"
+
+
+# ── The library the four reviewer scripts share must reach every runner ──────
+
+
+def _sparse_checkout_lists():
+    """(workflow, step name, sparse-checkout entries) for every checkout step."""
+    for path in sorted((REPO_ROOT / ".github" / "workflows").glob("*.y*ml")):
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict):
+            continue
+        for job in (doc.get("jobs") or {}).values():
+            for step in (job or {}).get("steps") or []:
+                sparse = (step.get("with") or {}).get("sparse-checkout")
+                if not sparse:
+                    continue
+                entries = [e.strip() for e in str(sparse).split("\n") if e.strip()]
+                yield path.name, step.get("name"), entries
+
+
+def test_every_sparse_checkout_of_a_reviewer_script_also_takes_the_shared_lib():
+    """A sparse checkout naming individual FILES gets exactly those files. All
+    four reviewer scripts now `source` lib/reviewer-login.bash, so a list that
+    names the script without the library leaves the script to die at its `source`
+    line under `set -e` — with the gate's own bootstrap arm unable to tell that
+    apart from a bad install."""
+    checked = []
+    for workflow, step, entries in _sparse_checkout_lists():
+        # A list naming the whole scripts directory already carries lib/.
+        if any(e == ".github/scripts" for e in entries):
+            continue
+        named = [e for e in entries if Path(e).name in REVIEWER_SCRIPTS]
+        if not named:
+            continue
+        checked.append((workflow, step, named))
+        assert LIB_REL in entries, (
+            f"{workflow} / {step!r} sparse-checks out {named} without {LIB_REL}; "
+            "the script sources that library and will die under set -e"
+        )
+    assert checked, (
+        "no sparse-checkout list names a reviewer script any more — this guard "
+        "would now pass without checking anything; re-point it or delete it"
+    )
+
+
+def test_every_reviewer_script_uses_the_shared_login_library():
+    """The identity predicate was copied into four scripts; the point of the
+    library is that it stops being four. A script that re-derives the bare login
+    locally has forked the predicate again."""
+    for name in REVIEWER_SCRIPTS:
+        text = (REPO_ROOT / ".github" / "scripts" / name).read_text(encoding="utf-8")
+        assert "lib/reviewer-login.bash" in text and "reviewer_login_init" in text, (
+            f"{name} does not source the shared reviewer-login library"
+        )
+        assert "REVIEWER_LOGIN%" not in text, (
+            f"{name} re-derives REVIEWER_LOGIN_BARE itself instead of calling "
+            "reviewer_login_init"
+        )
+        assert 'sub("\\\\[bot\\\\]$"' not in text, (
+            f"{name} hand-writes the [bot]-stripping jq instead of using the "
+            "library's select clause"
+        )


### PR DESCRIPTION
## What & why

Close two ways a pull request could clear its own review gate.

1. **`review-gate.sh` credited any actor's review, body or no body.** The `Automated review posted` required check counted every undismissed review on the PR, so a PR author submitting a one-word `COMMENT` review on their own pull request turned it green with no automated reviewer having run. The same filter also counted the **body-less `COMMENTED` review GitHub synthesizes around a standalone review comment** — and `resolve-addressed-threads.sh` posts one of those under the reviewer's own identity on every auto-resolved thread, greening the gate for a PR the reviewer was still holding. The gate now keeps only undismissed reviews written by `REVIEWER_LOGIN` **and** carrying a non-empty body.

2. **`auto-approve-skipped` trusted a string the PR author writes.** The job fired on `chore:`/`style:`/`release:` title prefixes with no cross-repository or author-association guard, and `decide` skipped the real review on the same prefixes. An outside contributor titling a fork PR `chore: bump` therefore cleared three merge levers at once: no review ran, an approving review was submitted, and both required statuses went green. Both jobs now require what GitHub sets rather than what the author writes — a same-repository head branch, or `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`.

Both files are synced downstream by `template-sync.yaml`, which is why the fix lands here rather than in the consumer where it was found.

## Review focus

**`.github/workflows/claude-review.yaml` — the guard must sit on BOTH jobs.** Guarding only the approval leaves an untrusted `chore:` PR skipped by `decide` on `opened` and every `synchronize`, and approved by nobody: reviewed by nobody, with no event able to produce either outcome. Guarded on both, the skip set is simply **empty** for an untrusted author, so their PR always gets the real review whatever its title. The bot arm stays unguarded on purpose — both jobs read `user.type`, a payload fact, so they already agree on that class and cannot disagree about a Dependabot PR.

**`.github/scripts/lib/reviewer-login.bash` — the new shared library.** "Is this the reviewer's?" was three copies of the same three lines (`REVIEWER_LOGIN_BARE`, the `sub("\\[bot\\]$";"")` normalization, the select clause) plus two more scripts spelling it a fourth way with an exact match. It is now one library sourced by six scripts. The normalization exists because REST spells an app bot `github-actions[bot]` and GraphQL spells it `github-actions`; both directions have already shipped here as live silent-no-op bugs.

**Sparse checkouts.** `review-gate.sh` and `decide-pr-review-trigger.sh` are fetched BY NAME, not as a directory, so each list had to grow the library or the script would die at its `source` line under `set -e`. `tests/test_review_gate.py::test_every_sparse_checkout_of_a_reviewer_script_also_takes_the_shared_lib` pins that, and fails loudly if no list names a reviewer script any more rather than passing vacuously.

## How it was tested

- `uv run --extra dev pytest tests/` — 834 passed. Three failures are pre-existing and environmental (`test_pnpm_supply_chain` wants `node_modules`; `test_drop_superseded_ci_events` fails identically on `origin/main`).
- `pre-commit run --files <every touched file>` — all hooks pass, including `shellcheck -x`, `shfmt`, `actionlint`, `zizmor` and `ruff`. `check-proto-pollution` errors on a missing `typescript` package in this sandbox; it reads no file in this diff.
- Both new tests were checked for non-vacuity, not just for passing:
  - `tests/test_review_gate.py` drives the real script through a `gh` stub that RUNS its `--jq` filter over a canned payload. Each invariant also runs the **pre-fix** filter over the same payload and asserts it answered the other way. Reverting the filter turns 4 tests red.
  - `tests/test_claude_review_fork_guard.py` EVALUATES the two jobs' real `if:` expressions against synthetic payloads (a small evaluator for the operator subset in use; anything outside it raises rather than guessing), so a guard present but wired into the wrong arm still reds. It also asserts the pre-fix conditions, kept verbatim in the test, fail the same invariants.
- Smoke-ran the four migrated scripts against stubbed API payloads and confirmed each still returns its pre-change verdict.

## Decisions made

- **Migrated two extra scripts onto the library.** `decide-pr-review-trigger.sh` and `append-haiku-cost.sh` matched the reviewer with an exact `.user.login ==` compare rather than `REVIEWER_LOGIN_BARE`, so a grep for the bare variable missed them. Leaving them would have left the SSOT claim false and would break both scripts silently for anyone who sets `REVIEWER_LOGIN` without the `[bot]` suffix. The alternative — a four-script library and two stragglers — costs one more sparse-checkout entry less, and a sixth copy of the predicate.
- **The `user.type == 'Bot'` arm of `auto-approve-skipped` keeps no trust guard.** Guarding it would strand every Dependabot PR, because `decide` skips bots on the same unguarded fact. Changing that means changing both jobs' bot handling together, which is a separate question from the title one.
- **A human's review no longer clears the gate.** The check is named `Automated review posted` and a human review satisfies the review-required ruleset directly, so this is the intended reading; the alternative would re-open the self-clearing hole for any PR whose author is a collaborator.

## Security boundary impact

Both changes tighten a merge gate. The gate now answers "did the automated reviewer post a real review?" instead of "did anyone post anything?", and the reviewer's title-based skip is no longer reachable by an untrusted author. No new privilege is granted anywhere: the jobs' `permissions:` blocks, checkout posture and tokens are unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VvuJNE8pEstzwvSmir592V)_