### PR TITLE
fix(ci): stop template-sync labeling its own PR merge-conflict

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -283,7 +283,7 @@ jobs:
             Please review the changes and merge if appropriate.
           branch: template-sync
           delete-branch: true
-          labels: ${{ steps.sync.outputs.has_conflicts == 'true' && 'template-sync,merge-conflict' || 'template-sync' }}
+          labels: template-sync
 
       # Resolve IN THIS RUN rather than posting an @claude comment and hoping a
       # separate workflow gets to it. The PR then arrives readable instead of


### PR DESCRIPTION
## What & why

`template-sync.yaml` applies the `merge-conflict` label to its own sync PR when the 3-way merge leaves unresolved markers. That name collides with `label-merge-conflicts.sh`'s label, which tracks GitHub's own `mergeable` state — a marker-bearing sync PR stays `MERGEABLE` (the markers are ordinary committed content, per this workflow's own header comment), so the labeler sweep strips the label again on the next push to main. Nothing reads the label back either way: the PR body already carries a full "Conflicts to resolve by hand" section. Downstream, `agent-glovebox` had renamed its copy to `needs-conflict-resolution` to dodge the collision; this removes the label entirely instead, upstream, so every consumer stops carrying the workaround.

## How it was tested

`git commit` (commit-msg hook) passed locally. One-line YAML literal, no behavior change beyond the label list.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AQQR6Su5zu9vj2ShPdzP6p)_