### PR TITLE
docs(hooks): fix a stale rationale in gate-plan-skill.mjs's comment

### DIFF
--- a/.claude/hooks/gate-plan-skill.mjs
+++ b/.claude/hooks/gate-plan-skill.mjs
@@ -68,7 +68,7 @@ export function isPlanFile(filePath) {
  * takes the CLI route and a web session the MCP route, so covering one moves the
  * session to the other.
  *
- * Only `create`: an update carries no title to read. The CLI arm reads the whole
+ * Only `create`: an issue that already exists already passed the gate. The CLI arm reads the whole
  * command rather than the `--title` argument, which needs no shell parser and
  * errs toward the reminder rather than the miss.
  * @param {any} payload @returns {boolean}


### PR DESCRIPTION
## What & why

`gate-plan-skill.mjs`'s comment said the gate only watches issue `create` because "an update carries no title to read" — false, the MCP `issue_write` tool's `title` field is valid on both `create` and `update`. The gate actually skips updates because an issue that already exists already passed the create-time check. [#472](https://github.com/AlexanderMattTurner/claude-automation-template/pull/472) found and fixed the same false claim in this gate's own test suite (`tests/test_skill_gates.py`); this corrects the matching comment in the hook itself so the two don't contradict each other.

Comment-only change, split into its own PR per this repo's rule that a `.claude/hooks/` edit is the highest-risk diff class and gets its own review rather than riding along with an unrelated fix.

## How it was tested

No behavior change — `uv run --extra dev pytest tests/test_skill_gates.py -q` passes unchanged.
