### PR TITLE
fix(ci): bump the stale agent-resolve-merge-conflicts pin

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yaml
+++ b/.github/workflows/auto-resolve-conflicts.yaml
@@ -80,7 +80,7 @@ permissions: {}
 # runs come from one commit.
 env:
   RESOLVER_REPOSITORY: AlexanderMattTurner/agent-resolve-merge-conflicts
-  RESOLVER_REF: ba747a3e64e954a30148db13be96e0cf0002f0a8
+  RESOLVER_REF: ca9a3fa872a9c06ade766de9bf69ff7b0329247f
 
 jobs:
   discover:
@@ -206,7 +206,7 @@ jobs:
       issues: write # `gh label create` for auto-resolve-blocked rides the issues API
       statuses: write # the per-head attempt mark is a commit status
       actions: write # `land` re-dispatches the resolver after a lost race
-    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@ba747a3e64e954a30148db13be96e0cf0002f0a8 # pin-comment-ok: that repository has cut no release yet, so there is no version for this SHA to name
+    uses: AlexanderMattTurner/agent-resolve-merge-conflicts/.github/workflows/auto-resolve.yaml@ca9a3fa872a9c06ade766de9bf69ff7b0329247f # pin-comment-ok: that repository has cut no release yet, so there is no version for this SHA to name
     with:
       pr: ${{ matrix.pr.number }}
       # The literals from this file's `env:` block, repeated because a reusable

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -318,7 +318,7 @@ jobs:
           resolver_dir="${RUNNER_TEMP}/template-sync-resolver"
           git clone --no-tags --depth 1 \
             "https://github.com/AlexanderMattTurner/agent-resolve-merge-conflicts.git" "${resolver_dir}"
-          git -C "${resolver_dir}" fetch --no-tags --depth 1 origin ba747a3e64e954a30148db13be96e0cf0002f0a8
+          git -C "${resolver_dir}" fetch --no-tags --depth 1 origin ca9a3fa872a9c06ade766de9bf69ff7b0329247f
           git -C "${resolver_dir}" checkout --detach FETCH_HEAD
           RESOLVER_DIR="${resolver_dir}/.github/resolver" \
             bash .github/scripts/template-sync-resolve.sh


### PR DESCRIPTION
## What & why

`install-hook-tools.sh` at the pinned commit `ba747a3e` crashed with `SHELLCHECK_PY_VERSION: unbound variable` whenever a caller's `tool-versions.sh` pinned neither `SHELLCHECK_PY_VERSION` nor `SHFMT_VERSION`. That is exactly the failure that hit [agent-sanitizer#370](https://github.com/AlexanderMattTurner/agent-sanitizer/pull/370)'s auto-resolve run. The bug is already fixed on `agent-resolve-merge-conflicts` main (guards both variables with `${VAR:-}` and skips the tool install when a pin is empty). This bumps the pin from `ba747a3e` to `ca9a3fa8`, the current main tip, in `auto-resolve-conflicts.yaml`.

## How it was tested

Confirmed `ca9a3fa872a9c06ade766de9bf69ff7b0329247f:.github/resolver/auto-resolve/install-hook-tools.sh` carries the guarded form, and diffed it against local `agent-resolve-merge-conflicts` main with no output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2vpcanqQZVJnKtkDzoykU)_