### PR TITLE
fix(template-sync): refuse a sync branch that still carries conflict markers

### DIFF
--- a/.github/scripts/lib/merge-conflict.bash
+++ b/.github/scripts/lib/merge-conflict.bash
@@ -28,3 +28,34 @@ protected_matches() {
   done
   return 0
 }
+
+# has_marker_triple — true when stdin carries all three marker kinds, each as a whole line.
+# The complete triple is the verdict, never one kind on its own.
+has_marker_triple() {
+  local text kind
+  text="$(cat)"
+  for kind in '<' '=' '>'; do
+    grep -qE "^${kind}{7}([ \t]|\$)" <<<"$text" || return 1
+  done
+}
+
+# committed_marker_paths BASE_REF [REF] — paths whose content in REF (default HEAD) carries the
+# marker triple. It reads the COMMIT and never the worktree, so an edit a resolver left unpushed
+# cannot change the verdict about what a consumer would check out. A path whose BASE_REF copy
+# already carries markers is skipped, so a repository that keeps marker text on purpose — a test
+# fixture, a document about conflicts — is never withheld from itself.
+committed_marker_paths() {
+  local base_ref="${1:?committed_marker_paths: BASE_REF required}" ref="${2:-HEAD}" listing rc f
+  listing="$(git grep -lE "$CONFLICT_MARKER_RE" "$ref" -- .)"
+  rc=$?
+  # 1 is "no match", the ordinary outcome on a branch nobody left a marker on.
+  [[ "${rc:-0}" -le 1 ]] || return "$rc"
+  while IFS= read -r f; do
+    f="${f#"${ref}:"}"
+    [[ -n "$f" ]] || continue
+    git cat-file blob "${ref}:${f}" | has_marker_triple || continue
+    git cat-file blob "${base_ref}:${f}" 2>/dev/null | has_marker_triple && continue
+    printf '%s\n' "$f"
+  done <<<"$listing"
+  return 0
+}

--- a/.github/scripts/lib/merge-conflict.bash
+++ b/.github/scripts/lib/merge-conflict.bash
@@ -29,14 +29,17 @@ protected_matches() {
   return 0
 }
 
-# has_marker_triple — true when stdin carries all three marker kinds, each as a whole line.
-# The complete triple is the verdict, never one kind on its own.
+# has_marker_triple — true when stdin carries all three marker kinds. The complete triple is the
+# verdict, never one kind on its own. It reads the kinds back out of CONFLICT_MARKER_RE's own
+# matches rather than spelling a per-kind pattern, so there is still one regex to drift.
 has_marker_triple() {
-  local text kind
-  text="$(cat)"
-  for kind in '<' '=' '>'; do
-    grep -qE "^${kind}{7}([ \t]|\$)" <<<"$text" || return 1
-  done
+  local matches rc kinds
+  matches="$(grep -oE "$CONFLICT_MARKER_RE")"
+  rc=$?
+  # 1 is "no marker at all", which is the answer, not a failure.
+  [[ "${rc:-0}" -le 1 ]] || return "$rc"
+  kinds="$(cut -c1 <<<"$matches")"
+  [[ "$kinds" == *'<'* ]] && [[ "$kinds" == *'='* ]] && [[ "$kinds" == *'>'* ]]
 }
 
 # committed_marker_paths BASE_REF [REF] — paths whose content in REF (default HEAD) carries the

--- a/.github/scripts/lib/merge-conflict.test.mjs
+++ b/.github/scripts/lib/merge-conflict.test.mjs
@@ -98,3 +98,32 @@ test("the marker regex does not match ordinary prose that looks like one", () =>
     assert.equal(markerMatches(line), false, `${line} is not a marker`);
   }
 });
+
+// The marker VERDICT — what the sync gate withholds a file on — needs the whole
+// triple. One kind alone is ordinary text, so a single-kind verdict would call
+// prose damage and hand the adopter back a file nothing was wrong with.
+function hasMarkerTriple(text) {
+  const out = execFileSync(
+    "bash",
+    [
+      "-c",
+      `source "${LIB}"; printf '%s' "$1" | has_marker_triple && echo yes || echo no`,
+      "_",
+      text,
+    ],
+    { encoding: "utf8" },
+  );
+  return out.trim() === "yes";
+}
+
+test("has_marker_triple is true only for a complete diff3 conflict", () => {
+  const conflict =
+    "a\n<<<<<<< local\nb\n||||||| base\nc\n=======\nd\n>>>>>>> template\ne\n";
+  assert.equal(hasMarkerTriple(conflict), true);
+});
+
+test("has_marker_triple is false for prose carrying only one marker kind", () => {
+  // A Markdown setext heading rule, and an opening marker with no closing one.
+  for (const text of ["Title\n=======\nbody\n", "a\n<<<<<<< local\nb\n"])
+    assert.equal(hasMarkerTriple(text), false, `${text} is not a conflict`);
+});

