### PR TITLE
fix(pre-commit): exempt committed patch files from the whitespace fixers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,14 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
+      # A committed `.patch`/`.diff` is exempt from every hook that rewrites
+      # bytes. A unified diff's context line for a BLANK line is a lone space,
+      # so stripping it makes `git apply` answer `corrupt patch`; appending a
+      # newline or rewriting line endings breaks the same file the same way.
       - id: trailing-whitespace
-        exclude: ^pnpm-lock\.yaml$
+        exclude: ^(pnpm-lock\.yaml|.*\.(patch|diff))$
       - id: end-of-file-fixer
-        exclude: ^pnpm-lock\.yaml$
+        exclude: ^(pnpm-lock\.yaml|.*\.(patch|diff))$
       - id: check-yaml
       - id: check-json
       - id: check-merge-conflict
@@ -30,6 +34,7 @@ repos:
       - id: check-symlinks
       - id: mixed-line-ending
         args: [--fix=lf]
+        exclude: ^.*\.(patch|diff)$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1


### PR DESCRIPTION
## What & why

Exempt `*.patch` and `*.diff` from `trailing-whitespace`, `end-of-file-fixer` and `mixed-line-ending`. A unified diff's context line for a blank line is a lone space, and a `-`/`+` line can carry meaningful trailing whitespace. The fixers strip both, and `git apply` then answers `corrupt patch`. This tree tracks no patch file today, so the exemption is preventative — the same gap fired for real in `agent-glovebox`, where a committed patch was rewritten at pre-push and blocked the push.

## How it was tested

Ran the three real hooks against a scratch patch holding a lone-space context line and two trailing-space diff lines. With this diff all three report `(no files to check)Skipped` and the file stays 55 bytes; with the config stashed back to `main`, `trailing-whitespace` reports `Fixing sample.patch` and the file drops to 52 bytes — the byte loss that makes `git apply` refuse.

<details>

```
printf -- '--- a/x\n+++ b/x\n@@ -1,3 +1,3 @@\n a\n \n-b \n+c \n' > sample.patch
pre-commit run trailing-whitespace --files sample.patch
pre-commit run end-of-file-fixer   --files sample.patch
pre-commit run mixed-line-ending   --files sample.patch
```

</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnZAF8WAo2VLkqQF6tgdDt)_