### PR TITLE
feat(template-sync): say which template commit moved which file

### DIFF
--- a/.github/scripts/template-sync-pr-body.sh
+++ b/.github/scripts/template-sync-pr-body.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Render the sync pull request's body.
+#
+# Extracted from template-sync.yaml, where it was ~60 lines of nested
+# `format()` expressions: invisible to shellcheck, untestable, and impossible
+# to read a conditional out of. The body it produced led with a
+# space-joined blob of every changed path and a raw `git log` of the whole
+# template, so a reader could not tell which commit explains which file.
+#
+# The order is deliberate. What changed and why comes first; the warnings that
+# need a human come next, loudest first; the bookkeeping comes last.
+#
+# Env, all optional except the first three, and all from template-sync.sh's
+# step outputs: TEMPLATE_REPO, TEMPLATE_SHA_SHORT, PR_BODY_PATH; then
+# CHANGED_FILES, CHANGELOG, DOWNGRADE_REPORT, AUTO_MERGED_FILES,
+# DECLINED_FILES, INERT_ENTRIES, DELETED_FILES, CONFLICT_REPORT.
+#
+# This script's output is markdown, so a backtick in a single-quoted format
+# string is a code span, never a command substitution.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+: "${TEMPLATE_REPO:?TEMPLATE_REPO required}"
+: "${TEMPLATE_SHA_SHORT:?TEMPLATE_SHA_SHORT required}"
+: "${PR_BODY_PATH:?PR_BODY_PATH required — the file to write the body to}"
+
+# The step outputs are lists, separated by spaces (the `tr`-joined ones) or by
+# newlines (CHANGED_FILES). Normalising to spaces lets one splitter read both:
+# `read -ra` stops at the first newline, and `for x in $list` would be
+# auto-quoted by shellharden, killing the split. No nameref and no `mapfile`,
+# so this still runs under the bash 3.2 a macOS contributor has.
+as_words() {
+  printf '%s' "${1:-}" | tr '\n' ' '
+}
+
+# One bullet per entry. The old body pasted these lists inline, where forty
+# paths on one line read as noise.
+bullets() {
+  local -a items
+  local item
+  read -ra items <<<"$(as_words "$1")"
+  for item in "${items[@]}"; do
+    [[ -n "$item" ]] && printf -- '- `%s`\n' "$item"
+  done
+}
+
+count() {
+  local -a items
+  read -ra items <<<"$(as_words "$1")"
+  printf '%s' "${#items[@]}"
+}
+
+{
+  printf 'Syncs %s file(s) from [%s](https://github.com/%s) at `%s`.\n' \
+    "$(count "${CHANGED_FILES:-}")" "$TEMPLATE_REPO" "$TEMPLATE_REPO" "$TEMPLATE_SHA_SHORT"
+
+  if [[ -n "${CHANGELOG:-}" ]]; then
+    printf '\n## What changed, and why\n\n%s\n' "$CHANGELOG"
+  elif [[ -n "${CHANGED_FILES:-}" ]]; then
+    printf '\n## Files synced\n\n%s\n' "$(bullets "$CHANGED_FILES")"
+  fi
+
+  # First, because it is the only section that can lose work silently.
+  if [[ -n "${DOWNGRADE_REPORT:-}" ]]; then
+    cat <<EOF
+
+## ⚠️ Adopter-ahead — review these auto-merges for lost customizations
+
+A "clean" 3-way auto-merge dropped lines that existed in this repo's local copy. The sync uses a single repo-wide merge base (\`.template-version\`), which can be stale for a file first synced at a different template revision — when it is, git reports no conflict while silently shrinking your changes. **Review each file below** and restore anything of yours the merge removed:
+
+$DOWNGRADE_REPORT
+EOF
+  fi
+
+  if [[ -n "${CONFLICT_REPORT:-}" ]]; then
+    printf '\n## Conflicts resolved in this run\n\nEach file below needed a real merge decision. Read the resolution, not just the diff.\n\n%s\n' \
+      "$CONFLICT_REPORT"
+  fi
+
+  if [[ -n "${DELETED_FILES:-}" ]]; then
+    printf '\n## Deleted in the template, still here\n\nThe sync does not delete them for you. Remove one only if this repo no longer needs it.\n\n%s\n' \
+      "$(bullets "$DELETED_FILES")"
+  fi
+
+  if [[ -n "${DECLINED_FILES:-}" ]]; then
+    printf '\n## Declined (deleted here, not re-added)\n\nThe template still ships these; this repo deleted them after an earlier sync, so the sync left them out. To adopt one, copy it from the template by hand.\n\n%s\n' \
+      "$(bullets "$DECLINED_FILES")"
+  fi
+
+  if [[ -n "${INERT_ENTRIES:-}" ]]; then
+    printf '\n## Inert EXCLUDE_PATHS / OPT_IN_PATHS entries\n\nThese name nothing in the template, so they exclude nothing. Correct the spelling, or delete the entry.\n\n%s\n' \
+      "$(bullets "$INERT_ENTRIES")"
+  fi
+
+  # Last: a reviewer who needs this already knows to look for it.
+  if [[ -n "${AUTO_MERGED_FILES:-}" ]]; then
+    printf '\n<details>\n<summary>%s file(s) merged with no conflict</summary>\n\n%s\n\n</details>\n' \
+      "$(count "$AUTO_MERGED_FILES")" "$(bullets "$AUTO_MERGED_FILES")"
+  fi
+} >"$PR_BODY_PATH"
+
+printf 'wrote %s (%s lines)\n' "$PR_BODY_PATH" "$(wc -l <"$PR_BODY_PATH")" >&2

