### PR TITLE
feat(hooks): add the bullshit check and the completion check

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -13,6 +13,8 @@ This directory contains configuration and skills for Claude Code.
 │   ├── session-setup.sh          # Runs on session start (installs tools, configures git)
 │   ├── pre-push-check.sh         # Runs before git push / gh pr (build, lint, typecheck)
 │   ├── parallelism-nudge.mjs     # PostToolUse: nudges once per turn on a long serial streak
+│   ├── bullshit-check.mjs        # PostToolUse + UserPromptSubmit: one self-audit question per window
+│   ├── completion-check.mjs      # Stop: after a push, asks once whether ALL the work is done
 │   ├── drop-superseded-ci-events.mjs  # UserPromptSubmit: drops non-actionable PR webhook turns
 │   ├── lib-checks.sh             # Shared bash helpers (exists, has_script)
 │   ├── lib-hook-io.mjs           # Shared JS hook I/O (isMain, bounded stdin read, JSON parse)
@@ -59,11 +61,23 @@ After each tool call, `parallelism-nudge.mjs` measures from the session transcri
 
 **Posture: advisory.** It never blocks (`additionalContext` only), fails open on any internal error, and nudges at most once per user-turn segment, so a long turn is not re-narrated on every call.
 
+`bullshit-check.mjs` also runs here, and on `UserPromptSubmit`. Once per twelve-minute window, at a moment hashed from the session id, it drops one of two short self-audit questions into the agent's context: the evidence check ("name the command whose output backs the claim you are about to make") or "are you taking the principled solution?". Both events already run the agent, so an idle session is never woken; a window missed while idle is carried to the next tool call, never to a prompt, so the question lands after work exists to audit. State lives under `$TMPDIR/claude-bullshit-check/` (`BULLSHIT_CHECK_STATE_DIR` overrides it).
+
+**Posture: advisory.** `additionalContext` only, one question per window across both events, and every fault exits silently.
+
 ### UserPromptSubmit Hook
 
 `drop-superseded-ci-events.mjs` drops non-actionable PR webhook turns before the model runs. A session subscribed to a PR is woken for every check run and bot comment; two classes carry nothing to act on—a CI-failure event whose head SHA a newer push already superseded, and a `github-actions[bot]` alert carrying the `[ignore-notif]` opt-out marker. The bot-author check reads only the trusted header preceding the first `<untrusted_external_data>` tag, so a forged author line inside an untrusted comment body cannot drive suppression.
 
 **Posture: fail open.** It is a noise filter, not a defense—any uncertainty passes the turn through untouched.
+
+`bullshit-check.mjs` runs on this event too; see the PostToolUse section above.
+
+### Stop Hook
+
+`completion-check.mjs` asks once, after the session has pushed, whether ALL the requested work is finished, and blocks the stop until the agent answers `Yes.` as its last line or `**Resuming work**` as its first. The push is recorded on `PreToolUse` under the same `Bash(git push:*)` matcher `pre-push-check.sh` uses, so no shell text is parsed. The check arms at a moment drawn from the five minutes after the first push, or at one of the first three stops that did real work, and a session that never pushes is never asked.
+
+**Posture: blocking, bounded, fail open.** It asks at most three times (`COMPLETION_CHECK_MAX`, a positive integer), then allows the stop; a turn with nothing to certify is allowed without spending the one shot; a malformed event or an unwritable state directory allows the stop; and `COMPLETION_CHECK=0` disables it. State lives under `$TMPDIR/claude-completion-check/` (`COMPLETION_CHECK_STATE_DIR` overrides it).
 
 ### Skills
 

--- a/.claude/hooks/bullshit-check.mjs
+++ b/.claude/hooks/bullshit-check.mjs
@@ -26,6 +26,7 @@ import {
   readdirSync,
   readFileSync,
   renameSync,
+  rmSync,
   unlinkSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -213,11 +214,8 @@ function publishState(path, record) {
     renameSync(tmp, path);
     return true;
   } catch {
-    try {
-      unlinkSync(tmp);
-    } catch {
-      // The rename failed with the temp file already gone; nothing to remove.
-    }
+    // A directory planted at the path refuses the rename; leave no temp behind.
+    rmSync(tmp, { force: true });
     return false;
   }
 }
