### PR TITLE
chore(plugins): enable precis, codex and tldr at project scope

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,5 +79,30 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "precis@precis": true,
+    "codex@codex-plugin-cc": true,
+    "tldr@alignment-hive": true
+  },
+  "extraKnownMarketplaces": {
+    "precis": {
+      "source": {
+        "source": "github",
+        "repo": "Crazytieguy/precis"
+      }
+    },
+    "codex-plugin-cc": {
+      "source": {
+        "source": "github",
+        "repo": "Crazytieguy/codex-plugin-cc"
+      }
+    },
+    "alignment-hive": {
+      "source": {
+        "source": "github",
+        "repo": "Crazytieguy/alignment-hive"
+      }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ These run inside Claude Code sessions (local CLI or cloud), not in CI.
 | --------------- | ------------------------------------------------------------------------------------ |
 | `code-reviewer` | Read-only reviewer (Read/Grep/Glob, `model: opus`)—unbiased second opinion on a diff |
 
+### Plugins (`.claude/settings.json`)
+
+Enabled at project scope, so every session in this repo loads them—local and cloud alike. Each downloads what it needs on its own and fails open when it cannot.
+
+| Plugin                  | What it does                                                                         | Needs                                       |
+| ----------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------- |
+| `precis@precis`         | Injects a structural codebase overview at session start; `precis <dir>` zooms in     | Downloads its own binary                    |
+| `codex@codex-plugin-cc` | Delegates code review and tasks to Codex, so a non-Claude model reviews the diff     | `node`, plus `/codex:setup` for OpenAI auth |
+| `tldr@alignment-hive`   | Adds a one-sentence TL;DR after a reply over ~100 words; `/focus` collapses to those | Nothing                                     |
+
 ### GitHub Actions (`.github/workflows/`)
 
 | Workflow                           | What it does                                                                                                                                                                                                          |


### PR DESCRIPTION
## What & why

Enable three Claude Code plugins in `.claude/settings.json`, and document them in the README. `precis` injects a structural codebase overview at session start. `codex` delegates review to a non-Claude model, which is what `peer-review` asks for. `tldr` follows a long reply with one sentence.

Project scope is the only durable one here: a cloud session gets a fresh container, so a user-scope install is gone by the next session. Enabling them writes two blocks:

```json
"enabledPlugins": { "precis@precis": true, "codex@codex-plugin-cc": true, "tldr@alignment-hive": true },
"extraKnownMarketplaces": { "precis": { "source": { "source": "github", "repo": "Crazytieguy/precis" } } }
```

The three came out of an evaluation of `Crazytieguy/alignment-hive` against this repo's goals. The rest of that marketplace is skipped: `hive` writes `.claude/hive/` state that `template-sync` would carry downstream, `model-router` is experimental, and `remote-kernels`, `mats`, `autopilot`, `github-action` and `hive-mind` are off-goal or deprecated upstream.

## Review focus

`.claude/settings.json` — this is a template repo, so both new blocks reach every downstream repo through `template-sync`. Read the two entries as a supply-chain question: three third-party marketplaces now load in every session in any repo made from this one.

## How it was tested

`bash .github/scripts/validate-config.sh` passes. `claude plugin list` reports all three enabled at project scope. The plugins loaded on the next session start: the `codex:setup`, `codex:codex-prompting` and `codex:hook-setup` skills appear in the skill list, and `tldr`'s Stop hook now asks for a TL;DR.

## Decisions made

- **No `autoUpdate` on the marketplaces.** The alignment-hive convention is to enable it. Pinning matches this repo's SHA-pinning doctrine instead; the install records a `gitCommitSha` per plugin. The cost: an update needs `claude plugin update` per plugin.
- **`tldr` ships despite duplicating a chat rule.** `CLAUDE.md` already caps a chat reply at 1–3 sentences, so its Stop hook is a second belt. It stays because `/focus` needs it to collapse a turn.
- **`codex` ships without OpenAI credentials in cloud sessions.** Its session-start hook fails open with a `/codex:setup` notice, so the reviews run locally and no-op in the cloud until authenticated.

Two notes below the fold. `precis` also registers a `PermissionRequest` hook that auto-approves a `Bash` call whose command is exactly `precis` with at most one path argument inside the cwd; anything else falls through to the normal prompt.

The push needed a local workaround, unrelated to the diff: the `lychee` pre-commit hook installs its binary with `cargo-binstall`, which needs `api.github.com/graphql`. The proxy denies that host with 403, and the fallback to `cargo install` fails on `--install-path`. Installing the 0.24.2 release binary at the hook's own cached path hits its fast path. That is a blocked host, not a repo defect, so nothing here changes.