--- a/.github/scripts/template-sync-pr-body.sh
+++ b/.github/scripts/template-sync-pr-body.sh
@@ -24,21 +24,17 @@ set -euo pipefail
 : "${TEMPLATE_SHA_SHORT:?TEMPLATE_SHA_SHORT required}"
 : "${PR_BODY_PATH:?PR_BODY_PATH required — the file to write the body to}"
 
-# The step outputs are lists, separated by spaces (the `tr`-joined ones) or by
-# newlines (CHANGED_FILES). Normalising to spaces lets one splitter read both:
-# `read -ra` stops at the first newline, and `for x in $list` would be
-# auto-quoted by shellharden, killing the split. No nameref and no `mapfile`,
-# so this still runs under the bash 3.2 a macOS contributor has.
-as_words() {
-  printf '%s' "${1:-}" | tr '\n' ' '
-}
+# Every step output is a space-joined list. `read -ra` splits one into an array,
+# the same way template-sync-automerge.sh reads CHANGED_PATHS — `for x in $list`
+# would be auto-quoted by shellharden, killing the split. No `mapfile`, so this
+# still runs under the bash 3.2 a macOS contributor has.
 
 # One bullet per entry. The old body pasted these lists inline, where forty
 # paths on one line read as noise.
 bullets() {
   local -a items
   local item
-  read -ra items <<<"$(as_words "$1")"
+  read -ra items <<<"${1:-}"
   for item in "${items[@]}"; do
     [[ -n "$item" ]] && printf -- '- `%s`\n' "$item"
   done
@@ -46,7 +42,7 @@ bullets() {
 
 count() {
   local -a items
-  read -ra items <<<"$(as_words "$1")"
+  read -ra items <<<"${1:-}"
   printf '%s' "${#items[@]}"
 }
 
@@ -73,7 +69,7 @@ EOF
   fi
 
   if [[ -n "${CONFLICT_REPORT:-}" ]]; then
-    printf '\n## Conflicts resolved in this run\n\nEach file below needed a real merge decision. Read the resolution, not just the diff.\n\n%s\n' \
+    printf '\n## Conflicts needing a merge decision\n\nEach file below needed a real merge decision. The resolver runs AFTER this body is written and nothing rewrites it, so check the branch: a file still carrying `<<<<<<<` is one resolution did not settle, and it is yours to finish.\n\n%s\n' \
       "$CONFLICT_REPORT"
   fi
 

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -179,14 +179,19 @@ main() {
     local -a range
     changed="$WORK_DIR/changed_here.txt"
     attributed="$WORK_DIR/attributed.txt"
+    # `sed`, not `grep -v`: an all-filtered list makes grep exit 1 and `set -e`
+    # would kill the run. `.template-version` is rewritten above and the template
+    # ships none, so no commit can ever explain it; `_template` is this script's
+    # own untracked checkout, which `--others` reports and `rm -rf` removes a few
+    # lines below. Both would land in the unexplained list on every single sync.
     {
       git diff --name-only
       git ls-files --others --exclude-standard
-    } | sort -u >"$changed"
+    } | sed -e '/^\.template-version$/d' -e '\#^_template/\?$#d' | sort -u >"$changed"
     [[ -s "$changed" ]] || return 0
     local changed_list
-    changed_list="$(cat "$changed")"
-    emit_multiline_output "changed_files" "$changed_list"
+    changed_list="$(tr '\n' ' ' <"$changed")"
+    echo "changed_files=$changed_list" >>"$GITHUB_OUTPUT"
 
     [[ -n "$PREV_SHA" && "$PREV_SHA" != "$TEMPLATE_SHA" ]] || return 0
     if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
@@ -218,7 +223,10 @@ main() {
         body+="  - \`${f}\`"$'\n'
         echo "$f" >>"$attributed"
       done <<<"$touched"
-    done < <(git -C _template log --format='%h%x09%s' "${range[@]}")
+      # --no-merges: `git show --name-only` prints nothing for a merge commit, so
+      # a merge would count as "touched nothing here" while being exactly the
+      # commit that carried the files. Its branch commits are already in range.
+    done < <(git -C _template log --no-merges --format='%h%x09%s' "${range[@]}")
 
     unexplained=$(comm -23 "$changed" <(sort -u "$attributed"))
     if [[ -n "$unexplained" ]]; then

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -164,6 +164,74 @@ main() {
     } >>"$GITHUB_OUTPUT"
   }
 
+  # Say WHY the tree changed: name each template commit that moved a file THIS
+  # sync actually rewrote, and the files it moved. The old body pasted a raw
+  # `git log --oneline` of the whole template, most of whose commits touch paths
+  # this repo never syncs — so the reader could not tell which commit explains
+  # any given file. Runs before `rm -rf _template`, and after the worktree
+  # carries the sync, because it needs both.
+  #
+  # A file with no commit in range is listed apart rather than dropped: it is
+  # real (a path synced for the first time, or a history the template rewrote),
+  # and silence about it would read as "nothing else changed".
+  emit_attributed_changelog() {
+    local changed body="" attributed unexplained kept=0 skipped=0
+    local -a range
+    changed="$WORK_DIR/changed_here.txt"
+    attributed="$WORK_DIR/attributed.txt"
+    {
+      git diff --name-only
+      git ls-files --others --exclude-standard
+    } | sort -u >"$changed"
+    [[ -s "$changed" ]] || return 0
+    local changed_list
+    changed_list="$(cat "$changed")"
+    emit_multiline_output "changed_files" "$changed_list"
+
+    [[ -n "$PREV_SHA" && "$PREV_SHA" != "$TEMPLATE_SHA" ]] || return 0
+    if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
+      range=("${PREV_SHA}..${TEMPLATE_SHA}")
+    else
+      echo "::warning::Previous template SHA $PREV_SHA is not in template history (force-push or rebase); attributing over the last 20 commits instead"
+      range=(-20 "$TEMPLATE_SHA")
+      body+="\`$PREV_SHA\` is no longer in the template's history, so this reads the last 20 commits rather than a range."$'\n\n'
+    fi
+
+    : >"$attributed"
+    local sha subject touched
+    while IFS=$'\t' read -r sha subject; do
+      [[ -n "$sha" ]] || continue
+      # Files this commit touched that this sync also rewrote here. `comm -12`
+      # over two sorted lists, so a commit touching only unsynced paths yields
+      # nothing and is skipped.
+      touched=$(comm -12 \
+        <(git -C _template show --pretty=format: --name-only "$sha" | sed '/^$/d' | sort -u) \
+        "$changed")
+      if [[ -z "$touched" ]]; then
+        skipped=$((skipped + 1))
+        continue
+      fi
+      kept=$((kept + 1))
+      body+="- \`${sha}\` ${subject}"$'\n'
+      while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        body+="  - \`${f}\`"$'\n'
+        echo "$f" >>"$attributed"
+      done <<<"$touched"
+    done < <(git -C _template log --format='%h%x09%s' "${range[@]}")
+
+    unexplained=$(comm -23 "$changed" <(sort -u "$attributed"))
+    if [[ -n "$unexplained" ]]; then
+      body+=$'\n'"Changed here with no commit in that range — a path synced for the first time, or one whose template history moved:"$'\n'
+      while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        body+="- \`${f}\`"$'\n'
+      done <<<"$unexplained"
+    fi
+    [[ "$skipped" -eq 0 ]] || body+=$'\n'"${skipped} other template commit(s) in that range touched nothing this repo syncs."$'\n'
+    [[ "$kept" -eq 0 && -z "$unexplained" ]] || emit_multiline_output "changelog" "$body"
+  }
+
   # Count non-blank lines present in the pre-sync local file but absent from a
   # candidate result. A clean 3-way merge should preserve every adopter line; a
   # nonzero count means the merge REMOVED content the adopter had — the silent
@@ -196,17 +264,6 @@ main() {
     echo "No previous template version found (first sync)"
   fi
   echo "Current template version: $TEMPLATE_SHA"
-
-  if [[ -n "$PREV_SHA" ]] && [[ "$PREV_SHA" != "$TEMPLATE_SHA" ]]; then
-    if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
-      CHANGELOG=$(git -C _template log --oneline "$PREV_SHA..$TEMPLATE_SHA")
-    else
-      echo "::warning::Previous template SHA $PREV_SHA not found in template history (likely rewritten by force-push or rebase)"
-      CHANGELOG="Previous SHA \`$PREV_SHA\` no longer exists in template history (force-push/rebase). Showing last 20 commits instead:"$'\n'
-      CHANGELOG+=$(git -C _template log --oneline -20 "$TEMPLATE_SHA")
-    fi
-    [[ -n "$CHANGELOG" ]] && emit_multiline_output "changelog" "$CHANGELOG"
-  fi
 
   echo "$TEMPLATE_SHA" >.template-version
 
@@ -442,6 +499,7 @@ main() {
   done
 
   report_inert_entries
+  emit_attributed_changelog
   rm -rf _template
 
   #############################################

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -222,7 +222,11 @@ jobs:
       # The body is a script, not an inline `format()` chain: a chain that long
       # is invisible to shellcheck, cannot be tested, and grew a shape nobody
       # could read a conditional out of. It runs BEFORE create-pull-request,
-      # because that action wants the body as a value.
+      # because that action reads the body from a file.
+      # It runs a BASE_SHA copy for the same reason the marker gate does:
+      # `.github/scripts` is in SYNC_PATHS, so a sync can leave conflict markers
+      # in this very script, and bash dies on them before any PR exists to show
+      # them — no PR, so neither the resolver nor the marker gate can repair it.
       - name: Render the pull request body
         if: inputs.dry-run != true && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
         id: pr-body
@@ -238,7 +242,13 @@ jobs:
           DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
           CONFLICT_REPORT: ${{ steps.sync.outputs.conflict_report }}
           PR_BODY_PATH: ${{ runner.temp }}/template-sync-body.md
-        run: bash .github/scripts/template-sync-pr-body.sh
+          BASE_SHA: ${{ github.sha }}
+        run: |
+          set -o pipefail
+          body_dir="${RUNNER_TEMP}/pr-body-scripts"
+          mkdir -p "${body_dir}" # bare-mkdir-ok: the extraction below is the post-condition and fails loudly
+          timeout --kill-after=30 300 git archive "${BASE_SHA}" .github/scripts | tar -x -f - -C "${body_dir}"
+          bash "${body_dir}/.github/scripts/template-sync-pr-body.sh"
 
       - name: Create Pull Request
         if: inputs.dry-run != true && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -219,6 +219,27 @@ jobs:
           DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
         run: bash .github/scripts/show-sync-diff.sh
 
+      # The body is a script, not an inline `format()` chain: a chain that long
+      # is invisible to shellcheck, cannot be tested, and grew a shape nobody
+      # could read a conditional out of. It runs BEFORE create-pull-request,
+      # because that action wants the body as a value.
+      - name: Render the pull request body
+        if: inputs.dry-run != true && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
+        id: pr-body
+        env:
+          TEMPLATE_REPO: ${{ env.TEMPLATE_REPO }}
+          TEMPLATE_SHA_SHORT: ${{ steps.sync.outputs.template_sha_short }}
+          CHANGED_FILES: ${{ steps.sync.outputs.changed_files }}
+          CHANGELOG: ${{ steps.sync.outputs.changelog }}
+          DOWNGRADE_REPORT: ${{ steps.sync.outputs.downgrade_report }}
+          AUTO_MERGED_FILES: ${{ steps.sync.outputs.auto_merged_files }}
+          DECLINED_FILES: ${{ steps.sync.outputs.declined_files }}
+          INERT_ENTRIES: ${{ steps.sync.outputs.inert_entries }}
+          DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
+          CONFLICT_REPORT: ${{ steps.sync.outputs.conflict_report }}
+          PR_BODY_PATH: ${{ runner.temp }}/template-sync-body.md
+        run: bash .github/scripts/template-sync-pr-body.sh
+
       - name: Create Pull Request
         if: inputs.dry-run != true && (steps.sync.outputs.has_changes == 'true' || steps.sync.outputs.has_conflicts == 'true' || steps.sync.outputs.has_deletions == 'true')
         id: create-pr
@@ -233,63 +254,7 @@ jobs:
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN_ORG || secrets.GITHUB_TOKEN }}
           commit-message: "chore: sync from template repository (${{ steps.sync.outputs.template_sha_short }})"
           title: "chore: sync from template repository"
-          body: |
-            This PR syncs updates from the template repository.
-
-            **Template version:** `${{ steps.sync.outputs.template_sha_short }}`
-            **Updated paths:** ${{ steps.sync.outputs.changed_paths }}
-            **Template repository:** ${{ env.TEMPLATE_REPO }}
-
-            ${{ steps.sync.outputs.changelog && format('### Changelog since last sync
-
-            ```
-            {0}
-            ```
-
-            ', steps.sync.outputs.changelog) }}${{ steps.sync.outputs.has_downgrades == 'true' && format('---
-
-            ## ⚠️ Adopter-ahead — review these auto-merges for lost customizations
-
-            A "clean" 3-way auto-merge dropped lines that existed in this repo''s local copy. The sync uses a single repo-wide merge base (`.template-version`), which can be stale for a file first synced at a different template revision — when it is, git reports no conflict while silently shrinking your changes. **Review each file below** and restore anything of yours the merge removed:
-
-            {0}
-
-            ', steps.sync.outputs.downgrade_report) || '' }}${{ steps.sync.outputs.auto_merged_files && format('### Auto-merged files
-
-            The following files were merged automatically (3-way merge, no conflicts):
-
-            `{0}`
-
-            ', steps.sync.outputs.auto_merged_files) || '' }}${{ steps.sync.outputs.declined_files && format('### Declined files (deleted here, not re-added)
-
-            The template still ships these, and this repo deleted them after an earlier sync. The sync left them out. To adopt one, copy it from the template by hand.
-
-            `{0}`
-
-            ', steps.sync.outputs.declined_files) || '' }}${{ steps.sync.outputs.inert_entries && format('### Inert EXCLUDE_PATHS / OPT_IN_PATHS entries
-
-            These entries name nothing in the template, so they cover nothing. Correct the spelling, or delete the entry.
-
-            `{0}`
-
-            ', steps.sync.outputs.inert_entries) || '' }}${{ steps.sync.outputs.has_deletions == 'true' && format('---
-
-            ## Files Removed from Template
-
-            The following files were **deleted in the template** but still exist locally. Consider removing them if they are no longer needed:
-
-            `{0}`
-
-            ', steps.sync.outputs.deleted_files) || '' }}${{ steps.sync.outputs.has_conflicts == 'true' && '---
-
-            ## Conflicts for Claude to Resolve
-
-            The following files need conflict resolution. Claude will resolve these automatically.
-
-            ' || '' }}${{ steps.sync.outputs.conflict_report }}
-
-            ---
-            Please review the changes and merge if appropriate.
+          body-path: ${{ runner.temp }}/template-sync-body.md
           branch: template-sync
           delete-branch: true
           labels: template-sync

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -726,3 +726,77 @@ def test_benign_auto_merge_reports_no_downgrade(workdir: Path) -> None:
     merged = (child / "config" / "a.txt").read_text(encoding="utf-8")
     assert "LOCAL-ADD" in merged and "TEMPLATE-ADD" in merged
     assert outputs["has_downgrades"] == "false"
+
+
+def test_the_changelog_names_only_commits_that_moved_a_file_here(
+    workdir: Path,
+) -> None:
+    """The body's job is to say WHY the tree changed. A raw `git log` of the
+    template cannot: most of its commits touch paths a given adopter never
+    syncs. Each entry here names a commit and the files it moved in THIS repo,
+    and a commit that moved none is counted, not listed."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "synced.txt", "base\n")
+    write(template / "elsewhere" / "ignored.txt", "base\n")
+    prev_sha = commit_all(template)
+    write(child / "config" / "synced.txt", "base\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
+
+    # One commit the adopter feels, one it cannot: `elsewhere` is not synced.
+    write(template / "config" / "synced.txt", "moved\n")
+    subprocess.run(
+        ["git", "commit", "-am", "feat(config): move the synced file"],
+        cwd=template,
+        check=True,
+        env={**os.environ, **GIT_IDENTITY_ENV},
+        capture_output=True,
+    )
+    write(template / "elsewhere" / "ignored.txt", "moved\n")
+    subprocess.run(
+        ["git", "commit", "-am", "chore(elsewhere): move an unsynced file"],
+        cwd=template,
+        check=True,
+        env={**os.environ, **GIT_IDENTITY_ENV},
+        capture_output=True,
+    )
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+    changelog = parse_outputs(output_file)["changelog"]
+
+    assert "feat(config): move the synced file" in changelog
+    assert "- `config/synced.txt`" in changelog
+    # The unsynced commit is accounted for, never listed.
+    assert "chore(elsewhere)" not in changelog
+    assert "1 other template commit(s) in that range touched nothing" in changelog
+
+
+def test_a_file_no_commit_in_range_explains_is_listed_apart(workdir: Path) -> None:
+    """A path synced for the first time has no commit in `PREV_SHA..HEAD` that
+    touched it, and dropping it would make the body read as though nothing else
+    changed."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "old.txt", "base\n")
+    write(template / "config" / "new.txt", "arrives now\n")
+    prev_sha = commit_all(template)
+    write(child / "config" / "old.txt", "base\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
+    write(template / "config" / "old.txt", "moved\n")
+    subprocess.run(
+        ["git", "commit", "-am", "feat(config): move the old file"],
+        cwd=template,
+        check=True,
+        env={**os.environ, **GIT_IDENTITY_ENV},
+        capture_output=True,
+    )
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+    changelog = parse_outputs(output_file)["changelog"]
+
+    assert "no commit in that range" in changelog
+    assert "- `config/new.txt`" in changelog

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -800,3 +800,63 @@ def test_a_file_no_commit_in_range_explains_is_listed_apart(workdir: Path) -> No
 
     assert "no commit in that range" in changelog
     assert "- `config/new.txt`" in changelog
+
+
+def test_bookkeeping_paths_stay_out_of_the_unexplained_list(workdir: Path) -> None:
+    """`.template-version` is rewritten by this script and the template ships
+    none, so no commit can ever explain it; `_template` is the script's own
+    untracked checkout. Both would sit under "no commit in that range" on every
+    single sync, which is the noise the attributed changelog exists to remove."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "a.txt", "base\n")
+    prev_sha = commit_all(template)
+    write(child / "config" / "a.txt", "base\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
+    write(template / "config" / "a.txt", "moved\n")
+    subprocess.run(
+        ["git", "commit", "-am", "feat(config): move the file"],
+        cwd=template,
+        check=True,
+        env={**os.environ, **GIT_IDENTITY_ENV},
+        capture_output=True,
+    )
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+    outputs = parse_outputs(output_file)
+
+    assert ".template-version" not in outputs["changelog"]
+    assert "_template" not in outputs["changelog"]
+    assert outputs["changed_files"].split() == ["config/a.txt"]
+
+
+def test_a_merge_commit_is_not_counted_as_touching_nothing(workdir: Path) -> None:
+    """`git show --name-only` prints no files for a merge, so a merge would land
+    in the "touched nothing this repo syncs" count while being exactly the commit
+    that carried the file. Its branch commits are already in range."""
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "a.txt", "base\n")
+    prev_sha = commit_all(template)
+    write(child / "config" / "a.txt", "base\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
+
+    env = {**os.environ, **GIT_IDENTITY_ENV}
+    run = lambda *a: subprocess.run(  # noqa: E731
+        a, cwd=template, check=True, env=env, capture_output=True
+    )
+    run("git", "switch", "-c", "feature")
+    write(template / "config" / "a.txt", "moved\n")
+    run("git", "commit", "-am", "feat(config): move the file")
+    run("git", "switch", "-")
+    run("git", "merge", "--no-ff", "-m", "Merge pull request #1", "feature")
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+    changelog = parse_outputs(output_file)["changelog"]
+
+    assert "feat(config): move the file" in changelog
+    assert "touched nothing this repo syncs" not in changelog

--- a/tests/test_template_sync_pr_body.py
+++ b/tests/test_template_sync_pr_body.py
@@ -32,13 +32,10 @@ def render(tmp_path: Path, **env: str) -> str:
     return out.read_text(encoding="utf-8")
 
 
-def test_a_newline_separated_file_list_is_counted_and_listed_whole(
-    tmp_path: Path,
-) -> None:
-    """CHANGED_FILES arrives newline-separated while every other list is
-    space-joined. A splitter that reads one line reports `1 file(s)` for a
-    twelve-file sync and silently drops eleven bullets."""
-    body = render(tmp_path, CHANGED_FILES="a.md\nb.md\nc.md")
+def test_a_multi_entry_list_is_counted_and_listed_whole(tmp_path: Path) -> None:
+    """A splitter that reads one entry reports `1 file(s)` for a twelve-file
+    sync and silently drops eleven bullets."""
+    body = render(tmp_path, CHANGED_FILES="a.md b.md c.md")
     assert "Syncs 3 file(s)" in body
     for name in ("a.md", "b.md", "c.md"):
         assert f"- `{name}`" in body
@@ -59,10 +56,32 @@ def test_the_explanation_leads_and_the_noise_is_folded(tmp_path: Path) -> None:
     assert "merged with no conflict" in body
 
 
+def test_each_section_renders_when_its_variable_is_set(tmp_path: Path) -> None:
+    """The absence test below passes just as well if a section can NEVER render,
+    so a typo'd env name would go unnoticed. Pin each one positively."""
+    for var, heading in (
+        ("DOWNGRADE_REPORT", "Adopter-ahead"),
+        ("CONFLICT_REPORT", "Conflicts needing a merge decision"),
+        ("DELETED_FILES", "Deleted in the template"),
+        ("DECLINED_FILES", "Declined"),
+        ("INERT_ENTRIES", "Inert EXCLUDE_PATHS"),
+        ("AUTO_MERGED_FILES", "merged with no conflict"),
+    ):
+        body = render(tmp_path, CHANGED_FILES="a.md", **{var: "z.md"})
+        assert heading in body, var
+        assert "z.md" in body, var
+
+
 def test_a_section_with_nothing_to_say_is_absent(tmp_path: Path) -> None:
     """An empty section costs the reader a scan and says nothing; the old body
     rendered several of them unconditionally."""
     body = render(tmp_path, CHANGED_FILES="a.md")
-    for heading in ("Adopter-ahead", "Declined", "Inert", "Deleted in the template"):
+    for heading in (
+        "Adopter-ahead",
+        "Declined",
+        "Inert",
+        "Deleted in the template",
+        "Conflicts",
+    ):
         assert heading not in body
     assert "None" not in body

--- a/tests/test_template_sync_pr_body.py
+++ b/tests/test_template_sync_pr_body.py
@@ -1,0 +1,68 @@
+"""Tests for .github/scripts/template-sync-pr-body.sh.
+
+The body used to be a nested `format()` chain inside template-sync.yaml, which
+no test could reach. These drive the script and assert on the rendered
+markdown.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+from tests._helpers import REPO_ROOT
+
+SCRIPT = REPO_ROOT / ".github" / "scripts" / "template-sync-pr-body.sh"
+
+
+def render(tmp_path: Path, **env: str) -> str:
+    out = tmp_path / "body.md"
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        env={
+            **os.environ,
+            "TEMPLATE_REPO": "Owner/tmpl",
+            "TEMPLATE_SHA_SHORT": "abc1234",
+            "PR_BODY_PATH": str(out),
+            **env,
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return out.read_text(encoding="utf-8")
+
+
+def test_a_newline_separated_file_list_is_counted_and_listed_whole(
+    tmp_path: Path,
+) -> None:
+    """CHANGED_FILES arrives newline-separated while every other list is
+    space-joined. A splitter that reads one line reports `1 file(s)` for a
+    twelve-file sync and silently drops eleven bullets."""
+    body = render(tmp_path, CHANGED_FILES="a.md\nb.md\nc.md")
+    assert "Syncs 3 file(s)" in body
+    for name in ("a.md", "b.md", "c.md"):
+        assert f"- `{name}`" in body
+
+
+def test_the_explanation_leads_and_the_noise_is_folded(tmp_path: Path) -> None:
+    """Inverted pyramid: why the tree changed, then what needs a human, and the
+    conflict-free merges behind a fold at the end."""
+    body = render(
+        tmp_path,
+        CHANGED_FILES="a.md",
+        CHANGELOG="- `a1b2c3d` feat: a thing\n  - `a.md`",
+        DOWNGRADE_REPORT="- `a.md` lost 3 lines",
+        AUTO_MERGED_FILES="a.md",
+    )
+    assert body.index("What changed, and why") < body.index("Adopter-ahead")
+    assert body.index("Adopter-ahead") < body.index("<details>")
+    assert "merged with no conflict" in body
+
+
+def test_a_section_with_nothing_to_say_is_absent(tmp_path: Path) -> None:
+    """An empty section costs the reader a scan and says nothing; the old body
+    rendered several of them unconditionally."""
+    body = render(tmp_path, CHANGED_FILES="a.md")
+    for heading in ("Adopter-ahead", "Declined", "Inert", "Deleted in the template"):
+        assert heading not in body
+    assert "None" not in body


### PR DESCRIPTION
## What & why

Make the sync PR body explain the sync. It led with every changed path space-joined onto one line, then a raw `git log --oneline` of the whole template — most of whose commits touch paths a given adopter never syncs. Nothing said which commit explains which file.

The changelog is now attributed: each entry names a template commit and the files it moved **in this repo**. A commit that moved nothing here is counted, not listed. A file no commit explains is listed apart, because silence about it reads as "nothing else changed".

Before, for a 12-file sync:

```
**Updated paths:** .hooks/pre-push .github/workflows/lint.yaml CLAUDE.md ...
### Changelog since last sync
a1b2c3d fix(hooks): stop the pre-push hook leaking GIT_DIR
9c8b7a6 docs(readme): fix a typo
... 14 more, most touching nothing this repo syncs
```

After:

```
Syncs 12 file(s) from Owner/tmpl at `abc1234`.

## What changed, and why

- `a1b2c3d` fix(hooks): stop the pre-push hook leaking GIT_DIR
  - `.hooks/pre-push`

14 other template commits in that range touched nothing this repo syncs.
```

The body moves out of the workflow into `.github/scripts/template-sync-pr-body.sh`. It was ~60 lines of nested `format()` expressions — invisible to shellcheck, unreachable by any test. Section order is now what-changed, then what-needs-a-human (adopter-ahead downgrades first, the only one that can lose work silently), then bookkeeping. An empty section is omitted, never rendered.

## Review focus

`emit_attributed_changelog` in `template-sync.sh` must run after the worktree carries the sync and before `rm -rf _template`; the `comm -12` intersection is what drops a commit that touched only unsynced paths.

Least sure: whether an adopter's first sync of a large `SYNC_PATHS` makes the unexplained list long. It is bounded by files-changed-here, not by template activity.

## How it was tested

`uv run --extra dev pytest tests/test_template_sync.py tests/test_template_sync_pr_body.py tests/test_template_sync_dry_run.py tests/test_template_sync_automerge.py -q` — 45 pass, 8 new.

<details>

Every new guard was run against the unfixed code first: dropping `--no-merges` reddens only `test_a_merge_commit_is_not_counted_as_touching_nothing`; removing the `sed` reddens only `test_bookkeeping_paths_stay_out_of_the_unexplained_list`.

`uvx pre-commit run` passes for `shellcheck`, `shfmt`, `actionlint`, `check-tier1`, `check-tier2` and `check-extras` on the touched files.

Review round (678e082) fixed two counts that were wrong on every real sync, plus three more findings:

- `.template-version` is rewritten above the scan and the template ships none; `_template` is the script's own untracked checkout that `--others` reports. Both landed under "no commit in that range" every run and inflated the file count. A `sed` drops them — not `grep -v`, whose exit 1 on an all-filtered list would kill the run under `set -e`.
- `git show --name-only` prints nothing for a merge, so every merged template PR counted as "touched nothing" while being the commit that carried the files.
- The conflicts heading claimed a resolution the resolver had not yet produced — it runs after the body is written and nothing rewrites it.
- `changed_files` is space-joined like every other list output, removing a round-trip in the body script.
- The renderer runs a `BASE_SHA` copy, as the marker gate does: `.github/scripts` is in `SYNC_PATHS`, so a sync can leave markers in this very script and bash would die before a PR exists to show them.

</details>

## Decisions made

**`changed_paths` is unchanged.** `template-sync-automerge.sh` reads it, so `changed_files` is an additional output rather than a change to that one. Repointing the automerge script would widen a body-rendering change into the auto-merge predicate.

**The `SC2016` opt-out is file-level.** The output is markdown, so a backtick in a single-quoted `printf` format is a code span; eight per-line disables read worse than one at the top.