@@ -231,19 +229,10 @@ function publishState(path, record) {
 function dropStaleClaims(path) {
   const dir = dirname(path);
   const prefix = `${basename(path)}.`;
-  let entries;
-  try {
-    entries = readdirSync(dir);
-  } catch {
-    return;
-  }
-  for (const entry of entries)
+  // `force` ignores a claim another process removed first.
+  for (const entry of readdirSync(dir))
     if (entry.startsWith(prefix) && !entry.endsWith(".tmp"))
-      try {
-        unlinkSync(join(dir, entry));
-      } catch {
-        // Another process removed it first, or it is not ours to remove.
-      }
+      rmSync(join(dir, entry), { force: true });
 }
 
 /**

--- a/.claude/hooks/bullshit-check.mjs
+++ b/.claude/hooks/bullshit-check.mjs
@@ -3,7 +3,7 @@
  * Once per segment, at a moment chosen at random inside that segment, ask the
  * agent one of the {@link PROMPTS} questions about the work it is doing. Which
  * question it gets is drawn from the same hash as the moment, so a session meets
- * each of them over a run and can predict neither.
+ * each of them over a run, and every hook process agrees with no shared state.
  *
  * Segments are measured from the session's OWN first event, not from the epoch,
  * so every session's first moment is ahead of it. An epoch-aligned grid
@@ -112,8 +112,8 @@ export function segmentOf(now, start, segmentMs = SEGMENT_MS) {
  * @param {number} [segmentMs]
  * @returns {number} how far into `segment` this session's check falls, in milliseconds.
  *   Derived from a hash rather than drawn and stored, so every hook process in the
- *   segment computes the same moment with no shared state, and the moment is
- *   unpredictable before the segment starts.
+ *   segment computes the same moment with no shared state. The hash is public, so
+ *   this spreads the moments; it hides nothing from an agent that reads this file.
  */
 export function offsetMs(sessionId, segment, segmentMs = SEGMENT_MS) {
   return digestOf(sessionId, segment).readUInt32BE(0) % segmentMs;

--- a/.claude/hooks/bullshit-check.mjs
+++ b/.claude/hooks/bullshit-check.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+/**
+ * Once per segment, at a moment chosen at random inside that segment, ask the
+ * agent one of the {@link PROMPTS} questions about the work it is doing. Which
+ * question it gets is drawn from the same hash as the moment, so a session meets
+ * each of them over a run and can predict neither.
+ *
+ * Segments are measured from the session's OWN first event, not from the epoch,
+ * so every session's first moment is ahead of it. An epoch-aligned grid
+ * instead drops the first segment for every session that starts after its
+ * moment, which is half of them.
+ *
+ * The check rides an event the agent is ALREADY running under — its own tool
+ * call, or a prompt the user just sent — rather than a timer, so an idle session
+ * is never woken: no event, no question. A segment whose moment passed while the
+ * agent sat idle is carried to its next event, so a session that works in bursts
+ * is asked at the same rate as one working straight through. Only the main
+ * thread is asked. Advisory: every fault exits silently. Dependency-free on
+ * purpose: the template ships no node_modules, so this runs on a bare `node`.
+ */
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+
+import { isMain, readStdinJson, writeFileNoFollow } from "./lib-hook-io.mjs";
+
+/** The window each check falls in. One check per window, wherever in it the draw lands. */
+export const SEGMENT_MS = 12 * 60 * 1000;
+
+/** A session id is a path segment here, so it is validated rather than rewritten. */
+const SAFE_SESSION_RE = /^[\w-]+$/;
+
+/**
+ * The questions. Each line asks for an ARTIFACT — a command, a file, a failure —
+ * rather than for a re-reading of the agent's own reasoning, which buys tokens
+ * and no evidence. A clean answer costs one line; a dirty one names the fix.
+ *
+ * Each opens `**Bullshit check`, the prefix the wiring tests match, and they ask
+ * about different failures: one about a claim that outruns its evidence, one
+ * about a fix that treats the symptom.
+ */
+export const PROMPTS = Object.freeze([
+  `<!-- periodic bullshit check -->
+**Bullshit check.** Answer from artifacts, not from memory:
+- Name the command whose output backs the claim you are about to make. No command? Say the claim is unverified, or run one now.
+- Name the file or line that shows the work still matches the request.
+- List any failure you got past without fixing — a skipped test, a waived check, a re-run over a red — and fix it or say why not.
+Nothing to report? One sentence, then carry on.`,
+  `<!-- periodic bullshit check -->
+**Bullshit check — are you taking the principled solution?** The principled fix removes the cause; the other kind hides the symptom. Answer about the fix you are shipping, not the one you meant to ship:
+- Name the root cause, and the line that shows this change removes it rather than the symptom you saw.
+- Name what you took the shortcut on — a special case, a retry, a widened exception, a narrowed assertion, a number you guessed instead of deriving — and either take the principled fix now or say what forbids it.
+- Name the search (a grep, a test run) that found the other sites that break the same way. Fix them, or say which ones you left and why.
+Already principled? One sentence, then carry on.`,
+]);
+
+/**
+ * @param {string} sessionId
+ * @param {number} segment
+ * @returns {string} the question this session gets for this segment. Drawn from the
+ *   same digest as {@link offsetMs} but a different word of it, so the question and
+ *   the moment vary independently and every process in the segment picks the same
+ *   one with no shared state.
+ */
+export function promptFor(sessionId, segment) {
+  return PROMPTS[digestOf(sessionId, segment).readUInt32BE(4) % PROMPTS.length];
+}
+
+/**
+ * This session's state file, or null when the session id is not already a safe
+ * filename. Refusing beats rewriting: a rewrite is many-to-one, so two sessions
+ * could share one file and one session's check would suppress the other's.
+ * @param {unknown} sessionId
+ * @param {string} [dir]
+ * @returns {string|null}
+ */
+export function statePath(
+  sessionId,
+  dir = process.env.BULLSHIT_CHECK_STATE_DIR ||
+    join(tmpdir(), "claude-bullshit-check"),
+) {
+  if (typeof sessionId !== "string" || !SAFE_SESSION_RE.test(sessionId))
+    return null;
+  return join(dir, `${sessionId}.segment`);
+}
+
+/**
+ * @param {number} now epoch milliseconds
+ * @param {number} start epoch milliseconds of this session's first event
+ * @param {number} [segmentMs]
+ * @returns {number} the index of the segment `now` falls in, counting from `start`.
+ *   Segment 0 therefore opens at the session's first event, which is what keeps
+ *   its moment ahead of the session rather than possibly behind it.
+ */
+export function segmentOf(now, start, segmentMs = SEGMENT_MS) {
+  return Math.floor((now - start) / segmentMs);
+}
+
+/**
+ * @param {string} sessionId
+ * @param {number} segment
+ * @param {number} [segmentMs]
+ * @returns {number} how far into `segment` this session's check falls, in milliseconds.
+ *   Derived from a hash rather than drawn and stored, so every hook process in the
+ *   segment computes the same moment with no shared state, and the moment is
+ *   unpredictable before the segment starts.
+ */
+export function offsetMs(sessionId, segment, segmentMs = SEGMENT_MS) {
+  return digestOf(sessionId, segment).readUInt32BE(0) % segmentMs;
+}
+
+/**
+ * @param {string} sessionId
+ * @param {number} segment
+ * @returns {Buffer} the bytes both draws read. One definition, so the moment and the
+ *   question can never be derived from two different hashes of the same pair.
+ */
+function digestOf(sessionId, segment) {
+  return createHash("sha256").update(`${sessionId}:${segment}`).digest();
+}
+
+/**
+ * @typedef {object} SessionState
+ * @property {number} start epoch milliseconds of this session's first event
+ * @property {number} last  the last segment resolved, or -1 when none is yet
+ */
+
+/**
+ * @param {string} path
+ * @returns {SessionState|null} the state recorded at `path`, or null when the file is
+ *   absent, unreadable, or holds anything but the two integers {@link runCheck}
+ *   writes. A record left by an earlier format reads as null, so the session
+ *   re-anchors rather than computing segments from a number that meant something
+ *   else.
+ */
+export function readState(path) {
+  try {
+    const fields = readFileSync(path, "utf8").trim().split(" ");
+    if (fields.length !== 2) return null;
+    const [start, last] = fields.map(Number);
+    // Number("") is 0, so a blank field would anchor the session at the epoch and
+    // put every segment boundary decades behind it.
+    if (!Number.isSafeInteger(start) || !Number.isSafeInteger(last))
+      return null;
+    return start > 0 && last >= -1 ? { start, last } : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether this event carries the segment's check, and what to record. `last` is
+ * the newest segment this session SPENT a check on, so each segment is asked once,
+ * on the first event at or after its moment. A session that spent no check in the
+ * segment BEFORE this one is overdue and is asked at once — an unattended agent
+ * works in short bursts, and a moment that keeps landing between them would cost
+ * most of the checks. With no state the session anchors here and asks nothing.
+ * @param {object} args
+ * @param {string} args.sessionId
+ * @param {number} args.now
+ * @param {SessionState|null} args.state  what the state file holds
+ * @param {number} [args.segmentMs]
+ * @param {boolean} [args.carryOverdue] whether an overdue check may ride this event.
+ *   Only a tool call carries one: a session woken by prompts every few minutes is
+ *   overdue at every wake, and the question would land before any work exists.
+ * @returns {{fire: boolean, record: SessionState|null}}
+ */
+export function decide({
+  sessionId,
+  now,
+  state,
+  segmentMs = SEGMENT_MS,
+  carryOverdue = true,
+}) {
+  // A clock that moved backwards past the anchor would put the session in a
+  // negative segment, whose moment is behind it — so re-anchor instead.
+  if (state === null || now < state.start)
+    return { fire: false, record: { start: now, last: -1 } };
+  const { start, last } = state;
+  const segment = segmentOf(now, start, segmentMs);
+  if (last >= segment) return { fire: false, record: null };
+  const due =
+    start + segment * segmentMs + offsetMs(sessionId, segment, segmentMs);
+  if (now < due && (last >= segment - 1 || !carryOverdue))
+    return { fire: false, record: null };
+  return { fire: true, record: { start, last: segment } };
+}
+
+/**
+ * Whether `record` reached `path`. The record is written to a sibling temp file and
+ * renamed over the path, so a concurrent reader sees the old record or the new one
+ * and never an absent file — an absence reads as a fresh session and re-anchors it,
+ * which drops the segment's question and leaves its claim file behind.
+ * @param {string} path
+ * @param {SessionState} record
+ * @returns {boolean}
+ */
+function publishState(path, record) {
+  const tmp = `${path}.${process.pid}.tmp`;
+  // writeFileNoFollow because this predictable $TMPDIR path is one a co-tenant
+  // could pre-plant a symlink at.
+  if (!writeFileNoFollow(tmp, `${record.start} ${record.last}`)) return false;
+  try {
+    renameSync(tmp, path);
+    return true;
+  } catch {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // The rename failed with the temp file already gone; nothing to remove.
+    }
+    return false;
+  }
+}
+
+/**
+ * Remove every claim file this session left under an earlier anchor. A re-anchored
+ * session counts segments from a new start, so a stale `path.0` would refuse the new
+ * segment 0's claim and drop its question after the record already marked it spent.
+ * @param {string} path the state file's path
+ */
+function dropStaleClaims(path) {
+  const dir = dirname(path);
+  const prefix = `${basename(path)}.`;
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries)
+    if (entry.startsWith(prefix) && !entry.endsWith(".tmp"))
+      try {
+        unlinkSync(join(dir, entry));
+      } catch {
+        // Another process removed it first, or it is not ours to remove.
+      }
+}
+
+/**
+ * Whether THIS process is the one that asks for `segment`. Two tool calls that finish
+ * together read the same record, so both decide to fire and the segment's one question
+ * would be asked twice. An exclusive create is the single step only one of them can
+ * win, so it — not the read-decide-write above — is what bounds the segment to one
+ * asking. The claim it replaces goes with it, so a session keeps at most two.
+ * @param {string} path the state file's path
+ * @param {number} segment
+ * @param {number} spent the segment this session last spent a check on, or -1 when
+ *   it has spent none. It names the one claim file on disk, where `segment - 1`
+ *   would name the wrong one whenever the session idled through a segment, leaking
+ *   a claim per gap.
+ * @returns {boolean}
+ */
+function claimSegment(path, segment, spent) {
+  try {
+    closeSync(openSync(`${path}.${segment}`, "wx", 0o600));
+  } catch {
+    return false;
+  }
+  try {
+    unlinkSync(`${path}.${spent}`);
+  } catch {
+    // No claim from that segment, or none spent yet, so nothing to clean up.
+  }
+  return true;
+}
+
+/**
+ * The events a question may ride. Both run the agent anyway — it just finished a
+ * tool call, or the user just sent a prompt — so neither wakes an idle session.
+ */
+const CARRYING_EVENTS = Object.freeze(["PostToolUse", "UserPromptSubmit"]);
+
+/**
+ * @typedef {{hook_event_name?: unknown, session_id?: unknown,
+ *   agent_id?: unknown}} HookPayload
+ */
+
+/**
+ * @param {HookPayload|undefined} payload
+ * @returns {string|null} the event this question
+ *   would ride, or null when the payload carries none. A payload that NAMES no event
+ *   answers null too: the response has to be stamped with the event Claude Code
+ *   fired, and a guess that lands on the wrong one spends the segment on a body
+ *   Claude Code then drops.
+ */
+export function carryingEvent(payload) {
+  return (
+    CARRYING_EVENTS.find((event) => event === payload?.hook_event_name) ?? null
+  );
+}
+
+/**
+ * @param {HookPayload|undefined} payload
+ * @param {number} now
+ * @returns {string|null} the question to ask, or null when this call carries none,
+ *   after recording the anchor and the segment it resolved. The record is written
+ *   BEFORE the question is emitted and the question is dropped when the write fails:
+ *   a check that cannot record itself would repeat on every later event in the
+ *   segment.
+ */
+export function runCheck(payload, now) {
+  const event = carryingEvent(payload);
+  if (event === null) return null;
+  // A subagent's tool call fires this hook too, under the parent's session id and
+  // its own agent_id. Answering there costs the segment's check and the reply
+  // lands in a context that ends with the subagent.
+  if (payload?.agent_id !== undefined) return null;
+  const sessionId = payload?.session_id;
+  const path = statePath(sessionId);
+  if (path === null) return null;
+  const state = readState(path);
+  const { fire, record } = decide({
+    // statePath returned a path, so the id passed its string test.
+    sessionId: /** @type {string} */ (sessionId),
+    now,
+    state,
+    carryOverdue: event === "PostToolUse",
+  });
+  if (record === null) return null;
+  try {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  } catch {
+    return null;
+  }
+  if (record.last === -1) dropStaleClaims(path);
+  if (!publishState(path, record)) return null;
+  if (!fire) return null;
+  // decide only fires on a state it read, so this is the record's own `last`.
+  const claimed = claimSegment(
+    path,
+    record.last,
+    /** @type {SessionState} */ (state).last,
+  );
+  return claimed
+    ? promptFor(/** @type {string} */ (sessionId), record.last)
+    : null;
+}
+
+if (isMain(import.meta.url)) {
+  try {
+    const raw = await readStdinJson();
+    const payload =
+      typeof raw === "object" && raw !== null
+        ? /** @type {HookPayload} */ (raw)
+        : undefined;
+    const prompt = runCheck(payload, Date.now());
+    // carryingEvent answered non-null for any payload that produced a question,
+    // and Claude Code ignores a body stamped with an event other than the one it
+    // fired.
+    if (prompt !== null)
+      process.stdout.write(
+        JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: carryingEvent(payload),
+            additionalContext: prompt,
+          },
+        }),
+      );
+  } catch {
+    // Advisory only: a malformed payload or an unwritable state directory costs
+    // one check, never the tool call.
+  }
+}