--- a/.github/scripts/template-sync-marker-gate.sh
+++ b/.github/scripts/template-sync-marker-gate.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Refuse a template-sync branch that still carries conflict markers.
+#
+# PROBLEM CLASS — raw diff3 markers committed as if they were a resolution.
+# template-sync.sh writes `<<<<<<< local` … `>>>>>>> template` into the tree on
+# purpose: those markers are what the two resolver tiers read. But
+# create-pull-request commits that tree BEFORE either tier runs, so a file
+# neither tier settles reaches the branch with its markers intact. Nothing then
+# failed — template-sync-resolve.sh only warns about its `unresolved` set — so
+# the run stayed green while a marked bash library sat on the branch and the
+# consumer's own CI died on `<<<` as a syntax error.
+#
+# This gate restores every still-marked path to its pre-sync content and pushes
+# that, so the branch head carries no marker whatever the tiers managed. It then
+# exits 1, which reds the run. The marker text stays in the pull request body's
+# conflict report, which is where a human resolves it from.
+#
+# Env: BASE_SHA (the commit the sync branched from), GITHUB_TOKEN.
+set -euo pipefail
+
+# Read before the sources below, which need `jq` on PATH: a missing tool must
+# not stand in for a missing variable in the failure this script reports.
+: "${BASE_SHA:?BASE_SHA required}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$(cd "${SCRIPT_DIR}/lib" && pwd)"
+# shellcheck source=.github/scripts/lib/merge-conflict.bash
+source "${LIB_DIR}/merge-conflict.bash"
+# shellcheck source=.github/scripts/lib/git-auth.bash
+source "${LIB_DIR}/git-auth.bash"
+
+BRANCH="template-sync"
+
+git_auth_header "$GITHUB_TOKEN"
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+# The branch, not the workspace, is what a consumer checks out, so judge and
+# repair the branch. `-f` drops the edits the resolve step chose not to push.
+git fetch --no-tags origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+git checkout -q -f -B "$BRANCH" "origin/${BRANCH}"
+
+marked=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] && marked+=("$path")
+done < <(committed_marker_paths "$BASE_SHA")
+
+if [[ ${#marked[@]} -eq 0 ]]; then
+  echo "template-sync-marker-gate: no conflict markers on ${BRANCH}."
+  exit 0
+fi
+
+echo "Conflict markers committed on ${BRANCH}:"
+git grep -nE "$CONFLICT_MARKER_RE" -- "${marked[@]}"
+
+# A marked path always existed locally before the sync, because template-sync.sh
+# writes markers only where it found a local file. So the base copy is the state
+# the adopter had. A path the base lacks can only be one a resolver tier created,
+# and there is no earlier content to go back to.
+for path in "${marked[@]}"; do
+  if git cat-file -e "${BASE_SHA}:${path}" 2>/dev/null; then
+    git checkout "$BASE_SHA" -- "$path"
+  else
+    git rm -q -f -- "$path"
+  fi
+done
+
+git commit -q -m "chore: withhold ${#marked[@]} unresolved template-sync file(s)
+
+The resolver left conflict markers in these files, so the sync keeps this
+repository's own copy of each. Apply the template's change by hand from the
+conflict report in the pull request body.
+
+${marked[*]}"
+timeout --kill-after=30 300 git push origin "HEAD:${BRANCH}"
+
+echo "::error::template-sync-marker-gate: ${#marked[@]} file(s) reached ${BRANCH} carrying conflict markers: ${marked[*]}. Each is back to this repository's pre-sync copy; resolve them by hand from the conflict report in the PR body."
+exit 1

--- a/.github/scripts/template-sync-marker-gate.sh
+++ b/.github/scripts/template-sync-marker-gate.sh
@@ -32,6 +32,14 @@ source "${LIB_DIR}/git-auth.bash"
 
 BRANCH="template-sync"
 
+# BASE_SHA decides what each marked file goes back to, and a path it cannot
+# resolve is DELETED below. An unreadable base would restore nothing and delete
+# everything, so refuse it here rather than acting on it.
+git rev-parse --verify --quiet "${BASE_SHA}^{commit}" >/dev/null || {
+  echo "::error::template-sync-marker-gate: BASE_SHA ${BASE_SHA} is not a commit in this checkout."
+  exit 1
+}
+
 git_auth_header "$GITHUB_TOKEN"
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/scripts/template-sync-marker-gate.sh
+++ b/.github/scripts/template-sync-marker-gate.sh
@@ -46,7 +46,7 @@ git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 # The branch, not the workspace, is what a consumer checks out, so judge and
 # repair the branch. `-f` drops the edits the resolve step chose not to push.
-git fetch --no-tags origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+timeout --kill-after=30 300 git fetch --no-tags origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
 git checkout -q -f -B "$BRANCH" "origin/${BRANCH}"
 
 marked=()

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -332,6 +332,19 @@ jobs:
           BY_MODEL: ${{ steps.resolve.outputs.by_model }}
         run: bash .github/scripts/template-sync-push.sh
 
+      # The markers reach the branch before either resolver tier runs, because
+      # create-pull-request commits the whole synced tree. So this is the step
+      # that holds the invariant: no file on `template-sync` carries a conflict
+      # marker. It runs even when a step above it failed, because a resolve step
+      # that died is exactly when the markers survive.
+      - name: Refuse conflict markers on the sync branch
+        if: ${{ !cancelled() && inputs.dry-run != true && steps.create-pr.outputs.pull-request-number }}
+        env:
+          BASE_SHA: ${{ github.sha }}
+          # token-fallback-ok: designed graceful degradation, not an accident.
+          GITHUB_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/template-sync-marker-gate.sh
+
       # A sync merges itself only when NOTHING needed judgement. See the script
       # for the full predicate; the two carve-outs are that a model-resolved file
       # never qualifies, and neither does a change to the supervision surface.

--- a/tests/test_required_env.py
+++ b/tests/test_required_env.py
@@ -25,6 +25,8 @@ CASES = [
     ("fetch-security-report.sh", ["GH_TOKEN", "REPO"]),
     # template-sync.sh requires GITHUB_OUTPUT
     ("template-sync.sh", ["GITHUB_OUTPUT"]),
+    # template-sync-marker-gate.sh requires BASE_SHA and GITHUB_TOKEN
+    ("template-sync-marker-gate.sh", ["BASE_SHA", "GITHUB_TOKEN"]),
     # cancel-pr-runs.sh requires REPO, HEAD_REF, HEAD_SHA, GH_TOKEN
     ("cancel-pr-runs.sh", ["REPO", "HEAD_REF", "HEAD_SHA", "GH_TOKEN"]),
     # label-merge-conflicts.sh requires GH_TOKEN and REPO

--- a/tests/test_template_sync_marker_gate.py
+++ b/tests/test_template_sync_marker_gate.py
@@ -1,0 +1,186 @@
+"""No file on the `template-sync` branch may carry conflict markers.
+
+template-sync.sh writes diff3 markers into the tree deliberately, and
+create-pull-request commits that tree before either resolver tier runs. So every
+file a tier fails to settle reaches the branch with `<<<<<<< local` still in it,
+and until this gate nothing failed: the resolve driver printed a `::warning::`
+for its `unresolved` set and exited 0. Downstream that shipped a bash library
+whose markers are a syntax error (agent-sanitizer#305,
+agent-control-plane-core#52).
+
+Each case drives the real script against a real git remote and asserts on the
+branch the remote ends up holding, because the branch is what a consumer checks
+out.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._helpers import REPO_ROOT, commit_files, git_env, git_out, init_test_repo
+
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "template-sync-marker-gate.sh"
+
+MARKED = (
+    "retry_with_backoff() {\n"
+    "<<<<<<< local\n"
+    "  local tries=5\n"
+    "||||||| base\n"
+    "  local tries=2\n"
+    "=======\n"
+    "  local tries=3\n"
+    ">>>>>>> template\n"
+    "}\n"
+)
+LOCAL = "retry_with_backoff() {\n  local tries=5\n}\n"
+# A repository may keep marker text on purpose. This one documents what a
+# conflict looks like, and the gate must never withhold it.
+FIXTURE = "docs/what-a-conflict-looks-like.md"
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> tuple[Path, str]:
+    """A work repo with a bare `origin`, `main` holding the pre-sync copies, and
+    `template-sync` checked out. Returns (work, base_sha)."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "-b", "main"], cwd=origin, check=True
+    )
+
+    work = tmp_path / "work"
+    init_test_repo(work)
+    base_sha = commit_files(
+        work,
+        {
+            ".github/scripts/lib/retry.bash": LOCAL,
+            "README.md": "# repo\n",
+            FIXTURE: MARKED,
+        },
+        "pre-sync",
+    )
+    env = git_env()
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(origin)], cwd=work, check=True
+    )
+    subprocess.run(
+        ["git", "push", "-q", "origin", "main"], cwd=work, env=env, check=True
+    )
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "template-sync"], cwd=work, check=True
+    )
+    return work, base_sha
+
+
+def fetch_origin(work: Path) -> None:
+    subprocess.run(
+        ["git", "fetch", "-q", "origin"], cwd=work, env=git_env(), check=True
+    )
+
+
+def push_branch(work: Path) -> None:
+    subprocess.run(
+        ["git", "push", "-q", "origin", "template-sync"],
+        cwd=work,
+        env=git_env(),
+        check=True,
+    )
+
+
+def run_gate(work: Path, base_sha: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=work,
+        env={**git_env(), "BASE_SHA": base_sha, "GITHUB_TOKEN": "x"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def pushed(work: Path, path: str) -> str:
+    """The content the remote's `template-sync` tip holds for PATH."""
+    fetch_origin(work)
+    return git_out(work, "show", f"origin/template-sync:{path}")
+
+
+def test_a_marked_file_is_withheld_and_the_run_goes_red(sandbox):
+    work, base_sha = sandbox
+    commit_files(
+        work,
+        {".github/scripts/lib/retry.bash": MARKED, "README.md": "# repo v2\n"},
+        "sync from template",
+    )
+    push_branch(work)
+
+    result = run_gate(work, base_sha)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "::error::" in result.stdout, "the run must carry a legible red"
+    assert ".github/scripts/lib/retry.bash" in result.stdout
+    # The conflicted file goes back to what this repo had; every other synced
+    # change on the branch survives, so the gate withholds one file, not the sync.
+    assert pushed(work, ".github/scripts/lib/retry.bash") == LOCAL.rstrip("\n")
+    assert pushed(work, "README.md") == "# repo v2"
+
+
+def test_a_file_the_base_does_not_have_is_removed(sandbox):
+    """A tier can only create a marked path that the pre-sync repo never had.
+    There is no earlier content to restore, so the branch must lose the file."""
+    work, base_sha = sandbox
+    commit_files(work, {"new-from-template.bash": MARKED}, "sync from template")
+    push_branch(work)
+
+    result = run_gate(work, base_sha)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    tracked = git_out(work, "ls-tree", "-r", "--name-only", "origin/template-sync")
+    assert "new-from-template.bash" not in tracked.splitlines()
+
+
+def test_an_uncommitted_marked_edit_is_not_the_branch(sandbox):
+    """The resolve step leaves edits it chose not to push. A consumer fetches the
+    branch, so the workspace must not decide the verdict."""
+    work, base_sha = sandbox
+    tip = commit_files(work, {"README.md": "# repo v2\n"}, "sync from template")
+    push_branch(work)
+    (work / ".github" / "scripts" / "lib" / "retry.bash").write_text(
+        MARKED, encoding="utf-8"
+    )
+
+    result = run_gate(work, base_sha)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    fetch_origin(work)
+    assert git_out(work, "rev-parse", "origin/template-sync") == tip
+
+
+def test_marker_text_the_repo_already_had_is_left_alone(sandbox):
+    """A file whose pre-sync copy carries markers is the repository's own
+    fixture, not a failed resolution, so the gate must pass it."""
+    work, base_sha = sandbox
+    tip = commit_files(work, {"README.md": "# repo v2\n"}, "sync from template")
+    push_branch(work)
+
+    result = run_gate(work, base_sha)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert pushed(work, FIXTURE) == MARKED.rstrip("\n")
+    assert git_out(work, "rev-parse", "origin/template-sync") == tip
+
+
+def test_a_clean_branch_passes_and_is_left_alone(sandbox):
+    work, base_sha = sandbox
+    tip = commit_files(
+        work,
+        {".github/scripts/lib/retry.bash": "  local tries=4\n"},
+        "sync from template",
+    )
+    push_branch(work)
+
+    result = run_gate(work, base_sha)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    fetch_origin(work)
+    assert git_out(work, "rev-parse", "origin/template-sync") == tip

--- a/tests/test_template_sync_marker_gate.py
+++ b/tests/test_template_sync_marker_gate.py
@@ -170,6 +170,25 @@ def test_marker_text_the_repo_already_had_is_left_alone(sandbox):
     assert git_out(work, "rev-parse", "origin/template-sync") == tip
 
 
+def test_a_base_the_checkout_cannot_resolve_stops_the_gate(sandbox):
+    """BASE_SHA says what each marked file goes back to, and a path it cannot
+    resolve is deleted. An unreadable base must stop the gate, not empty it."""
+    work, _ = sandbox
+    tip = commit_files(
+        work,
+        {".github/scripts/lib/retry.bash": MARKED},
+        "sync from template",
+    )
+    push_branch(work)
+
+    result = run_gate(work, "0" * 40)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "is not a commit" in result.stdout
+    fetch_origin(work)
+    assert git_out(work, "rev-parse", "origin/template-sync") == tip
+
+
 def test_a_clean_branch_passes_and_is_left_alone(sandbox):
     work, base_sha = sandbox
     tip = commit_files(


### PR DESCRIPTION
## What & why

Claims `.github/scripts/template-sync-marker-gate.sh` and the post-push step in `template-sync.yaml`.

A new step, "Refuse conflict markers on the sync branch", restores every path on `template-sync` that still carries a diff3 marker to this repository's pre-sync copy, pushes that, and exits 1. `template-sync.sh` writes those markers on purpose, but `create-pull-request` commits the tree before either resolver tier runs, and `template-sync-resolve.sh` only warns about what it could not settle. So a marked file reached the branch while the run reported success. Ports AlexanderMattTurner/agent-resolve-merge-conflicts#99, which fixed the same defect there after it broke agent-sanitizer#305 and agent-control-plane-core#52. Every consumer syncs this workflow from here, so the class cannot recur in a repo made from this template.

```
$ git show origin/template-sync:.github/scripts/lib/retry.bash   # before
<<<<<<< local
  local tries=5
=======
  local tries=3
>>>>>>> template
$ git show origin/template-sync:.github/scripts/lib/retry.bash   # after
  local tries=5
```

## Review focus

`.github/scripts/lib/merge-conflict.bash` — `committed_marker_paths` decides what gets withheld, and a false positive hands the adopter back a file nothing was wrong with. It reads the commit, never the worktree, and skips a path whose `BASE_SHA` copy already carries markers. The gate deletes a marked path the base does not carry, so it also refuses a `BASE_SHA` the checkout cannot resolve.

## How it was tested

`uv run pytest tests/test_template_sync_marker_gate.py tests/test_required_env.py -q` — 21 pass. `node --test .github/scripts/lib/merge-conflict.test.mjs` — 9 pass. Deleting the base-exemption line from `committed_marker_paths` turns 3 of the 6 new cases red.

## Decisions made

**No clone of the resolver repository.** #99's script sources its helpers from `${RESOLVER_DIR}`, which only the resolve step sets up, as a shell-local variable no later step sees. This repo already keeps `CONFLICT_MARKER_RE` in `.github/scripts/lib/merge-conflict.bash` and `git_auth_header` in `lib/git-auth.bash`, so `has_marker_triple` and `committed_marker_paths` join that library and the gate needs no network. The alternative clones `agent-resolve-merge-conflicts` at a second pinned SHA and puts a second marker verdict beside the one this tree has.

**The verdict reads the commit, not the worktree.** #99 greps the working tree and leans on the force checkout above it to make the two agree.

<details>

- No pinned-step-name registry here: `tests/test_template_sync_base_driver.py` is an `agent-resolve-merge-conflicts` file, and this workflow calls `bash .github/scripts/<name>.sh` with no `DRIVERS_DIR`. `tests/test_required_env.py` exists and gets the new entry. No `changelog.d/`, so #99's fragment has no counterpart.
- `template-sync-push.sh` already refuses to push a marked resolution, but only over the paths the resolver reported — a file no tier touched never reaches it.
- Not run locally: `shellcheck`, `shfmt`, `shellharden`, `pre-commit` (none installed). Ran `bash -n`, `check-pipefail-sigpipe.py`, `ruff format --check`, `ruff check` and `validate-config.sh`.

</details>
