### PR TITLE
feat(hooks): ask what the work can delete

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -61,7 +61,7 @@ After each tool call, `parallelism-nudge.mjs` measures from the session transcri
 
 **Posture: advisory.** It never blocks (`additionalContext` only), fails open on any internal error, and nudges at most once per user-turn segment, so a long turn is not re-narrated on every call.
 
-`bullshit-check.mjs` also runs here, and on `UserPromptSubmit`. Once per twelve-minute window, at a moment hashed from the session id, it drops one of two short self-audit questions into the agent's context: the evidence check ("name the command whose output backs the claim you are about to make") or "are you taking the principled solution?". Both events already run the agent, so an idle session is never woken; a window missed while idle is carried to the next tool call, never to a prompt, so the question lands after work exists to audit. State lives under `$TMPDIR/claude-bullshit-check/` (`BULLSHIT_CHECK_STATE_DIR` overrides it).
+`bullshit-check.mjs` also runs here, and on `UserPromptSubmit`. Once per twelve-minute window, at a moment hashed from the session id, it drops one short self-audit question into the agent's context: the evidence check ("name the command whose output backs the claim you are about to make"), "are you taking the principled solution?", or "is any of this unnecessary?", which asks what the work can delete before it is called done. Both events already run the agent, so an idle session is never woken; a window missed while idle is carried to the next tool call, never to a prompt, so the question lands after work exists to audit. State lives under `$TMPDIR/claude-bullshit-check/` (`BULLSHIT_CHECK_STATE_DIR` overrides it).
 
 **Posture: advisory.** `additionalContext` only, one question per window across both events, and every fault exits silently.
 

--- a/.claude/hooks/bullshit-check.mjs
+++ b/.claude/hooks/bullshit-check.mjs
@@ -48,8 +48,8 @@ export const SEGMENT_MS = 12 * 60 * 1000;
  * and no evidence. A clean answer costs one line; a dirty one names the fix.
  *
  * Each opens `**Bullshit check`, the prefix the wiring tests match, and they ask
- * about different failures: one about a claim that outruns its evidence, one
- * about a fix that treats the symptom.
+ * about different failures: a claim that outruns its evidence, a fix that treats
+ * the symptom, and a change that is larger than the job it does.
  */
 export const PROMPTS = Object.freeze([
   `<!-- periodic bullshit check -->
@@ -64,6 +64,12 @@ Nothing to report? One sentence, then carry on.`,
 - Name what you took the shortcut on — a special case, a retry, a widened exception, a narrowed assertion, a number you guessed instead of deriving — and either take the principled fix now or say what forbids it.
 - Name the search (a grep, a test run) that found the other sites that break the same way. Fix them, or say which ones you left and why.
 Already principled? One sentence, then carry on.`,
+  `<!-- periodic bullshit check -->
+**Bullshit check — is any of this unnecessary?** Think from first principles about what the work is trying to achieve. Interrogate what you built before calling it done:
+- Is anything here unnecessary, overly complicated, or based on a weak assumption? Challenge them.
+- What can you delete entirely?
+- What can you simplify now that the unnecessary pieces are gone?
+Then make the changes. Prefer deleting over simplifying, simplifying over optimizing, and optimizing over automating. It might be done already: you do NOT have to change anything. If it is good, leave it alone.`,
 ]);
 
 /**

--- a/.claude/hooks/bullshit-check.mjs
+++ b/.claude/hooks/bullshit-check.mjs
@@ -43,13 +43,10 @@ import {
 export const SEGMENT_MS = 12 * 60 * 1000;
 
 /**
- * The questions. Each line asks for an ARTIFACT — a command, a file, a failure —
- * rather than for a re-reading of the agent's own reasoning, which buys tokens
- * and no evidence. A clean answer costs one line; a dirty one names the fix.
- *
- * Each opens `**Bullshit check`, the prefix the wiring tests match, and they ask
- * about different failures: a claim that outruns its evidence, a fix that treats
- * the symptom, and a change that is larger than the job it does.
+ * The questions. Each opens `**Bullshit check`, the prefix the wiring tests match.
+ * The first two ask for an ARTIFACT — a command, a file, a failure — rather than a
+ * re-reading of the agent's own reasoning, which buys tokens and no evidence. The
+ * third asks what the work can delete, and the change itself answers it.
  */
 export const PROMPTS = Object.freeze([
   `<!-- periodic bullshit check -->
@@ -67,7 +64,7 @@ Already principled? One sentence, then carry on.`,
   `<!-- periodic bullshit check -->
 **Bullshit check — is any of this unnecessary?** Think from first principles about what the work is trying to achieve. Interrogate what you built before calling it done:
 - Is anything here unnecessary, overly complicated, or based on a weak assumption? Challenge them.
-- What can you delete entirely?
+- What can you delete entirely? Name it by file.
 - What can you simplify now that the unnecessary pieces are gone?
 Then make the changes. Prefer deleting over simplifying, simplifying over optimizing, and optimizing over automating. It might be done already: you do NOT have to change anything. If it is good, leave it alone.`,
 ]);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ the prose from the release's commits.
 ### Added
 
 - `bullshit-check.mjs`, an advisory hook that once per twelve-minute window, at
-  a moment hashed from the session id, drops one of two short self-audit
-  questions into the agent's context: the evidence check ("name the command
-  whose output backs the claim you are about to make") or "are you taking the
-  principled solution?". It rides `PostToolUse` and `UserPromptSubmit`, both
+  a moment hashed from the session id, drops one short self-audit question into
+  the agent's context: the evidence check ("name the command whose output backs
+  the claim you are about to make"), "are you taking the principled solution?",
+  or "is any of this unnecessary?", which asks what the work can delete before
+  it is called done. It rides `PostToolUse` and `UserPromptSubmit`, both
   events the agent already runs under, so an idle session is never woken; a
   window missed while idle is carried to the next tool call, never to a prompt,
   so the question lands after work exists to audit. Each line asks for an


### PR DESCRIPTION
## What & why

`bullshit-check.mjs` drops one short self-audit question into the agent's context once per twelve-minute window. It rotated between two questions. This adds a third, which asks the agent to think from first principles about the goal, then name what it can delete, simplify, or challenge as a weak assumption. It says outright that leaving good work alone is a valid answer, so the question does not push a rewrite of code that is already right. The rotation already draws from a hash of the session id and the window, so the new question needs no other machinery. This edit sits in `.claude/hooks/`, and the hook stays advisory: it judges no tool call and blocks nothing.

## Review focus

The `PROMPTS` array in `.claude/hooks/bullshit-check.mjs` is the whole change; `promptFor` and the tests read its length, so nothing else moves when the set grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvEDHZ2sMLRo2pqLLrvygd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvEDHZ2sMLRo2pqLLrvygd)_