--- a/.claude/hooks/bullshit-check.mjs
+++ b/.claude/hooks/bullshit-check.mjs
@@ -32,13 +32,15 @@ import {
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
-import { isMain, readStdinJson, writeFileNoFollow } from "./lib-hook-io.mjs";
+import {
+  isMain,
+  readStdinJson,
+  sessionStatePath,
+  writeFileNoFollow,
+} from "./lib-hook-io.mjs";
 
 /** The window each check falls in. One check per window, wherever in it the draw lands. */
 export const SEGMENT_MS = 12 * 60 * 1000;
-
-/** A session id is a path segment here, so it is validated rather than rewritten. */
-const SAFE_SESSION_RE = /^[\w-]+$/;
 
 /**
  * The questions. Each line asks for an ARTIFACT — a command, a file, a failure —
@@ -77,9 +79,7 @@ export function promptFor(sessionId, segment) {
 }
 
 /**
- * This session's state file, or null when the session id is not already a safe
- * filename. Refusing beats rewriting: a rewrite is many-to-one, so two sessions
- * could share one file and one session's check would suppress the other's.
+ * This session's state file, or null when the session id is not a safe filename.
  * @param {unknown} sessionId
  * @param {string} [dir]
  * @returns {string|null}
@@ -89,9 +89,7 @@ export function statePath(
   dir = process.env.BULLSHIT_CHECK_STATE_DIR ||
     join(tmpdir(), "claude-bullshit-check"),
 ) {
-  if (typeof sessionId !== "string" || !SAFE_SESSION_RE.test(sessionId))
-    return null;
-  return join(dir, `${sessionId}.segment`);
+  return sessionStatePath(sessionId, dir, ".segment");
 }
 
 /**

--- a/.claude/hooks/completion-check.mjs
+++ b/.claude/hooks/completion-check.mjs
@@ -22,7 +22,12 @@ import { mkdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { isMain, readStdinJson, writeFileNoFollow } from "./lib-hook-io.mjs";
+import {
+  isMain,
+  readStdinJson,
+  readTranscriptTail,
+  writeFileNoFollow,
+} from "./lib-hook-io.mjs";
 
 /** The answer that ends the check. */
 export const AFFIRMATION = "Yes.";
@@ -114,8 +119,8 @@ function toolResultText(part) {
  * and stopped at the user prompt that opened it: the last assistant text ("" when
  * the turn produced none) and whether the turn called a tool worth certifying. A
  * tool result is itself a user-role entry, so only an entry with no `tool_result`
- * part counts as the prompt that opened the turn. Unparsable lines are skipped: a
- * line this hook cannot read is not a reason to hold the session open.
+ * part counts as the prompt that opened the turn. Subagent (sidechain) lines and
+ * unparsable lines are skipped: neither is a reason to hold the session open.
  * @param {string} transcript raw JSONL
  * @returns {{reply: string, usedTools: boolean}}
  */
@@ -126,12 +131,16 @@ export function readTurn(transcript) {
   /** @type {Map<unknown, string>} */
   const toolResults = new Map();
   for (const line of transcript.split("\n").reverse()) {
-    let message;
+    let entry;
     try {
-      message = JSON.parse(line)?.message;
+      entry = JSON.parse(line);
     } catch {
       continue;
     }
+    // A subagent's lines carry the parent's session and would read as the main
+    // thread's turn boundary, tool calls and reply.
+    if (entry?.isSidechain === true) continue;
+    const message = entry?.message;
     const parts = /** @type {TranscriptPart[]} */ (
       Array.isArray(message?.content) ? message.content : []
     );
@@ -265,9 +274,11 @@ export function run(payload, options = {}) {
   const path = statePath(payload?.session_id, dir);
   const transcript = payload?.transcript_path;
   if (path === null || typeof transcript !== "string") return null;
+  const envMax = Number(process.env.COMPLETION_CHECK_MAX);
+  // Only a finite positive integer bounds the pings; `Infinity` would never end them.
   const max =
     options.maxPings ??
-    (Number(process.env.COMPLETION_CHECK_MAX) || DEFAULT_MAX_PINGS);
+    (Number.isInteger(envMax) && envMax > 0 ? envMax : DEFAULT_MAX_PINGS);
   const now = options.now ?? Date.now;
   const random = options.random ?? Math.random;
 
@@ -282,22 +293,27 @@ export function run(payload, options = {}) {
       : state.stopsLeft;
   const armed = { ...state, deadlineMs, stopsLeft };
 
-  const { reply, usedTools } = readTurn(readFileSync(transcript, "utf8"));
-  // Nothing to certify neither counts toward the arming stop nor spends the one
-  // shot: the question is still owed on the next turn that does work.
-  if (!usedTools || reply === "") {
-    save(path, armed);
-    return null;
-  }
-  if (now() < deadlineMs && stopsLeft > 1) {
-    save(path, { ...armed, stopsLeft: stopsLeft - 1 });
+  const { reply, usedTools } = readTurn(readTranscriptTail(transcript));
+  if (state.pings === 0) {
+    // Nothing to certify neither counts toward the arming stop nor spends the one
+    // shot: the question is still owed on the next turn that does work.
+    if (!usedTools || reply === "") {
+      save(path, armed);
+      return null;
+    }
+    if (now() < deadlineMs && stopsLeft > 1) {
+      save(path, { ...armed, stopsLeft: stopsLeft - 1 });
+      return null;
+    }
+  } else if (isAffirmative(reply)) {
+    // A question is outstanding, so the reply answers IT — with or without a tool
+    // call. Before the first ping the reply answers the USER, so a turn that merely
+    // ends in "Yes." must not spend the one shot on a question never asked.
+    save(path, { ...armed, done: true });
     return null;
   }
   const ping = state.pings + 1;
-  // The affirmation ends the check only while the question is outstanding. Before
-  // the first ping the reply answers the USER, so a turn that merely ends in "Yes."
-  // would otherwise spend the one shot on a question this check never asked.
-  if ((state.pings > 0 && isAffirmative(reply)) || ping > max) {
+  if (ping > max) {
     save(path, { ...armed, done: true });
     return null;
   }

--- a/.claude/hooks/completion-check.mjs
+++ b/.claude/hooks/completion-check.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/**
+ * Stop: once this session has pushed, ask ONCE whether ALL the requested work is
+ * finished, and block the stop until it answers. The check ARMS on whichever comes
+ * first: a moment drawn uniformly from the window after the first push, or the
+ * k-th stop that has something to certify after that push, k drawn uniformly from
+ * 1 to ARMING_STOPS_MAX. Neither is predictable, and the stop count reaches a
+ * session that pushes and quits inside the window. Before arming, and in a session
+ * that never pushes, the stop is allowed silently.
+ *
+ * The push is RECORDED, never parsed: `.claude/settings.json` runs this file with
+ * `--record-push` on PreToolUse under the `Bash(git push:*)` matcher, the same
+ * matcher pre-push-check.sh trusts, so Claude Code decides what a push is and no
+ * shell text is read here. The pings are bounded (default 3, `COMPLETION_CHECK_MAX`)
+ * and the check is one-shot, so a session can never be trapped; `COMPLETION_CHECK=0`
+ * disables it. An armed stop with nothing to certify — a turn that called no tool,
+ * or whose only tool calls were empty `ReadNotifications` polls — is allowed WITHOUT
+ * spending the one shot. Advisory posture: malformed events and state failures allow
+ * the stop. Dependency-free on purpose: the template ships no node_modules.
+ */
+import { mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { isMain, readStdinJson, writeFileNoFollow } from "./lib-hook-io.mjs";
+
+/** The answer that ends the check. */
+export const AFFIRMATION = "Yes.";
+
+/**
+ * What the agent leads with instead when work remains, so the operator can count
+ * how often this check caught real unfinished work. Count only assistant replies
+ * whose FIRST line is the marker: the literal also sits in this file, in its test,
+ * and inside the question text itself.
+ */
+export const RESUMPTION = "**Resuming work**";
+
+/** Times the question is asked before the stop is allowed. */
+export const DEFAULT_MAX_PINGS = 3;
+
+/** Width of the window after the first push that the arming moment is drawn from. */
+export const PUSH_WINDOW_MS = 5 * 60 * 1000;
+
+/** Largest k the arming stop count is drawn from, so the check arms within k stops. */
+export const ARMING_STOPS_MAX = 3;
+
+/**
+ * Whether this reply answers the question. The answer must be the LAST non-empty
+ * line, so the word inside a report ("Yes. the tests pass, but …") does not end the
+ * check. Emphasis, backticks, case and the period are all ignored, so a cosmetic
+ * difference cannot trap a session that did answer.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function isAffirmative(text) {
+  const lines = text.split("\n").filter((line) => line.trim() !== "");
+  const normalize = (/** @type {string} */ value) =>
+    value.replace(/[`*_\s.]/g, "").toLowerCase();
+  return normalize(lines.at(-1) ?? "") === normalize(AFFIRMATION);
+}
+
+/**
+ * The question fed back to the agent when the stop is blocked.
+ * @param {number} ping 1-based number of this ping
+ * @param {number} max total pings allowed
+ * @returns {string}
+ */
+export function question(ping, max) {
+  return (
+    `Completion check ${ping} of ${max}. Are you done with ALL work?\n\n` +
+    "Re-read the original request and check every part of it, including any " +
+    "work you named but left undone, and any fix your own diagnosis implies " +
+    `(CLAUDE.md → Autonomy). If work remains, reply \`${RESUMPTION}\` as your ` +
+    "first line and do it now — do not ask me anything and do not report back " +
+    "until it is done.\n\n" +
+    `If, and only if, everything is complete, reply with exactly \`${AFFIRMATION}\` ` +
+    "as the last line of your reply. That ends this check. Do not answer " +
+    `\`${AFFIRMATION}\` while work remains.`
+  );
+}
+
+/**
+ * @typedef {{type?: unknown, text?: unknown, id?: unknown, name?: unknown,
+ *   tool_use_id?: unknown, content?: unknown}} TranscriptPart
+ */
+
+/** The exact empty-poll result text `ReadNotifications` returns. */
+const EMPTY_POLL_RESULT = "No queued notifications.";
+
+/** The tool whose empty result carries no signal — see the header comment. */
+const EMPTY_POLL_TOOL = "ReadNotifications";
+
+const isToolResult = (/** @type {TranscriptPart} */ part) =>
+  part?.type === "tool_result";
+
+/**
+ * Text of a tool_result part, whether its `content` is a plain string or a block
+ * array.
+ * @param {TranscriptPart} part
+ * @returns {string}
+ */
+function toolResultText(part) {
+  const { content } = part;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content))
+    return content
+      .flatMap((block) => (typeof block?.text === "string" ? [block.text] : []))
+      .join("\n");
+  return "";
+}
+
+/**
+ * The turn that just ended, read backwards from the end of the JSONL transcript
+ * and stopped at the user prompt that opened it: the last assistant text ("" when
+ * the turn produced none) and whether the turn called a tool worth certifying. A
+ * tool result is itself a user-role entry, so only an entry with no `tool_result`
+ * part counts as the prompt that opened the turn. Unparsable lines are skipped: a
+ * line this hook cannot read is not a reason to hold the session open.
+ * @param {string} transcript raw JSONL
+ * @returns {{reply: string, usedTools: boolean}}
+ */
+export function readTurn(transcript) {
+  let reply = null;
+  /** @type {{id: unknown, name: unknown}[]} */
+  const toolUses = [];
+  /** @type {Map<unknown, string>} */
+  const toolResults = new Map();
+  for (const line of transcript.split("\n").reverse()) {
+    let message;
+    try {
+      message = JSON.parse(line)?.message;
+    } catch {
+      continue;
+    }
+    const parts = /** @type {TranscriptPart[]} */ (
+      Array.isArray(message?.content) ? message.content : []
+    );
+    if (message?.role !== "assistant") {
+      if (message?.role !== "user") continue;
+      for (const part of parts)
+        if (isToolResult(part))
+          toolResults.set(part.tool_use_id, toolResultText(part));
+      if (!parts.some(isToolResult)) break;
+      continue;
+    }
+    for (const part of parts)
+      if (part?.type === "tool_use")
+        toolUses.push({ id: part.id, name: part.name });
+    const text = parts
+      .flatMap((part) =>
+        part?.type === "text" && typeof part.text === "string"
+          ? [part.text]
+          : [],
+      )
+      .join("\n")
+      .trim();
+    if (reply === null && text !== "") reply = text;
+  }
+  // Each tool_use is matched to its tool_result by id, because the result text is
+  // what decides an empty poll. A poll that finds something still counts.
+  const usedTools = toolUses.some((use) => {
+    if (use.name !== EMPTY_POLL_TOOL) return true;
+    return toolResults.get(use.id)?.trim() !== EMPTY_POLL_RESULT;
+  });
+  return { reply: reply ?? "", usedTools };
+}
+
+/**
+ * @typedef {{pushedAt: number|null, deadlineMs: number|null,
+ *   stopsLeft: number, pings: number, done: boolean}} CheckState
+ */
+
+/** The state a session starts from: no push yet, so nothing to arm on. */
+const FRESH = Object.freeze({
+  pushedAt: null,
+  deadlineMs: null,
+  stopsLeft: 0,
+  pings: 0,
+  done: false,
+});
+
+/**
+ * This session's state file, or null when the session id is not a safe filename.
+ * @param {unknown} sessionId
+ * @param {string} dir
+ * @returns {string|null}
+ */
+export function statePath(sessionId, dir) {
+  if (typeof sessionId !== "string" || !/^[\w-]+$/.test(sessionId)) return null;
+  return join(dir, `${sessionId}.json`);
+}
+
+/**
+ * The state in `path`, or the fresh state when the file is absent or unreadable —
+ * an absent file is the normal first-event case, and a lost one costs at most a
+ * redrawn arming moment. A number that fails to parse reads as its fresh value, so
+ * a damaged record arms at this stop: arming early is the safe direction for a
+ * check that only asks a question.
+ * @param {string} path
+ * @returns {CheckState}
+ */
+export function readState(path) {
+  let saved;
+  try {
+    saved = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return { ...FRESH };
+  }
+  const number = (/** @type {unknown} */ value) =>
+    typeof value === "number" && Number.isFinite(value) ? value : null;
+  return {
+    pushedAt: number(saved?.pushedAt),
+    deadlineMs: number(saved?.deadlineMs),
+    stopsLeft: number(saved?.stopsLeft) ?? 0,
+    pings: number(saved?.pings) ?? 0,
+    done: saved?.done === true,
+  };
+}
+
+/**
+ * @param {string} path
+ * @param {CheckState} state
+ * @returns {boolean} whether `state` reached `path`. A blocked stop is only safe
+ *   while the count advances, so every caller allows the stop when this fails.
+ */
+function save(path, state) {
+  try {
+    mkdirSync(join(path, ".."), { recursive: true, mode: 0o700 });
+  } catch {
+    return false;
+  }
+  return writeFileNoFollow(path, JSON.stringify(state));
+}
+
+/**
+ * The PreToolUse arm: record when this session first ran a push. The matcher in
+ * settings.json is what decided the command IS a push; this only stamps the time.
+ * Later pushes leave the first stamp alone, so the arming window opens once.
+ * @param {string} path the session's state file
+ * @param {number} now epoch milliseconds
+ * @returns {boolean} whether a first push was recorded by this call
+ */
+export function recordPush(path, now) {
+  const state = readState(path);
+  if (state.pushedAt !== null) return false;
+  return save(path, { ...state, pushedAt: now });
+}
+
+/**
+ * One Stop event: the response that blocks it with the question, or null to allow
+ * it. The arming draw is taken once, from the recorded push, and persists — so a
+ * redraw on every event cannot keep it out of reach. Only an affirmation or a spent
+ * ping budget ends the check; a stop allowed for any other reason leaves it armed.
+ * @param {{session_id?: unknown, transcript_path?: unknown}} payload the Stop payload
+ * @param {{stateDir?: string, maxPings?: number, now?: () => number,
+ *   random?: () => number}} [options] test overrides
+ * @returns {{decision: string, reason: string}|null}
+ */
+export function run(payload, options = {}) {
+  if (process.env.COMPLETION_CHECK === "0") return null;
+  const dir =
+    options.stateDir ??
+    process.env.COMPLETION_CHECK_STATE_DIR ??
+    join(tmpdir(), "claude-completion-check");
+  const path = statePath(payload?.session_id, dir);
+  const transcript = payload?.transcript_path;
+  if (path === null || typeof transcript !== "string") return null;
+  const max =
+    options.maxPings ??
+    (Number(process.env.COMPLETION_CHECK_MAX) || DEFAULT_MAX_PINGS);
+  const now = options.now ?? Date.now;
+  const random = options.random ?? Math.random;
+
+  const state = readState(path);
+  if (state.done || state.pushedAt === null) return null;
+  // The draw is stored on first use, so every later Stop reads the same moment.
+  const deadlineMs =
+    state.deadlineMs ?? state.pushedAt + Math.floor(random() * PUSH_WINDOW_MS);
+  const stopsLeft =
+    state.deadlineMs === null
+      ? 1 + Math.floor(random() * ARMING_STOPS_MAX)
+      : state.stopsLeft;
+  const armed = { ...state, deadlineMs, stopsLeft };
+
+  const { reply, usedTools } = readTurn(readFileSync(transcript, "utf8"));
+  // Nothing to certify neither counts toward the arming stop nor spends the one
+  // shot: the question is still owed on the next turn that does work.
+  if (!usedTools || reply === "") {
+    save(path, armed);
+    return null;
+  }
+  if (now() < deadlineMs && stopsLeft > 1) {
+    save(path, { ...armed, stopsLeft: stopsLeft - 1 });
+    return null;
+  }
+  const ping = state.pings + 1;
+  // The affirmation ends the check only while the question is outstanding. Before
+  // the first ping the reply answers the USER, so a turn that merely ends in "Yes."
+  // would otherwise spend the one shot on a question this check never asked.
+  if ((state.pings > 0 && isAffirmative(reply)) || ping > max) {
+    save(path, { ...armed, done: true });
+    return null;
+  }
+  return save(path, { ...armed, pings: ping })
+    ? { decision: "block", reason: question(ping, max) }
+    : null;
+}
+
+if (isMain(import.meta.url)) {
+  try {
+    const raw = await readStdinJson();
+    const payload =
+      typeof raw === "object" && raw !== null
+        ? /** @type {{session_id?: unknown, transcript_path?: unknown}} */ (raw)
+        : {};
+    if (process.argv.includes("--record-push")) {
+      const dir =
+        process.env.COMPLETION_CHECK_STATE_DIR ??
+        join(tmpdir(), "claude-completion-check");
+      const path = statePath(payload.session_id, dir);
+      if (path !== null) recordPush(path, Date.now());
+    } else {
+      const response = run(payload);
+      if (response) process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+  } catch {
+    // Fail open: a malformed payload or an unwritable state directory allows the
+    // stop, so this hook can never hold a session open on its own defect.
+  }
+}

--- a/.claude/hooks/completion-check.mjs
+++ b/.claude/hooks/completion-check.mjs
@@ -26,6 +26,7 @@ import {
   isMain,
   readStdinJson,
   readTranscriptTail,
+  sessionStatePath,
   writeFileNoFollow,
 } from "./lib-hook-io.mjs";
 
@@ -195,8 +196,7 @@ const FRESH = Object.freeze({
  * @returns {string|null}
  */
 export function statePath(sessionId, dir) {
-  if (typeof sessionId !== "string" || !/^[\w-]+$/.test(sessionId)) return null;
-  return join(dir, `${sessionId}.json`);
+  return sessionStatePath(sessionId, dir, ".json");
 }
 
 /**

--- a/.claude/hooks/lib-hook-io.mjs
+++ b/.claude/hooks/lib-hook-io.mjs
@@ -1,6 +1,13 @@
 /** Shared I/O helpers for Claude Code hook scripts. */
 
-import { closeSync, openSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  fstatSync,
+  openSync,
+  readSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { pathToFileURL } from "node:url";
 
 /**
@@ -116,4 +123,34 @@ export function errMessage(err) {
   if (!(err instanceof Error)) return String(err);
   const cause = err.cause instanceof Error ? `: ${err.cause.message}` : "";
   return err.message + cause;
+}
+
+/**
+ * Bound on how much transcript a hook reads per invocation. A transcript grows
+ * for the life of a session, so a whole-file read makes every event slower and
+ * can outlive the hook's timeout in exactly the long sessions the hook is for.
+ */
+export const TRANSCRIPT_TAIL_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Last `maxBytes` of the file at `path`, trimmed to whole JSONL lines (the
+ * leading partial line after a mid-file start is dropped).
+ * @param {string} path
+ * @param {number} [maxBytes]
+ * @returns {string}
+ */
+export function readTranscriptTail(path, maxBytes = TRANSCRIPT_TAIL_BYTES) {
+  const fd = openSync(path, "r");
+  try {
+    const size = fstatSync(fd).size;
+    const start = Math.max(0, size - maxBytes);
+    const buf = Buffer.alloc(size - start);
+    readSync(fd, buf, 0, buf.length, start);
+    const text = buf.toString("utf8");
+    if (start === 0) return text;
+    const nl = text.indexOf("\n");
+    return nl === -1 ? "" : text.slice(nl + 1);
+  } finally {
+    closeSync(fd);
+  }
 }

--- a/.claude/hooks/lib-hook-io.mjs
+++ b/.claude/hooks/lib-hook-io.mjs
@@ -8,6 +8,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 /**
@@ -153,4 +154,19 @@ export function readTranscriptTail(path, maxBytes = TRANSCRIPT_TAIL_BYTES) {
   } finally {
     closeSync(fd);
   }
+}
+
+/**
+ * The state file a hook keeps for one session, or null when the session id is not
+ * already a safe filename. The file sits in a shared `$TMPDIR`, so the id is a path
+ * segment here and is validated rather than rewritten: a rewrite is many-to-one, so
+ * two sessions could share one file and one session's state would drive the other's.
+ * @param {unknown} sessionId
+ * @param {string} dir
+ * @param {string} suffix the file extension, `.segment` or `.json`
+ * @returns {string|null}
+ */
+export function sessionStatePath(sessionId, dir, suffix) {
+  if (typeof sessionId !== "string" || !/^[\w-]+$/.test(sessionId)) return null;
+  return join(dir, `${sessionId}${suffix}`);
 }

--- a/.claude/hooks/parallelism-nudge.mjs
+++ b/.claude/hooks/parallelism-nudge.mjs
@@ -18,16 +18,9 @@
  * must run on a bare `node` from a fresh clone.
  */
 import { createHash } from "node:crypto";
-import {
-  closeSync,
-  existsSync,
-  fstatSync,
-  openSync,
-  readSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { isMain } from "./lib-hook-io.mjs";
+import { isMain, readTranscriptTail } from "./lib-hook-io.mjs";
 
 /** Serial tool-turns (assistant messages with >=1 tool call, no delegation
  * anywhere in the segment) after which the nudge fires. High enough that a
@@ -45,34 +38,6 @@ export const TURN_CADENCE_THRESHOLD = 8;
  * (`Task` is the Claude Code CLI's native name for the sub-agent tool;
  * `Agent` is the remote harness's name for the same tool.) */
 export const DELEGATION_TOOLS = new Set(["Task", "Agent", "Workflow"]);
-
-/** Bound on how much transcript is read per invocation. A window this size
- * always covers the current user-turn segment in practice; when it doesn't,
- * stats are computed over the window alone, which only under-counts. */
-export const TRANSCRIPT_TAIL_BYTES = 8 * 1024 * 1024;
-
-/**
- * Last `maxBytes` of the file at `path`, trimmed to whole JSONL lines (the
- * leading partial line after a mid-file start is dropped).
- * @param {string} path
- * @param {number} [maxBytes]
- * @returns {string}
- */
-export function readTranscriptTail(path, maxBytes = TRANSCRIPT_TAIL_BYTES) {
-  const fd = openSync(path, "r");
-  try {
-    const size = fstatSync(fd).size;
-    const start = Math.max(0, size - maxBytes);
-    const buf = Buffer.alloc(size - start);
-    readSync(fd, buf, 0, buf.length, start);
-    const text = buf.toString("utf8");
-    if (start === 0) return text;
-    const nl = text.indexOf("\n");
-    return nl === -1 ? "" : text.slice(nl + 1);
-  } finally {
-    closeSync(fd);
-  }
-}
 
 /**
  * The tool_use blocks of one main-thread assistant transcript line, or [] when

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,12 @@
             "if": "Bash(gh pr create:*)",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/safe-launch.sh \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push-check.sh",
             "timeout": 1800
+          },
+          {
+            "type": "command",
+            "if": "Bash(git push:*)",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/safe-launch.sh \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/completion-check.mjs --record-push",
+            "timeout": 15
           }
         ]
       }
@@ -66,6 +72,16 @@
             "timeout": 60
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/bullshit-check.mjs",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -75,6 +91,27 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/drop-superseded-ci-events.mjs",
             "timeout": 15
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/bullshit-check.mjs",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/completion-check.mjs",
+            "timeout": 30
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,27 @@ the prose from the release's commits.
 
 ### Added
 
+- `bullshit-check.mjs`, an advisory hook that once per twelve-minute window, at
+  a moment hashed from the session id, drops one of two short self-audit
+  questions into the agent's context: the evidence check ("name the command
+  whose output backs the claim you are about to make") or "are you taking the
+  principled solution?". It rides `PostToolUse` and `UserPromptSubmit`, both
+  events the agent already runs under, so an idle session is never woken; a
+  window missed while idle is carried to the next tool call, never to a prompt,
+  so the question lands after work exists to audit. Each line asks for an
+  artifact — a command, a file, a search — rather than a re-reading of the
+  agent's own reasoning.
+
+- `completion-check.mjs`, a Stop hook that asks once, after the session has
+  pushed, whether ALL the requested work is finished, and blocks the stop until
+  the agent answers `Yes.` as its last line or `**Resuming work**` as its first.
+  It arms at a moment drawn from the five minutes after the first push, or at a
+  stop drawn from the first three that did real work, so the moment is not
+  predictable; it asks at most three times (`COMPLETION_CHECK_MAX`) and
+  `COMPLETION_CHECK=0` disables it. The push is recorded by the same
+  `Bash(git push:*)` matcher `pre-push-check.sh` already trusts, on PreToolUse,
+  so no shell text is parsed.
+
 - `Automated review posted`, a **required** check that makes auto-merge wait for
   the automated reviewer. The cheap checks finish in about ninety seconds while
   an LLM review takes minutes, so a PR gated only on the cheap checks merged

--- a/tests/bullshit-check.test.mjs
+++ b/tests/bullshit-check.test.mjs
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
@@ -342,6 +343,15 @@ describe("runCheck", () => {
       readFileSync(join(dir, "session-run.segment"), "utf8"),
       `${start} -1`,
     );
+  });
+
+  it("drops the question when a directory squats on the record path", () => {
+    // The record is renamed into place, and a rename over a directory fails: the
+    // question is dropped, and the temp file the rename would have moved is gone.
+    const dir = stateDir();
+    mkdirSync(join(dir, "session-run.segment"));
+    assert.equal(runCheck(payload(), Date.now()), null);
+    assert.ok(readdirSync(dir).every((entry) => !entry.endsWith(".tmp")));
   });
 
   it("drops the question when the record cannot be written", () => {

--- a/tests/bullshit-check.test.mjs
+++ b/tests/bullshit-check.test.mjs
@@ -97,13 +97,14 @@ describe("promptFor", () => {
   });
 
   it("draws the question independently of the moment", () => {
-    // Both draws read one digest, so a shared word would tie the question to
-    // the half of the segment its moment fell in.
-    const early = new Set();
-    for (let i = 0; i < 200; i += 1)
-      if (offsetMs("split", i) < SEGMENT_MS / 2)
-        early.add(promptFor("split", i));
-    assert.equal(early.size, PROMPTS.length);
+    // A shared digest word would make the question a function of the moment:
+    // SEGMENT_MS is even, so `offsetMs % PROMPTS.length` would BE the prompt index.
+    const tiedToTheMoment = Array.from({ length: 200 }, (_, i) => i).every(
+      (i) =>
+        PROMPTS.indexOf(promptFor("split", i)) ===
+        offsetMs("split", i) % PROMPTS.length,
+    );
+    assert.equal(tiedToTheMoment, false);
   });
 });
 

--- a/tests/bullshit-check.test.mjs
+++ b/tests/bullshit-check.test.mjs
@@ -1,0 +1,355 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  PROMPTS,
+  SEGMENT_MS,
+  carryingEvent,
+  decide,
+  offsetMs,
+  promptFor,
+  readState,
+  runCheck,
+  segmentOf,
+  statePath,
+} from "../.claude/hooks/bullshit-check.mjs";
+
+/** A throwaway state directory, so no test reads another's record. */
+function stateDir() {
+  const dir = mkdtempSync(join(tmpdir(), "bullshit-check-"));
+  process.env.BULLSHIT_CHECK_STATE_DIR = dir;
+  return dir;
+}
+
+/**
+ * An anchor that puts `now` one millisecond before the end of segment 0, where
+ * that segment's moment is always behind it — the offset cannot exceed the
+ * segment. So a check due NOW needs no search for a session id.
+ */
+function anchorDueBy(now, segmentMs = SEGMENT_MS) {
+  return now - (segmentMs - 1);
+}
+
+describe("statePath", () => {
+  it("names one file per session under the state directory", () => {
+    assert.equal(statePath("abc-123", "/state"), "/state/abc-123.segment");
+  });
+
+  it("refuses a session id that is not already a safe filename", () => {
+    for (const id of ["../escape", "a/b", "", 7, undefined, null])
+      assert.equal(statePath(id, "/state"), null);
+  });
+});
+
+describe("segmentOf", () => {
+  it("counts segments from the anchor, not from the epoch", () => {
+    const start = 1_700_000_123_456;
+    assert.equal(segmentOf(start, start), 0);
+    assert.equal(segmentOf(start + SEGMENT_MS - 1, start), 0);
+    assert.equal(segmentOf(start + SEGMENT_MS, start), 1);
+    assert.equal(segmentOf(start + SEGMENT_MS, start + 1), 0);
+  });
+});
+
+describe("offsetMs", () => {
+  it("lands inside the segment and spreads over it", () => {
+    const sixths = new Set();
+    for (let segment = 0; segment < 300; segment += 1) {
+      const offset = offsetMs("spread", segment);
+      assert.ok(offset >= 0 && offset < SEGMENT_MS, `offset ${offset}`);
+      sixths.add(Math.floor((offset / SEGMENT_MS) * 6));
+    }
+    // Sixths rather than a mean: a draw stuck in one part of the segment
+    // averages to the middle and would pass a mean test.
+    assert.equal(sixths.size, 6);
+  });
+
+  it("answers the same moment for every process in one segment", () => {
+    assert.equal(offsetMs("session-a", 42), offsetMs("session-a", 42));
+    assert.notEqual(offsetMs("session-a", 42), offsetMs("session-b", 42));
+  });
+});
+
+describe("promptFor", () => {
+  it("opens every question with the prefix the wiring tests match", () => {
+    for (const prompt of PROMPTS) assert.match(prompt, /\*\*Bullshit check/);
+  });
+
+  it("answers the same question for every process in one segment", () => {
+    assert.equal(promptFor("session-a", 7), promptFor("session-a", 7));
+  });
+
+  it("reaches every question as the segments pass", () => {
+    const seen = new Set(
+      Array.from({ length: 60 }, (_, i) => promptFor("session-a", i)),
+    );
+    assert.equal(seen.size, PROMPTS.length);
+  });
+
+  it("draws the question independently of the moment", () => {
+    // Both draws read one digest, so a shared word would tie the question to
+    // the half of the segment its moment fell in.
+    const early = new Set();
+    for (let i = 0; i < 200; i += 1)
+      if (offsetMs("split", i) < SEGMENT_MS / 2)
+        early.add(promptFor("split", i));
+    assert.equal(early.size, PROMPTS.length);
+  });
+});
+
+describe("carryingEvent", () => {
+  it("names the event a question would ride", () => {
+    assert.equal(
+      carryingEvent({ hook_event_name: "PostToolUse" }),
+      "PostToolUse",
+    );
+    assert.equal(
+      carryingEvent({ hook_event_name: "UserPromptSubmit" }),
+      "UserPromptSubmit",
+    );
+  });
+
+  it("refuses every other event, and a payload that names none", () => {
+    for (const event of ["PreToolUse", "SessionStart", "Stop", ""])
+      assert.equal(carryingEvent({ hook_event_name: event }), null);
+    assert.equal(carryingEvent({}), null);
+    assert.equal(carryingEvent(undefined), null);
+  });
+});
+
+describe("readState", () => {
+  it("reads back a recorded anchor and segment", () => {
+    const path = join(stateDir(), "s.segment");
+    writeFileSync(path, "1700000000000 17\n");
+    assert.deepEqual(readState(path), { start: 1_700_000_000_000, last: 17 });
+  });
+
+  it("answers null for an absent or unusable record", () => {
+    const dir = stateDir();
+    assert.equal(readState(join(dir, "absent.segment")), null);
+    for (const text of [
+      "",
+      "17",
+      "1700000000000 17 33",
+      "1700000000000  17",
+      "not-a-number 17",
+      "1.5 17",
+      "0 17",
+      "1700000000000 -2",
+    ]) {
+      const path = join(dir, "junk.segment");
+      writeFileSync(path, text);
+      assert.equal(readState(path), null, `read back ${JSON.stringify(text)}`);
+    }
+  });
+});
+
+describe("decide", () => {
+  const session = "session-a";
+  const start = 1_700_000_123_456;
+  const segment = 3;
+  const due = start + segment * SEGMENT_MS + offsetMs(session, segment);
+
+  it("anchors a session that has no record yet, and asks nothing", () => {
+    assert.deepEqual(decide({ sessionId: session, now: start, state: null }), {
+      fire: false,
+      record: { start, last: -1 },
+    });
+  });
+
+  it("re-anchors when the clock moved back behind the anchor", () => {
+    assert.deepEqual(
+      decide({ sessionId: session, now: start - 1, state: { start, last: 0 } }),
+      { fire: false, record: { start: start - 1, last: -1 } },
+    );
+  });
+
+  it("fires on the first call at or after the moment, once", () => {
+    const state = { start, last: 2 };
+    assert.deepEqual(decide({ sessionId: session, now: due - 1, state }), {
+      fire: false,
+      record: null,
+    });
+    assert.deepEqual(decide({ sessionId: session, now: due, state }), {
+      fire: true,
+      record: { start, last: segment },
+    });
+    assert.deepEqual(
+      decide({
+        sessionId: session,
+        now: due + 60_000,
+        state: { start, last: segment },
+      }),
+      { fire: false, record: null },
+    );
+  });
+
+  it("never rewinds to a segment it has already spent", () => {
+    assert.deepEqual(
+      decide({ sessionId: session, now: due, state: { start, last: 5 } }),
+      { fire: false, record: null },
+    );
+  });
+
+  it("asks at once when the segment before this one went unspent", () => {
+    // Spent segment 1, idle through segment 2, back BEFORE segment 3's moment.
+    const first = decide({
+      sessionId: session,
+      now: due - 1,
+      state: { start, last: 1 },
+    });
+    assert.deepEqual(first, { fire: true, record: { start, last: segment } });
+    // One question for the segments it skipped, never a backlog.
+    assert.deepEqual(
+      decide({ sessionId: session, now: due - 1, state: first.record }),
+      { fire: false, record: null },
+    );
+  });
+
+  it("carries an overdue check only when told to", () => {
+    // A prompt waits for the moment: a session woken by prompts is overdue at
+    // every wake and would be asked at turn start, before any work exists.
+    const state = { start, last: 1 };
+    assert.equal(
+      decide({ sessionId: session, now: due - 1, state, carryOverdue: false })
+        .fire,
+      false,
+    );
+    assert.deepEqual(
+      decide({ sessionId: session, now: due, state, carryOverdue: false }),
+      { fire: true, record: { start, last: segment } },
+    );
+  });
+});
+
+describe("runCheck", () => {
+  const payload = (fields = {}) => ({
+    hook_event_name: "PostToolUse",
+    session_id: "session-run",
+    ...fields,
+  });
+
+  /** Writes the state file that leaves `now` past a due moment. */
+  function dueState(dir, now, session = "session-run") {
+    const start = anchorDueBy(now);
+    writeFileSync(join(dir, `${session}.segment`), `${start} -1`);
+    return start;
+  }
+
+  it("asks once per segment and records what it spent", () => {
+    const dir = stateDir();
+    const now = Date.now();
+    const start = dueState(dir, now);
+    assert.equal(runCheck(payload(), now), promptFor("session-run", 0));
+    assert.equal(
+      readFileSync(join(dir, "session-run.segment"), "utf8"),
+      `${start} 0`,
+    );
+    // The record is renamed into place, so no temp file survives the write.
+    assert.ok(readdirSync(dir).every((entry) => !entry.endsWith(".tmp")));
+    assert.equal(runCheck(payload(), now + 1), null);
+  });
+
+  it("asks once when two events race on the same segment", () => {
+    const dir = stateDir();
+    const now = Date.now();
+    const start = dueState(dir, now);
+    assert.ok(runCheck(payload(), now));
+    // The second process read the record before the first one wrote, so it
+    // sees the same pre-fire state and decides to fire too.
+    writeFileSync(join(dir, "session-run.segment"), `${start} -1`);
+    assert.equal(runCheck(payload(), now), null);
+  });
+
+  it("asks on the user's prompt as well as on a tool call, once", () => {
+    const dir = stateDir();
+    const now = Date.now();
+    dueState(dir, now);
+    assert.ok(runCheck(payload({ hook_event_name: "UserPromptSubmit" }), now));
+    assert.equal(runCheck(payload(), now), null);
+  });
+
+  it("leaves an overdue check to the next tool call, not the prompt", () => {
+    // Segment 0 spent, segment 1 skipped, now early in segment 2 before its
+    // moment.
+    const dir = stateDir();
+    const start = Date.now() - 2 * SEGMENT_MS;
+    writeFileSync(join(dir, "session-run.segment"), `${start} 0`);
+    const early = start + 2 * SEGMENT_MS + offsetMs("session-run", 2) - 1;
+    assert.equal(
+      runCheck(payload({ hook_event_name: "UserPromptSubmit" }), early),
+      null,
+    );
+    assert.ok(runCheck(payload(), early));
+  });
+
+  it("asks again after a re-anchor despite a stale claim file", () => {
+    const dir = stateDir();
+    const now = Date.now();
+    const start = dueState(dir, now);
+    assert.ok(runCheck(payload(), now));
+    assert.ok(existsSync(join(dir, "session-run.segment.0")));
+    const rewound = start - 1000;
+    assert.equal(runCheck(payload(), rewound), null);
+    assert.equal(existsSync(join(dir, "session-run.segment.0")), false);
+    assert.ok(runCheck(payload(), rewound + offsetMs("session-run", 0)));
+  });
+
+  it("anchors a session on its first event and asks nothing yet", () => {
+    const dir = stateDir();
+    const now = Date.now();
+    assert.equal(runCheck(payload(), now), null);
+    assert.equal(
+      readFileSync(join(dir, "session-run.segment"), "utf8"),
+      `${now} -1`,
+    );
+    assert.ok(runCheck(payload(), now + offsetMs("session-run", 0)));
+  });
+
+  it("leaves the record alone for a subagent's tool call", () => {
+    const dir = stateDir();
+    const now = Date.now();
+    const start = dueState(dir, now);
+    assert.equal(runCheck(payload({ agent_id: "agent_01ABC" }), now), null);
+    assert.equal(
+      readFileSync(join(dir, "session-run.segment"), "utf8"),
+      `${start} -1`,
+    );
+    assert.ok(runCheck(payload(), now));
+  });
+
+  it("stays silent, record untouched, for a payload it cannot place", () => {
+    const dir = stateDir();
+    const now = Date.now();
+    const start = dueState(dir, now);
+    assert.equal(runCheck(payload({ session_id: "../escape" }), now), null);
+    assert.equal(runCheck(undefined, now), null);
+    assert.equal(
+      runCheck(payload({ hook_event_name: "PreToolUse" }), now),
+      null,
+    );
+    assert.equal(runCheck({ session_id: "session-run" }, now), null);
+    assert.equal(
+      readFileSync(join(dir, "session-run.segment"), "utf8"),
+      `${start} -1`,
+    );
+  });
+
+  it("drops the question when the record cannot be written", () => {
+    // A regular file where the state directory should be: repeating the
+    // question on every later event is worse than missing this segment's.
+    const blocked = join(stateDir(), "blocked");
+    writeFileSync(blocked, "not a directory");
+    process.env.BULLSHIT_CHECK_STATE_DIR = blocked;
+    assert.equal(runCheck(payload(), Date.now()), null);
+  });
+});

--- a/tests/completion-check.test.mjs
+++ b/tests/completion-check.test.mjs
@@ -18,6 +18,7 @@ import {
   run,
   statePath,
 } from "../.claude/hooks/completion-check.mjs";
+import { readTranscriptTail } from "../.claude/hooks/lib-hook-io.mjs";
 
 /** A throwaway state directory, so no test reads another's record. */
 function stateDir() {
@@ -136,6 +137,25 @@ describe("readTurn", () => {
     );
   });
 
+  it("skips a subagent's lines when finding the turn", () => {
+    // A sidechain prompt would otherwise read as the main turn's boundary and hide
+    // the main thread's own tool call.
+    const side = (role, content) =>
+      JSON.stringify({ isSidechain: true, message: { role, content } });
+    const transcript = [
+      PROMPT,
+      TOOL_USE,
+      TOOL_RESULT,
+      side("user", [{ type: "text", text: "subagent brief" }]),
+      side("assistant", [{ type: "text", text: "subagent report" }]),
+      reply("main report"),
+    ].join("\n");
+    assert.deepEqual(readTurn(transcript), {
+      reply: "main report",
+      usedTools: true,
+    });
+  });
+
   it("skips a line it cannot parse", () => {
     assert.deepEqual(readTurn(`not json\n${workedTurn("ok")}\n{broken`), {
       reply: "ok",
@@ -228,6 +248,58 @@ describe("run", () => {
     assert.equal(run(payload, options), null);
     assert.equal(readState(path).done, true);
     assert.equal(run(payload, options), null);
+  });
+
+  it("takes a no-tool 'Yes.' as the answer once a question is outstanding", () => {
+    // The reply to the question usually calls no tool. Before this, the no-work
+    // exemption let that stop through without marking the check done.
+    const dir = stateDir();
+    const { path, payload } = armedSession(dir, workedTurn("Pushed."));
+    const options = { stateDir: dir, now: () => 10 };
+    assert.equal(run(payload, options)?.decision, "block");
+    writeFileSync(payload.transcript_path, [PROMPT, reply("Yes.")].join("\n"));
+    assert.equal(run(payload, options), null);
+    assert.equal(readState(path).done, true);
+    // And a no-tool reply that is NOT the answer is asked again, never let through.
+    const again = armedSession(dir, workedTurn("Pushed."), "t");
+    assert.equal(run(again.payload, options)?.decision, "block");
+    writeFileSync(
+      again.payload.transcript_path,
+      [PROMPT, reply("hm")].join("\n"),
+    );
+    assert.match(run(again.payload, options)?.reason ?? "", /check 2 of 3/);
+  });
+
+  it("falls back to the default ping cap for a non-integer COMPLETION_CHECK_MAX", () => {
+    const dir = stateDir();
+    const { payload } = armedSession(dir, workedTurn("nope"));
+    const options = { stateDir: dir, now: () => 10 };
+    for (const value of ["Infinity", "0", "-2", "1.5", "many"]) {
+      process.env.COMPLETION_CHECK_MAX = value;
+      try {
+        assert.match(run(payload, options)?.reason ?? "", /of 3\./, value);
+      } finally {
+        delete process.env.COMPLETION_CHECK_MAX;
+      }
+      writeFileSync(
+        armedSession(dir, workedTurn("nope")).path,
+        JSON.stringify({
+          pushedAt: 1,
+          deadlineMs: 2,
+          stopsLeft: 1,
+          pings: 0,
+          done: false,
+        }),
+      );
+    }
+  });
+
+  it("reads only a bounded tail of the transcript", () => {
+    const dir = stateDir();
+    const path = join(dir, "long.jsonl");
+    writeFileSync(path, `${"x".repeat(50)}\n${workedTurn("tail")}`);
+    const tail = readTranscriptTail(path, workedTurn("tail").length + 10);
+    assert.deepEqual(readTurn(tail), { reply: "tail", usedTools: true });
   });
 
   it("does not let an unasked 'Yes.' spend the one shot", () => {

--- a/tests/completion-check.test.mjs
+++ b/tests/completion-check.test.mjs
@@ -270,27 +270,24 @@ describe("run", () => {
     assert.match(run(again.payload, options)?.reason ?? "", /check 2 of 3/);
   });
 
-  it("falls back to the default ping cap for a non-integer COMPLETION_CHECK_MAX", () => {
+  it("honours COMPLETION_CHECK_MAX, and falls back for a non-integer", () => {
     const dir = stateDir();
-    const { payload } = armedSession(dir, workedTurn("nope"));
     const options = { stateDir: dir, now: () => 10 };
-    for (const value of ["Infinity", "0", "-2", "1.5", "many"]) {
+    for (const [value, expected] of [
+      ["2", /of 2\./],
+      ["Infinity", /of 3\./],
+      ["0", /of 3\./],
+      ["-2", /of 3\./],
+      ["1.5", /of 3\./],
+      ["many", /of 3\./],
+    ]) {
+      const { payload } = armedSession(dir, workedTurn("nope"));
       process.env.COMPLETION_CHECK_MAX = value;
       try {
-        assert.match(run(payload, options)?.reason ?? "", /of 3\./, value);
+        assert.match(run(payload, options)?.reason ?? "", expected, value);
       } finally {
         delete process.env.COMPLETION_CHECK_MAX;
       }
-      writeFileSync(
-        armedSession(dir, workedTurn("nope")).path,
-        JSON.stringify({
-          pushedAt: 1,
-          deadlineMs: 2,
-          stopsLeft: 1,
-          pings: 0,
-          done: false,
-        }),
-      );
     }
   });
 

--- a/tests/completion-check.test.mjs
+++ b/tests/completion-check.test.mjs
@@ -1,0 +1,304 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  AFFIRMATION,
+  ARMING_STOPS_MAX,
+  DEFAULT_MAX_PINGS,
+  PUSH_WINDOW_MS,
+  RESUMPTION,
+  isAffirmative,
+  question,
+  readState,
+  readTurn,
+  recordPush,
+  run,
+  statePath,
+} from "../.claude/hooks/completion-check.mjs";
+
+/** A throwaway state directory, so no test reads another's record. */
+function stateDir() {
+  return mkdtempSync(join(tmpdir(), "completion-check-"));
+}
+
+/** One JSONL transcript line. */
+function line(role, content) {
+  return JSON.stringify({ message: { role, content } });
+}
+
+const PROMPT = line("user", [{ type: "text", text: "do the thing" }]);
+const TOOL_USE = line("assistant", [
+  { type: "tool_use", id: "t1", name: "Bash", input: { command: "true" } },
+]);
+const TOOL_RESULT = line("user", [
+  { type: "tool_result", tool_use_id: "t1", content: "ok" },
+]);
+const reply = (text) => line("assistant", [{ type: "text", text }]);
+
+/** A transcript whose last turn did real work and ended with `text`. */
+function workedTurn(text = "Pushed the fix.") {
+  return [PROMPT, TOOL_USE, TOOL_RESULT, reply(text)].join("\n");
+}
+
+/**
+ * A pushed session whose stop is armed: the window is behind it and the stop
+ * count is spent, so the next certifiable stop asks.
+ */
+function armedSession(dir, transcript, id = "s") {
+  const path = join(dir, `${id}.json`);
+  const transcriptPath = join(dir, `${id}.jsonl`);
+  writeFileSync(transcriptPath, transcript);
+  writeFileSync(
+    path,
+    JSON.stringify({
+      pushedAt: 1,
+      deadlineMs: 2,
+      stopsLeft: 1,
+      pings: 0,
+      done: false,
+    }),
+  );
+  return { path, payload: { session_id: id, transcript_path: transcriptPath } };
+}
+
+describe("isAffirmative", () => {
+  it("accepts the answer as the last line, however dressed", () => {
+    for (const text of [
+      "Yes.",
+      "**Yes.**",
+      "`Yes`",
+      "yes",
+      "All done.\n\nYes.",
+    ])
+      assert.equal(isAffirmative(text), true, text);
+  });
+
+  it("refuses the word inside a report or before more text", () => {
+    for (const text of [
+      "Yes. The tests pass, but one is red.",
+      "Yes.\nMore.",
+      "",
+    ])
+      assert.equal(isAffirmative(text), false, JSON.stringify(text));
+  });
+});
+
+describe("question", () => {
+  it("names the ping, the affirmation and the resumption marker", () => {
+    const text = question(2, 3);
+    assert.match(text, /Completion check 2 of 3/);
+    assert.ok(text.includes(AFFIRMATION));
+    assert.ok(text.includes(RESUMPTION));
+  });
+});
+
+describe("readTurn", () => {
+  it("reads the last turn's reply and whether it used a tool", () => {
+    assert.deepEqual(readTurn(workedTurn("Done.")), {
+      reply: "Done.",
+      usedTools: true,
+    });
+  });
+
+  it("stops at the prompt that opened the turn", () => {
+    const earlier = [PROMPT, TOOL_USE, TOOL_RESULT, reply("old")].join("\n");
+    const later = [PROMPT, reply("new")].join("\n");
+    assert.deepEqual(readTurn(`${earlier}\n${later}`), {
+      reply: "new",
+      usedTools: false,
+    });
+  });
+
+  it("does not count an empty ReadNotifications poll as work", () => {
+    const poll = line("assistant", [
+      { type: "tool_use", id: "p1", name: "ReadNotifications", input: {} },
+    ]);
+    const empty = line("user", [
+      {
+        type: "tool_result",
+        tool_use_id: "p1",
+        content: "No queued notifications.",
+      },
+    ]);
+    assert.equal(
+      readTurn([PROMPT, poll, empty, reply("waiting")].join("\n")).usedTools,
+      false,
+    );
+    const found = line("user", [
+      { type: "tool_result", tool_use_id: "p1", content: "1 notification" },
+    ]);
+    assert.equal(
+      readTurn([PROMPT, poll, found, reply("got one")].join("\n")).usedTools,
+      true,
+    );
+  });
+
+  it("skips a line it cannot parse", () => {
+    assert.deepEqual(readTurn(`not json\n${workedTurn("ok")}\n{broken`), {
+      reply: "ok",
+      usedTools: true,
+    });
+  });
+});
+
+describe("state", () => {
+  it("refuses a session id that is not a safe filename", () => {
+    for (const id of ["../x", "a/b", "", undefined])
+      assert.equal(statePath(id, "/state"), null);
+    assert.equal(statePath("abc-1", "/state"), "/state/abc-1.json");
+  });
+
+  it("reads a fresh state for an absent or damaged record", () => {
+    const dir = stateDir();
+    const fresh = readState(join(dir, "absent.json"));
+    assert.equal(fresh.pushedAt, null);
+    assert.equal(fresh.done, false);
+    const path = join(dir, "junk.json");
+    writeFileSync(path, '{"pushedAt":"soon","stopsLeft":"two","done":"yes"}');
+    assert.deepEqual(readState(path), {
+      pushedAt: null,
+      deadlineMs: null,
+      stopsLeft: 0,
+      pings: 0,
+      done: false,
+    });
+  });
+
+  it("records the first push only", () => {
+    const path = join(stateDir(), "s.json");
+    assert.equal(recordPush(path, 1000), true);
+    assert.equal(recordPush(path, 2000), false);
+    assert.equal(readState(path).pushedAt, 1000);
+  });
+});
+
+describe("run", () => {
+  it("allows every stop of a session that never pushed", () => {
+    const dir = stateDir();
+    const transcript = join(dir, "t.jsonl");
+    writeFileSync(transcript, workedTurn());
+    assert.equal(
+      run({ session_id: "s", transcript_path: transcript }, { stateDir: dir }),
+      null,
+    );
+  });
+
+  it("draws the arming moment once and keeps it", () => {
+    const dir = stateDir();
+    const path = join(dir, "s.json");
+    const transcript = join(dir, "s.jsonl");
+    writeFileSync(transcript, workedTurn());
+    recordPush(path, 1_000_000);
+    const options = { stateDir: dir, random: () => 0.5, now: () => 1_000_000 };
+    assert.equal(
+      run({ session_id: "s", transcript_path: transcript }, options),
+      null,
+    );
+    const saved = readState(path);
+    assert.equal(
+      saved.deadlineMs,
+      1_000_000 + Math.floor(0.5 * PUSH_WINDOW_MS),
+    );
+    // stopsLeft drew 1 + floor(0.5 * 3) = 2, and this certifiable stop spent one.
+    assert.equal(saved.stopsLeft, 1 + Math.floor(0.5 * ARMING_STOPS_MAX) - 1);
+    // A different random on the next stop changes nothing: the draw is stored.
+    run(
+      { session_id: "s", transcript_path: transcript },
+      { ...options, random: () => 0.9 },
+    );
+    assert.equal(readState(path).deadlineMs, saved.deadlineMs);
+  });
+
+  it("asks once the window has passed, and again until answered or spent", () => {
+    const dir = stateDir();
+    const { path, payload } = armedSession(dir, workedTurn("Pushed."));
+    const options = { stateDir: dir, now: () => 10 };
+    const first = run(payload, options);
+    assert.equal(first?.decision, "block");
+    assert.match(first?.reason ?? "", /Completion check 1 of 3/);
+    assert.equal(readState(path).pings, 1);
+    // Not the affirmation: asked again.
+    writeFileSync(payload.transcript_path, workedTurn("Still going."));
+    assert.match(run(payload, options)?.reason ?? "", /check 2 of 3/);
+    // The affirmation as the last line ends the check.
+    writeFileSync(payload.transcript_path, workedTurn("All done.\n\nYes."));
+    assert.equal(run(payload, options), null);
+    assert.equal(readState(path).done, true);
+    assert.equal(run(payload, options), null);
+  });
+
+  it("does not let an unasked 'Yes.' spend the one shot", () => {
+    const dir = stateDir();
+    const { path, payload } = armedSession(dir, workedTurn("Yes."));
+    const response = run(payload, { stateDir: dir, now: () => 10 });
+    assert.equal(response?.decision, "block");
+    assert.equal(readState(path).done, false);
+  });
+
+  it("allows the stop after the ping budget is spent", () => {
+    const dir = stateDir();
+    const { path, payload } = armedSession(dir, workedTurn("nope"));
+    const options = { stateDir: dir, now: () => 10, maxPings: 2 };
+    assert.equal(run(payload, options)?.decision, "block");
+    assert.equal(run(payload, options)?.decision, "block");
+    assert.equal(run(payload, options), null);
+    assert.equal(readState(path).done, true);
+    assert.equal(DEFAULT_MAX_PINGS, 3);
+  });
+
+  it("allows a stop with nothing to certify without spending the shot", () => {
+    const dir = stateDir();
+    const idle = [PROMPT, reply("nothing to do")].join("\n");
+    const { path, payload } = armedSession(dir, idle);
+    assert.equal(run(payload, { stateDir: dir, now: () => 10 }), null);
+    assert.equal(readState(path).pings, 0);
+    assert.equal(readState(path).done, false);
+  });
+
+  it("waits out the stop count inside the window", () => {
+    const dir = stateDir();
+    const { path, payload } = armedSession(dir, workedTurn());
+    writeFileSync(
+      path,
+      JSON.stringify({
+        pushedAt: 1,
+        deadlineMs: 100,
+        stopsLeft: 2,
+        pings: 0,
+        done: false,
+      }),
+    );
+    assert.equal(run(payload, { stateDir: dir, now: () => 50 }), null);
+    assert.equal(readState(path).stopsLeft, 1);
+    assert.equal(
+      run(payload, { stateDir: dir, now: () => 50 })?.decision,
+      "block",
+    );
+  });
+
+  it("is disabled by COMPLETION_CHECK=0 and by an unusable payload", () => {
+    const dir = stateDir();
+    const { payload } = armedSession(dir, workedTurn());
+    process.env.COMPLETION_CHECK = "0";
+    try {
+      assert.equal(run(payload, { stateDir: dir, now: () => 10 }), null);
+    } finally {
+      delete process.env.COMPLETION_CHECK;
+    }
+    assert.equal(
+      run({ session_id: "../x", transcript_path: "t" }, { stateDir: dir }),
+      null,
+    );
+    assert.equal(run({ session_id: "s" }, { stateDir: dir }), null);
+  });
+
+  it("records the state it acted on", () => {
+    const dir = stateDir();
+    const { path, payload } = armedSession(dir, workedTurn());
+    run(payload, { stateDir: dir, now: () => 10 });
+    assert.equal(JSON.parse(readFileSync(path, "utf8")).pings, 1);
+  });
+});

--- a/tests/test_bullshit_check.py
+++ b/tests/test_bullshit_check.py
@@ -1,0 +1,168 @@
+"""End-to-end tests for .claude/hooks/bullshit-check.mjs.
+
+Each test drives the real hook as a subprocess through the command
+`.claude/settings.json` wires, under each event that command is wired to, and
+asserts the observable outcome: the additionalContext JSON on stdout carrying
+the event's own name, or silence, plus the state file the run leaves behind. The
+in-process cases live in tests/bullshit-check.test.mjs; only this can tell a
+hook that works in isolation from one whose launch line never fires it.
+"""
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from tests._helpers import REPO_ROOT
+
+HOOK = REPO_ROOT / ".claude" / "hooks" / "bullshit-check.mjs"
+SETTINGS = REPO_ROOT / ".claude" / "settings.json"
+
+# Every event the hook rides. Each one runs the agent already, so a question on
+# it wakes nothing that was idle.
+EVENTS = ["PostToolUse", "UserPromptSubmit"]
+
+# Asks the hook's OWN exports which session to use and where its moments fall,
+# so the arithmetic is never re-derived here. The id's segment 0 moment sits in
+# the first half of the segment, which leaves a spawned hook slack to read its
+# own clock, and its segment 2 moment sits at least ten seconds in, so a run can
+# land before it. SEGMENT_MS divides the hash, so a hardcoded id's margins would
+# move whenever that constant does.
+_SESSION_JS = """
+import { SEGMENT_MS, offsetMs } from "%s";
+let n = 0;
+while (offsetMs(`wired-session-${n}`, 0) >= SEGMENT_MS / 2
+  || offsetMs(`wired-session-${n}`, 2) < 10_000) n += 1;
+console.log(`wired-session-${n}`);
+console.log(offsetMs(`wired-session-${n}`, 0));
+console.log(SEGMENT_MS);
+"""
+
+
+@pytest.fixture(scope="module")
+def session() -> tuple[str, int, int]:
+    """(session id, its segment 0 offset in ms, SEGMENT_MS), from the hook."""
+    proc = subprocess.run(
+        ["node", "--input-type=module", "-e", _SESSION_JS % HOOK.as_uri()],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    name, offset, segment_ms = proc.stdout.split()
+    return name, int(offset), int(segment_ms)
+
+
+def _wired_command(event: str) -> str:
+    """The one command settings.json launches for this hook on `event`."""
+    hooks = json.loads(SETTINGS.read_text(encoding="utf-8"))["hooks"]
+    commands = [
+        entry["command"]
+        for group in hooks.get(event, [])
+        for entry in group.get("hooks", [])
+        if "bullshit-check.mjs" in entry.get("command", "")
+    ]
+    assert len(commands) == 1, (
+        f"settings.json wires the hook {len(commands)} times on {event} — a wiring "
+        f"scan that finds none makes every assertion below pass over nothing"
+    )
+    return commands[0]
+
+
+def _run(
+    event: str, session: tuple[str, int, int], state: Path
+) -> subprocess.CompletedProcess:
+    payload = {"hook_event_name": event, "session_id": session[0]}
+    if event == "PostToolUse":
+        payload["tool_name"] = "Bash"
+    else:
+        payload["prompt"] = "carry on"
+    return subprocess.run(
+        ["bash", "-c", _wired_command(event)],
+        input=json.dumps(payload).encode(),
+        capture_output=True,
+        env={
+            "PATH": os.environ["PATH"],
+            "CLAUDE_PROJECT_DIR": str(REPO_ROOT),
+            "BULLSHIT_CHECK_STATE_DIR": str(state),
+        },
+        timeout=30,
+    )
+
+
+def _record(state: Path, session: tuple[str, int, int]) -> Path:
+    state.mkdir(exist_ok=True)
+    return state / f"{session[0]}.segment"
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+@pytest.mark.parametrize("event", EVENTS)
+def test_the_wired_command_delivers_the_question(event, tmp_path, session):
+    # Anchored, nothing resolved yet, and the segment 0 moment five seconds
+    # behind with the rest of the segment ahead.
+    anchor = _now_ms() - session[1] - 5_000
+    path = _record(tmp_path, session)
+    path.write_text(f"{anchor} -1", encoding="utf-8")
+
+    proc = _run(event, session, tmp_path)
+
+    assert proc.returncode == 0, proc.stderr.decode(errors="replace")[:400]
+    emitted = json.loads(proc.stdout)["hookSpecificOutput"]
+    # Claude Code ignores a body stamped with an event other than the one it fired.
+    assert emitted["hookEventName"] == event
+    assert "Bullshit check" in emitted["additionalContext"]
+    assert path.read_text(encoding="utf-8") == f"{anchor} 0"
+
+
+@pytest.mark.parametrize("event", EVENTS)
+def test_the_wired_command_says_nothing_once_the_segment_is_spent(
+    event, tmp_path, session
+):
+    anchor = _now_ms() - session[1] - 5_000
+    _record(tmp_path, session).write_text(f"{anchor} 0", encoding="utf-8")
+
+    proc = _run(event, session, tmp_path)
+
+    assert proc.returncode == 0
+    assert proc.stdout.decode().strip() == ""
+
+
+def test_an_overdue_check_rides_the_tool_call_and_not_the_prompt(tmp_path, session):
+    """A session woken by prompts is overdue at every wake. Asking there would land
+    the question at turn start, before any work exists to audit, so the prompt
+    waits for the segment's own moment and the tool call takes the carry."""
+    # Five seconds into segment 2, before its moment, with segment 1 never spent.
+    anchor = _now_ms() - 2 * session[2] - 5_000
+    path = _record(tmp_path, session)
+    path.write_text(f"{anchor} 0", encoding="utf-8")
+
+    prompt = _run("UserPromptSubmit", session, tmp_path)
+    assert prompt.returncode == 0
+    assert prompt.stdout.decode().strip() == ""
+    assert path.read_text(encoding="utf-8") == f"{anchor} 0"
+
+    tool = _run("PostToolUse", session, tmp_path)
+    assert tool.returncode == 0, tool.stderr.decode(errors="replace")[:400]
+    assert (
+        "Bullshit check"
+        in json.loads(tool.stdout)["hookSpecificOutput"]["additionalContext"]
+    )
+    assert path.read_text(encoding="utf-8") == f"{anchor} 2"
+
+
+def test_the_wired_command_anchors_a_session_it_has_not_seen(tmp_path, session):
+    path = _record(tmp_path, session)
+    before = _now_ms()
+
+    proc = _run("PostToolUse", session, tmp_path)
+
+    assert proc.returncode == 0, proc.stderr.decode(errors="replace")[:400]
+    assert proc.stdout.decode().strip() == ""
+    start, last = path.read_text(encoding="utf-8").split(" ")
+    assert last == "-1"
+    assert before <= int(start) <= _now_ms()

--- a/tests/test_bullshit_check.py
+++ b/tests/test_bullshit_check.py
@@ -12,6 +12,7 @@ import json
 import os
 import subprocess
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -42,9 +43,17 @@ console.log(SEGMENT_MS);
 """
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Session:
+    """The session id the wired runs use, and the two numbers the hook derives from it."""
+
+    name: str
+    offset_ms: int
+    segment_ms: int
+
+
 @pytest.fixture(scope="module")
-def session() -> tuple[str, int, int]:
-    """(session id, its segment 0 offset in ms, SEGMENT_MS), from the hook."""
+def session() -> Session:
     proc = subprocess.run(
         ["node", "--input-type=module", "-e", _SESSION_JS % HOOK.as_uri()],
         capture_output=True,
@@ -52,7 +61,7 @@ def session() -> tuple[str, int, int]:
         check=True,
     )
     name, offset, segment_ms = proc.stdout.split()
-    return name, int(offset), int(segment_ms)
+    return Session(name=name, offset_ms=int(offset), segment_ms=int(segment_ms))
 
 
 def _wired_command(event: str) -> str:
@@ -71,10 +80,8 @@ def _wired_command(event: str) -> str:
     return commands[0]
 
 
-def _run(
-    event: str, session: tuple[str, int, int], state: Path
-) -> subprocess.CompletedProcess:
-    payload = {"hook_event_name": event, "session_id": session[0]}
+def _run(event: str, session: Session, state: Path) -> subprocess.CompletedProcess:
+    payload = {"hook_event_name": event, "session_id": session.name}
     if event == "PostToolUse":
         payload["tool_name"] = "Bash"
     else:
@@ -92,9 +99,9 @@ def _run(
     )
 
 
-def _record(state: Path, session: tuple[str, int, int]) -> Path:
+def _record(state: Path, session: Session) -> Path:
     state.mkdir(exist_ok=True)
-    return state / f"{session[0]}.segment"
+    return state / f"{session.name}.segment"
 
 
 def _now_ms() -> int:
@@ -105,7 +112,7 @@ def _now_ms() -> int:
 def test_the_wired_command_delivers_the_question(event, tmp_path, session):
     # Anchored, nothing resolved yet, and the segment 0 moment five seconds
     # behind with the rest of the segment ahead.
-    anchor = _now_ms() - session[1] - 5_000
+    anchor = _now_ms() - session.offset_ms - 5_000
     path = _record(tmp_path, session)
     path.write_text(f"{anchor} -1", encoding="utf-8")
 
@@ -123,7 +130,7 @@ def test_the_wired_command_delivers_the_question(event, tmp_path, session):
 def test_the_wired_command_says_nothing_once_the_segment_is_spent(
     event, tmp_path, session
 ):
-    anchor = _now_ms() - session[1] - 5_000
+    anchor = _now_ms() - session.offset_ms - 5_000
     _record(tmp_path, session).write_text(f"{anchor} 0", encoding="utf-8")
 
     proc = _run(event, session, tmp_path)
@@ -137,7 +144,7 @@ def test_an_overdue_check_rides_the_tool_call_and_not_the_prompt(tmp_path, sessi
     the question at turn start, before any work exists to audit, so the prompt
     waits for the segment's own moment and the tool call takes the carry."""
     # Five seconds into segment 2, before its moment, with segment 1 never spent.
-    anchor = _now_ms() - 2 * session[2] - 5_000
+    anchor = _now_ms() - 2 * session.segment_ms - 5_000
     path = _record(tmp_path, session)
     path.write_text(f"{anchor} 0", encoding="utf-8")
 

--- a/tests/test_completion_check.py
+++ b/tests/test_completion_check.py
@@ -1,0 +1,141 @@
+"""End-to-end tests for .claude/hooks/completion-check.mjs.
+
+Drives the two commands `.claude/settings.json` wires — the PreToolUse
+`--record-push` arm through `safe-launch.sh`, and the Stop arm through `node` —
+as subprocesses against a real transcript file, and asserts what Claude Code
+would see: the block JSON on stdout, or silence. The in-process cases live in
+tests/completion-check.test.mjs; only this can tell a hook that works in
+isolation from one whose launch line never fires it.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from tests._helpers import REPO_ROOT
+
+SETTINGS = REPO_ROOT / ".claude" / "settings.json"
+SESSION = "wired-completion"
+
+
+def _wired_command(event: str) -> str:
+    """The one command settings.json launches for this hook on `event`."""
+    hooks = json.loads(SETTINGS.read_text(encoding="utf-8"))["hooks"]
+    commands = [
+        entry["command"]
+        for group in hooks.get(event, [])
+        for entry in group.get("hooks", [])
+        if "completion-check.mjs" in entry.get("command", "")
+    ]
+    assert len(commands) == 1, (
+        f"settings.json wires the hook {len(commands)} times on {event} — a wiring "
+        f"scan that finds none makes every assertion below pass over nothing"
+    )
+    return commands[0]
+
+
+def test_the_push_arm_is_gated_on_the_harness_push_matcher():
+    """The hook never parses shell text; settings.json's `if` is what decides a
+    Bash call is a push, and it is the matcher pre-push-check.sh already uses."""
+    hooks = json.loads(SETTINGS.read_text(encoding="utf-8"))["hooks"]
+    entries = [
+        entry
+        for group in hooks["PreToolUse"]
+        for entry in group.get("hooks", [])
+        if "completion-check.mjs" in entry.get("command", "")
+    ]
+    assert [e.get("if") for e in entries] == ["Bash(git push:*)"]
+
+
+def _run(event: str, payload: dict, state: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", _wired_command(event)],
+        input=json.dumps(payload).encode(),
+        capture_output=True,
+        env={
+            "PATH": os.environ["PATH"],
+            "CLAUDE_PROJECT_DIR": str(REPO_ROOT),
+            "COMPLETION_CHECK_STATE_DIR": str(state),
+        },
+        timeout=60,
+    )
+
+
+def _line(role: str, content: list) -> str:
+    return json.dumps({"message": {"role": role, "content": content}})
+
+
+def _worked_turn(text: str) -> str:
+    return "\n".join(
+        [
+            _line("user", [{"type": "text", "text": "do it"}]),
+            _line(
+                "assistant",
+                [{"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}],
+            ),
+            _line(
+                "user", [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]
+            ),
+            _line("assistant", [{"type": "text", "text": text}]),
+        ]
+    )
+
+
+def test_the_wired_push_arm_records_the_push_and_says_nothing(tmp_path):
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "session_id": SESSION,
+        "tool_name": "Bash",
+        "tool_input": {"command": "git push -u origin x"},
+    }
+    proc = _run("PreToolUse", payload, tmp_path)
+
+    assert proc.returncode == 0, proc.stderr.decode(errors="replace")[:400]
+    assert proc.stdout.decode().strip() == ""
+    saved = json.loads((tmp_path / f"{SESSION}.json").read_text(encoding="utf-8"))
+    assert isinstance(saved["pushedAt"], int) and saved["pushedAt"] > 0
+
+
+def test_the_wired_stop_arm_allows_a_session_that_never_pushed(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(_worked_turn("Done."), encoding="utf-8")
+    payload = {
+        "hook_event_name": "Stop",
+        "session_id": SESSION,
+        "transcript_path": str(transcript),
+    }
+    proc = _run("Stop", payload, tmp_path)
+
+    assert proc.returncode == 0, proc.stderr.decode(errors="replace")[:400]
+    assert proc.stdout.decode().strip() == ""
+
+
+def test_the_wired_stop_arm_asks_once_the_window_has_passed(tmp_path):
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(_worked_turn("Pushed the fix."), encoding="utf-8")
+    # Pushed long ago, window behind, stop count spent: the next stop asks.
+    (tmp_path / f"{SESSION}.json").write_text(
+        json.dumps(
+            {"pushedAt": 1, "deadlineMs": 2, "stopsLeft": 1, "pings": 0, "done": False}
+        ),
+        encoding="utf-8",
+    )
+    payload = {
+        "hook_event_name": "Stop",
+        "session_id": SESSION,
+        "transcript_path": str(transcript),
+    }
+
+    first = _run("Stop", payload, tmp_path)
+    assert first.returncode == 0, first.stderr.decode(errors="replace")[:400]
+    emitted = json.loads(first.stdout)
+    assert emitted["decision"] == "block"
+    assert "Completion check 1 of 3" in emitted["reason"]
+
+    transcript.write_text(_worked_turn("All done.\n\nYes."), encoding="utf-8")
+    second = _run("Stop", payload, tmp_path)
+    assert second.returncode == 0
+    assert second.stdout.decode().strip() == ""
+    saved = json.loads((tmp_path / f"{SESSION}.json").read_text(encoding="utf-8"))
+    assert saved["done"] is True


### PR DESCRIPTION
Two advisory hooks from agent-glovebox, ported so they run on a bare `node` from a fresh clone. Both ride events the agent already runs under, so neither wakes an idle session.

`bullshit-check.mjs` drops one of two short self-audit questions into the agent's context once per twelve-minute window, at a moment hashed from the session id: the evidence check, or "are you taking the principled solution?". It runs on `PostToolUse` and `UserPromptSubmit`. A window missed while idle is carried to the next tool call and never to a prompt, so the question lands after work exists to audit.

```
$ echo '{"hook_event_name":"UserPromptSubmit","session_id":"s3","prompt":"go on"}' | .claude/hooks/bullshit-check.mjs
{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"…**Bullshit check — are you taking the principled solution?**…"}}
```

`completion-check.mjs` asks once, after the session has pushed, whether ALL the requested work is finished, and blocks the Stop until the agent answers `Yes.` as its last line or `**Resuming work**` as its first. It arms at a moment drawn from the five minutes after the first push or at one of the first three working stops, asks at most three times, and is off under `COMPLETION_CHECK=0`. A Stop after a push that ends "Pushed the fix." gets back `{"decision":"block","reason":"Completion check 1 of 3. Are you done with ALL work? …"}`.

## Decisions made

- The push is recorded on `PreToolUse` under the `Bash(git push:*)` matcher that `pre-push-check.sh` already trusts, not found by parsing the transcript's shell commands. glovebox's version reads the commands with a bash grammar; the template ships no parser, and a regex over shell text is what `code-style.md` forbids. The cost is that a push behind `cd x && git push` goes unrecorded — the same miss `pre-push-check.sh` accepts today.
- The two hooks share one PR. Both are supervision-stack edits of the same class, discovered together, and a reviewer reads them together.

## Review focus

Read `.claude/hooks/completion-check.mjs`'s `run` first: the invariant one screen cannot show is that the arming draw is stored on first use and every later Stop reads it back, so a redraw can never keep the question out of reach. The wiring in `.claude/settings.json` is the part I am least sure of — the `Stop` event is new to this template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TwRG94DRGfP5omKLii3e6

---
_Generated by [Claude Code](https://claude.ai/code/session_018TwRG94DRGfP5omKLii3e6)_