### PR TITLE
fix(template-sync): fail the marker gate when its scan never ran

### DIFF
--- a/.github/scripts/lib/merge-conflict.bash
+++ b/.github/scripts/lib/merge-conflict.bash
@@ -32,12 +32,15 @@ protected_matches() {
 # has_marker_triple — true when stdin carries all three marker kinds. The complete triple is the
 # verdict, never one kind on its own. It reads the kinds back out of CONFLICT_MARKER_RE's own
 # matches rather than spelling a per-kind pattern, so there is still one regex to drift.
+#
+# The `|| rc=$?` is what makes the next line reachable. A bare assignment carries the command's
+# status, so under `set -e` a caller that does NOT invoke this inside `||`/`&&`/`if` dies right
+# here, and a scan that never ran then reads as a clean file.
 has_marker_triple() {
-  local matches rc kinds
-  matches="$(grep -oE "$CONFLICT_MARKER_RE")"
-  rc=$?
+  local matches kinds rc=0
+  matches="$(grep -oE "$CONFLICT_MARKER_RE")" || rc=$?
   # 1 is "no marker at all", which is the answer, not a failure.
-  [[ "${rc:-0}" -le 1 ]] || return "$rc"
+  [[ "$rc" -le 1 ]] || return "$rc"
   kinds="$(cut -c1 <<<"$matches")"
   [[ "$kinds" == *'<'* ]] && [[ "$kinds" == *'='* ]] && [[ "$kinds" == *'>'* ]]
 }
@@ -47,12 +50,15 @@ has_marker_triple() {
 # cannot change the verdict about what a consumer would check out. A path whose BASE_REF copy
 # already carries markers is skipped, so a repository that keeps marker text on purpose — a test
 # fixture, a document about conflicts — is never withheld from itself.
+#
+# A scan that fails returns git's own status, so the caller can tell "no markers" from "the scan
+# never ran". Read that status: a caller that discards it treats a broken scan as a clean branch,
+# which is the one answer this function must never give by accident.
 committed_marker_paths() {
-  local base_ref="${1:?committed_marker_paths: BASE_REF required}" ref="${2:-HEAD}" listing rc f
-  listing="$(git grep -lE "$CONFLICT_MARKER_RE" "$ref" -- .)"
-  rc=$?
+  local base_ref="${1:?committed_marker_paths: BASE_REF required}" ref="${2:-HEAD}" listing f rc=0
+  listing="$(git grep -lE "$CONFLICT_MARKER_RE" "$ref" -- .)" || rc=$?
   # 1 is "no match", the ordinary outcome on a branch nobody left a marker on.
-  [[ "${rc:-0}" -le 1 ]] || return "$rc"
+  [[ "$rc" -le 1 ]] || return "$rc"
   while IFS= read -r f; do
     f="${f#"${ref}:"}"
     [[ -n "$f" ]] || continue

--- a/.github/scripts/lib/merge-conflict.bash
+++ b/.github/scripts/lib/merge-conflict.bash
@@ -32,10 +32,8 @@ protected_matches() {
 # has_marker_triple — true when stdin carries all three marker kinds. The complete triple is the
 # verdict, never one kind on its own. It reads the kinds back out of CONFLICT_MARKER_RE's own
 # matches rather than spelling a per-kind pattern, so there is still one regex to drift.
-#
-# The `|| rc=$?` is what makes the next line reachable. A bare assignment carries the command's
-# status, so under `set -e` a caller that does NOT invoke this inside `||`/`&&`/`if` dies right
-# here, and a scan that never ran then reads as a clean file.
+# `|| rc=$?` keeps the next line reachable: a bare assignment carries the command's status, so
+# under `set -e` it kills an unprotected caller right here.
 has_marker_triple() {
   local matches kinds rc=0
   matches="$(grep -oE "$CONFLICT_MARKER_RE")" || rc=$?
@@ -51,9 +49,8 @@ has_marker_triple() {
 # already carries markers is skipped, so a repository that keeps marker text on purpose — a test
 # fixture, a document about conflicts — is never withheld from itself.
 #
-# A scan that fails returns git's own status, so the caller can tell "no markers" from "the scan
-# never ran". Read that status: a caller that discards it treats a broken scan as a clean branch,
-# which is the one answer this function must never give by accident.
+# A failed scan returns git's own status, so the caller can tell "no markers" from "the scan never
+# ran". Read it: a caller that discards it reports a broken scan as a clean branch.
 committed_marker_paths() {
   local base_ref="${1:?committed_marker_paths: BASE_REF required}" ref="${2:-HEAD}" listing f rc=0
   listing="$(git grep -lE "$CONFLICT_MARKER_RE" "$ref" -- .)" || rc=$?

--- a/.github/scripts/lib/merge-conflict.bash
+++ b/.github/scripts/lib/merge-conflict.bash
@@ -52,14 +52,19 @@ has_marker_triple() {
 # A failed scan returns git's own status, so the caller can tell "no markers" from "the scan never
 # ran". Read it: a caller that discards it reports a broken scan as a clean branch.
 committed_marker_paths() {
-  local base_ref="${1:?committed_marker_paths: BASE_REF required}" ref="${2:-HEAD}" listing f rc=0
+  local base_ref="${1:?committed_marker_paths: BASE_REF required}" ref="${2:-HEAD}" listing f rc=0 rc_f=0
   listing="$(git grep -lE "$CONFLICT_MARKER_RE" "$ref" -- .)" || rc=$?
   # 1 is "no match", the ordinary outcome on a branch nobody left a marker on.
   [[ "$rc" -le 1 ]] || return "$rc"
   while IFS= read -r f; do
     f="${f#"${ref}:"}"
     [[ -n "$f" ]] || continue
-    git cat-file blob "${ref}:${f}" | has_marker_triple || continue
+    # Same rc<=1 contract as above, but per-file: a git/pipe failure here must
+    # abort the scan too, not read as "this one file has no markers".
+    rc_f=0
+    git cat-file blob "${ref}:${f}" | has_marker_triple || rc_f=$?
+    [[ "$rc_f" -le 1 ]] || return "$rc_f"
+    [[ "$rc_f" -eq 0 ]] || continue
     git cat-file blob "${base_ref}:${f}" 2>/dev/null | has_marker_triple && continue
     printf '%s\n' "$f"
   done <<<"$listing"

--- a/.github/scripts/template-sync-marker-gate.sh
+++ b/.github/scripts/template-sync-marker-gate.sh
@@ -66,9 +66,6 @@ done <<<"$scan"
 
 if [[ ${#marked[@]} -eq 0 ]]; then
   echo "template-sync-marker-gate: no conflict markers on ${BRANCH}."
-  # The next step resolves its own script from this workspace, and the workflow runs a reviewed
-  # copy rather than the template's proposal. Leave the workspace back on the base commit.
-  git checkout -q -f --detach "$BASE_SHA"
   exit 0
 fi
 

--- a/.github/scripts/template-sync-marker-gate.sh
+++ b/.github/scripts/template-sync-marker-gate.sh
@@ -49,13 +49,26 @@ git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 timeout --kill-after=30 300 git fetch --no-tags origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
 git checkout -q -f -B "$BRANCH" "origin/${BRANCH}"
 
+# Command substitution, never `< <(…)`: a process substitution runs in a subshell whose exit
+# status the reading loop cannot see, so a scan that died would deliver an empty list and read
+# as a clean branch. Capturing the status is what makes a failed scan a failure.
+scan_rc=0
+scan="$(committed_marker_paths "$BASE_SHA")" || scan_rc=$?
+[[ "$scan_rc" -eq 0 ]] || {
+  echo "::error::template-sync-marker-gate: the marker scan failed (exit ${scan_rc}); ${BRANCH} is NOT known to be clean."
+  exit 1
+}
+
 marked=()
 while IFS= read -r path; do
   [[ -n "$path" ]] && marked+=("$path")
-done < <(committed_marker_paths "$BASE_SHA")
+done <<<"$scan"
 
 if [[ ${#marked[@]} -eq 0 ]]; then
   echo "template-sync-marker-gate: no conflict markers on ${BRANCH}."
+  # The next step resolves its own script from this workspace, and the workflow runs a reviewed
+  # copy rather than the template's proposal. Leave the workspace back on the base commit.
+  git checkout -q -f --detach "$BASE_SHA"
   exit 0
 fi
 

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -355,9 +355,13 @@ jobs:
       # A sync merges itself only when NOTHING needed judgement. See the script
       # for the full predicate; the two carve-outs are that a model-resolved file
       # never qualifies, and neither does a change to the supervision surface.
+      # It runs a BASE_SHA copy for the same reason the gate does: the gate
+      # passing only proves the branch carries no conflict marker, never that
+      # this script or the predicate it reads still match the reviewed version.
       - name: Enable auto-merge on a fully deterministic sync
         if: inputs.dry-run != true && steps.create-pr.outputs.pull-request-number && vars.TEMPLATE_SYNC_AUTOMERGE != 'false'
         env:
+          BASE_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || github.token }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
@@ -366,4 +370,9 @@ jobs:
           HAS_DOWNGRADES: ${{ steps.sync.outputs.has_downgrades }}
           ALL_DETERMINISTIC: ${{ steps.resolve.outputs.all_deterministic }}
           CHANGED_PATHS: ${{ steps.sync.outputs.changed_paths }}
-        run: bash .github/scripts/template-sync-automerge.sh
+        run: |
+          set -o pipefail
+          automerge_dir="${RUNNER_TEMP}/marker-gate-automerge"
+          mkdir -p "${automerge_dir}" # bare-mkdir-ok: the extraction below is the post-condition and fails loudly
+          timeout --kill-after=30 300 git archive "${BASE_SHA}" .github/scripts | tar -x -f - -C "${automerge_dir}"
+          bash "${automerge_dir}/.github/scripts/template-sync-automerge.sh"

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -337,11 +337,8 @@ jobs:
       # that holds the invariant: no file on `template-sync` carries a conflict
       # marker. It runs even when a step above it failed, because a resolve step
       # that died is exactly when the markers survive.
-      #
-      # The gate runs from a BASE_SHA copy, never from the workspace. The
-      # workspace is the sync branch here, and `.github/scripts` is in
-      # SYNC_PATHS, so the gate's own file can be one of the marked ones — bash
-      # then dies on `<<<<<<<` and the branch keeps its markers.
+      # It runs a BASE_SHA copy, not the workspace: `.github/scripts` is in
+      # SYNC_PATHS, so a sync can mark the gate's own file, and bash dies on it.
       - name: Refuse conflict markers on the sync branch
         if: ${{ !cancelled() && inputs.dry-run != true && steps.create-pr.outputs.pull-request-number }}
         env:
@@ -349,9 +346,10 @@ jobs:
           # token-fallback-ok: designed graceful degradation, not an accident.
           GITHUB_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
         run: |
+          set -o pipefail
           gate_dir="${RUNNER_TEMP}/marker-gate"
           mkdir -p "${gate_dir}" # bare-mkdir-ok: the extraction below is the post-condition and fails loudly
-          timeout --kill-after=30 300 git archive "${BASE_SHA}" .github/scripts | tar -x -C "${gate_dir}"
+          timeout --kill-after=30 300 git archive "${BASE_SHA}" .github/scripts | tar -x -f - -C "${gate_dir}"
           bash "${gate_dir}/.github/scripts/template-sync-marker-gate.sh"
 
       # A sync merges itself only when NOTHING needed judgement. See the script

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -337,13 +337,22 @@ jobs:
       # that holds the invariant: no file on `template-sync` carries a conflict
       # marker. It runs even when a step above it failed, because a resolve step
       # that died is exactly when the markers survive.
+      #
+      # The gate runs from a BASE_SHA copy, never from the workspace. The
+      # workspace is the sync branch here, and `.github/scripts` is in
+      # SYNC_PATHS, so the gate's own file can be one of the marked ones — bash
+      # then dies on `<<<<<<<` and the branch keeps its markers.
       - name: Refuse conflict markers on the sync branch
         if: ${{ !cancelled() && inputs.dry-run != true && steps.create-pr.outputs.pull-request-number }}
         env:
           BASE_SHA: ${{ github.sha }}
           # token-fallback-ok: designed graceful degradation, not an accident.
           GITHUB_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
-        run: bash .github/scripts/template-sync-marker-gate.sh
+        run: |
+          gate_dir="${RUNNER_TEMP}/marker-gate"
+          mkdir -p "${gate_dir}" # bare-mkdir-ok: the extraction below is the post-condition and fails loudly
+          timeout --kill-after=30 300 git archive "${BASE_SHA}" .github/scripts | tar -x -C "${gate_dir}"
+          bash "${gate_dir}/.github/scripts/template-sync-marker-gate.sh"
 
       # A sync merges itself only when NOTHING needed judgement. See the script
       # for the full predicate; the two carve-outs are that a model-resolved file

--- a/tests/test_template_sync_marker_gate.py
+++ b/tests/test_template_sync_marker_gate.py
@@ -13,12 +13,20 @@ branch the remote ends up holding, because the branch is what a consumer checks
 out.
 """
 
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
-from tests._helpers import REPO_ROOT, commit_files, git_env, git_out, init_test_repo
+from tests._helpers import (
+    REPO_ROOT,
+    commit_all,
+    commit_files,
+    git_env,
+    git_out,
+    init_test_repo,
+)
 
 SCRIPT = REPO_ROOT / ".github" / "scripts" / "template-sync-marker-gate.sh"
 
@@ -88,11 +96,19 @@ def push_branch(work: Path) -> None:
     )
 
 
-def run_gate(work: Path, base_sha: str) -> subprocess.CompletedProcess[str]:
+def run_gate(
+    work: Path,
+    base_sha: str,
+    script: Path = SCRIPT,
+    extra_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = {**git_env(), "BASE_SHA": base_sha, "GITHUB_TOKEN": "x"}
+    if extra_path is not None:
+        env["PATH"] = f"{extra_path}:{env['PATH']}"
     return subprocess.run(
-        ["bash", str(SCRIPT)],
+        ["bash", str(script)],
         cwd=work,
-        env={**git_env(), "BASE_SHA": base_sha, "GITHUB_TOKEN": "x"},
+        env=env,
         capture_output=True,
         text=True,
         check=False,
@@ -187,6 +203,101 @@ def test_a_base_the_checkout_cannot_resolve_stops_the_gate(sandbox):
     assert "is not a commit" in result.stdout
     fetch_origin(work)
     assert git_out(work, "rev-parse", "origin/template-sync") == tip
+
+
+def test_a_failed_scan_never_reads_as_a_clean_branch(sandbox, tmp_path):
+    """The scan is the gate's only evidence. A `git grep` that dies must reach
+    the caller as a failure, not as an empty list that looks like no markers."""
+    work, base_sha = sandbox
+    commit_files(work, {".github/scripts/lib/retry.bash": MARKED}, "sync from template")
+    push_branch(work)
+    stub_dir = tmp_path / "stub-bin"
+    stub_dir.mkdir()
+    real_git = shutil.which("git")
+    assert real_git, "the stub forwards to the real git; without it this proves nothing"
+    (stub_dir / "git").write_text(
+        f'#!/usr/bin/env bash\n[[ "$1" == "grep" ]] && exit 128\nexec {real_git} "$@"\n',
+        encoding="utf-8",
+    )
+    (stub_dir / "git").chmod(0o755)
+
+    result = run_gate(work, base_sha, extra_path=stub_dir)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "the marker scan failed" in result.stdout
+    assert "no conflict markers" not in result.stdout
+
+
+def test_the_gate_runs_from_a_base_copy_when_its_own_file_is_marked(sandbox, tmp_path):
+    """`.github/scripts` is in SYNC_PATHS, so a sync can leave markers in the
+    gate's own file. The workflow runs a BASE_SHA copy for exactly this case."""
+    work, base_sha = sandbox
+    gate_path = ".github/scripts/template-sync-marker-gate.sh"
+    commit_files(work, {gate_path: MARKED}, "sync from template")
+    push_branch(work)
+
+    in_tree = run_gate(work, base_sha, script=work / gate_path)
+    assert in_tree.returncode != 0
+    assert "::error::" not in in_tree.stdout, "bash cannot parse the marked copy"
+
+    base_copy = tmp_path / "gate" / ".github" / "scripts"
+    base_copy.mkdir(parents=True)
+    shutil.copy2(SCRIPT, base_copy / SCRIPT.name)
+    shutil.copytree(SCRIPT.parent / "lib", base_copy / "lib")
+
+    result = run_gate(work, base_sha, script=base_copy / SCRIPT.name)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    tracked = git_out(work, "ls-tree", "-r", "--name-only", "origin/template-sync")
+    assert gate_path not in tracked.splitlines()
+
+
+def test_a_branch_with_no_marker_text_at_all_is_clean(sandbox):
+    """`git grep` exits 1 when nothing matches, which is the ordinary result on
+    a clean sync. That is the scan's answer, not the scan failing — and it must
+    read that way to a caller that invokes the scan unprotected too, because the
+    contract cannot depend on the caller's syntax."""
+    work, base_sha = sandbox
+    subprocess.run(["git", "rm", "-q", FIXTURE], cwd=work, env=git_env(), check=True)
+    commit_all(work, "sync from template")
+    push_branch(work)
+
+    # HEAD is the branch here, so the scan matches nothing. Run it BEFORE the
+    # gate, which leaves the workspace back on a base that does carry markers.
+    lib = SCRIPT.parent / "lib" / "merge-conflict.bash"
+    unprotected = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'set -euo pipefail\nsource "{lib}"\n'
+            f'committed_marker_paths "{base_sha}"\necho survived\n',
+        ],
+        cwd=work,
+        env=git_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert unprotected.returncode == 0, unprotected.stdout + unprotected.stderr
+    assert "survived" in unprotected.stdout
+
+    result = run_gate(work, base_sha)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "no conflict markers" in result.stdout
+
+
+def test_a_clean_run_leaves_the_workspace_off_the_sync_branch(sandbox):
+    """The next workflow step resolves its own script from the workspace, and
+    the sync branch is the template's proposal rather than a reviewed tree."""
+    work, base_sha = sandbox
+    commit_files(work, {"README.md": "# repo v2\n"}, "sync from template")
+    push_branch(work)
+
+    result = run_gate(work, base_sha)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert git_out(work, "rev-parse", "HEAD") == base_sha
 
 
 def test_a_clean_branch_passes_and_is_left_alone(sandbox):

--- a/tests/test_template_sync_marker_gate.py
+++ b/tests/test_template_sync_marker_gate.py
@@ -228,6 +228,27 @@ def test_a_failed_scan_never_reads_as_a_clean_branch(sandbox, tmp_path):
     assert "no conflict markers" not in result.stdout
 
 
+def test_a_failed_per_file_check_never_reads_as_that_file_has_no_markers(sandbox, tmp_path):
+    """has_marker_triple's own grep can fail (rc > 1), distinct from finding no
+    marker (rc <= 1). The per-file loop must abort the scan on that failure,
+    not read it as `|| continue` and report the branch clean."""
+    work, base_sha = sandbox
+    commit_files(work, {".github/scripts/lib/retry.bash": MARKED}, "sync from template")
+    push_branch(work)
+    stub_dir = tmp_path / "stub-bin"
+    stub_dir.mkdir()
+    # git grep (the top-level scan) is a git subcommand, not the grep binary, so
+    # this stub only reaches has_marker_triple's own `grep -oE` call.
+    (stub_dir / "grep").write_text("#!/usr/bin/env bash\nexit 2\n", encoding="utf-8")
+    (stub_dir / "grep").chmod(0o755)
+
+    result = run_gate(work, base_sha, extra_path=stub_dir)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "the marker scan failed" in result.stdout
+    assert "no conflict markers" not in result.stdout
+
+
 def test_the_gate_runs_from_a_base_copy_when_its_own_file_is_marked(sandbox, tmp_path):
     """`.github/scripts` is in SYNC_PATHS, so a sync can leave markers in the
     gate's own file. The workflow runs a BASE_SHA copy for exactly this case."""
@@ -285,19 +306,6 @@ def test_a_branch_with_no_marker_text_at_all_is_clean(sandbox):
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "no conflict markers" in result.stdout
-
-
-def test_a_clean_run_leaves_the_workspace_off_the_sync_branch(sandbox):
-    """The next workflow step resolves its own script from the workspace, and
-    the sync branch is the template's proposal rather than a reviewed tree."""
-    work, base_sha = sandbox
-    commit_files(work, {"README.md": "# repo v2\n"}, "sync from template")
-    push_branch(work)
-
-    result = run_gate(work, base_sha)
-
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert git_out(work, "rev-parse", "HEAD") == base_sha
 
 
 def test_a_clean_branch_passes_and_is_left_alone(sandbox):

--- a/tests/test_template_sync_marker_gate.py
+++ b/tests/test_template_sync_marker_gate.py
@@ -228,7 +228,9 @@ def test_a_failed_scan_never_reads_as_a_clean_branch(sandbox, tmp_path):
     assert "no conflict markers" not in result.stdout
 
 
-def test_a_failed_per_file_check_never_reads_as_that_file_has_no_markers(sandbox, tmp_path):
+def test_a_failed_per_file_check_never_reads_as_that_file_has_no_markers(
+    sandbox, tmp_path
+):
     """has_marker_triple's own grep can fail (rc > 1), distinct from finding no
     marker (rc <= 1). The per-file loop must abort the scan on that failure,
     not read it as `|| continue` and report the branch clean."""


### PR DESCRIPTION
## What & why

Claims `.github/scripts/template-sync-marker-gate.sh`, `.github/scripts/lib/merge-conflict.bash`, and `template-sync.yaml`. Follows up #495, which landed the gate with holes review found after the merge.

1. **A failed scan read as a clean branch.** The gate took its list through `< <(committed_marker_paths …)`, whose subshell status the reading loop cannot see. It now captures the status and refuses a branch it could not scan.
2. **The gate ran from the sync branch.** `.github/scripts` is in `SYNC_PATHS`, so a sync can mark the gate's own file and bash dies on it. The step now runs a `BASE_SHA` copy.
3. **A failed PER-FILE check read as "this file has no marker."** `has_marker_triple`'s own `grep` can fail (rc > 1), distinct from finding no marker (rc ≤ 1) — the loop's `|| continue` treated both the same. It now applies the same rc ≤ 1 contract per file that the top-level scan already uses.
4. **Auto-merge trusted the just-synced tree.** The gate passing proves no file carries a conflict marker, never that `merge-conflict.bash`'s predicate still matches the reviewed version. The auto-merge step now runs its own `BASE_SHA` copy, the same way the gate does — which removes the gate's only reason to leave the workspace on `BASE_SHA` after a clean run, so that checkout and its test are gone.

```
$ git cat-file blob "$ref:$f" | has_marker_triple   # has_marker_triple's grep errors, rc=2
$ echo $?
1   # before: has_marker_triple's own failure and "no marker" both hit `|| continue`
```

## Review focus

`committed_marker_paths`'s per-file loop in `merge-conflict.bash`, and whether the auto-merge step's own extraction (mirroring the gate's) is the right fix for its dependency on `BASE_SHA` state versus some other boundary.

## How it was tested

`uv run pytest tests/test_template_sync_marker_gate.py tests/test_template_sync_automerge.py tests/test_required_env.py -q` — 34 pass. `node --test .github/scripts/lib/merge-conflict.test.mjs` — 9 pass. The new per-file case is shown red against the unfixed library: stubbing `grep` to exit 2 (only reachable from `has_marker_triple`, since the top-level scan uses `git grep`) makes the gate report "no conflict markers" and exit 0; fixed, it reports "the marker scan failed" and exits 1.

## Decisions made

**Auto-merge extracts its own `BASE_SHA` copy rather than depending on the gate's workspace state.** The prior design coupled two steps' safety through an unstated side effect. Independent extraction is one inline block, matching the gate's own pattern, and needs no cross-step contract.

<details>
<summary>Details</summary>

- Confirmed by running: the new per-file test fails on `git stash`-ed pre-fix code with the exact "no conflict markers" false-clean report; passes fixed.
- `bash -n`, `shellcheck -x` on both changed shell files, `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow.
- Not run locally: `actionlint`, `zizmor`, `pre-commit` (not installed here).

</details>