### PR TITLE
chore(deps): move the ci-truth-serum pin onto main

### DIFF
--- a/.github/workflows/sync-required-checks.yaml
+++ b/.github/workflows/sync-required-checks.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           # pin-exempt: PEP 508 `name @ git+URL@sha` pins to an exact commit;
           # the commit SHA after the trailing @ is the pin, not a missing version.
-          python3 -m pip install --user "ci-truth-serum @ git+https://github.com/AlexanderMattTurner/ci-truth-serum@b5c7fdc1fbf8cd3222e3a8a34d62535d645702ef"
+          python3 -m pip install --user "ci-truth-serum @ git+https://github.com/AlexanderMattTurner/ci-truth-serum@01aa20655323f8ce5a5b8554556dd9dbeeedc232"
 
       - name: Sync required status checks
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,7 @@ repos:
   # and global-stdio-swap Python lints. Tier aggregates over per-check ids so a
   # check added upstream to a tier applies here with no config change.
   - repo: https://github.com/AlexanderMattTurner/ci-truth-serum
-    rev: b5c7fdc1fbf8cd3222e3a8a34d62535d645702ef # ci-truth-serum#169 head, not yet on main
+    rev: 01aa20655323f8ce5a5b8554556dd9dbeeedc232 # ci-truth-serum main, past #169
     hooks:
       - id: check-tier1
       # check-path-gate-deps and check-failure-notifier-coverage are Tier 2


### PR DESCRIPTION
## What & why

Advances the `ci-truth-serum` pin in `.pre-commit-config.yaml` and `sync-required-checks.yaml` from [ci-truth-serum#169](https://github.com/AlexanderMattTurner/ci-truth-serum/pull/169)'s head to that PR's merge commit on `main` (`01aa2065`), now that it has merged. Both files already point at an ancestor of the new SHA, so no hook gains or loses a finding.

## How it was tested

`pre-commit run --all-files` passes clean at the new pin, aside from `lychee`, which fails the same way on unmodified `main`: the sandbox blocks the cargo-source install its GitHub API fallback needs.