### PR TITLE
docs(template-sync): name the two exclusions an adopter has to get right

### DIFF
--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -47,8 +47,10 @@ name: Sync from Template
 # 8. A file the adopter GENERATES belongs in EXCLUDE_PATHS. The sync line-merges,
 #    so the template's block lands beside the generated one and the generator
 #    reverts it on the next run — the same pull request reopens every week. In
-#    JSON that merge can also produce a DUPLICATE object key, which every parser
-#    reads last-wins, so the adopter's own block silently stops taking effect.
+#    JSON that merge can also produce a DUPLICATE member name. RFC 8259 leaves
+#    that case to the parser: jq, Python and JavaScript each keep the LAST one,
+#    so the adopter's own block silently stops taking effect, while another
+#    parser may keep the first or refuse the file outright.
 # =============================================================================
 #
 # ROOT SCAFFOLDING A SYNCED WORKFLOW MAY ASSUME

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -38,6 +38,17 @@ name: Sync from Template
 #    reports green while the action runs the new one. package.json is outside
 #    SYNC_PATHS, so adding `.github/actions/**/*.test.mjs` there is the
 #    consumer's edit to make.
+# 7. That same move breaks an EXCLUDE_PATHS entry naming the OLD path: the entry
+#    matches nothing, and the file arrives at the new path. The sync reports
+#    every entry that names nothing in the template, so read the inert-entry
+#    section of the sync pull request body. Exclude a composite action as the
+#    DIRECTORY `.github/actions/<name>`, never as `<name>/action.yaml` alone,
+#    so the action's scripts are covered too.
+# 8. A file the adopter GENERATES belongs in EXCLUDE_PATHS. The sync line-merges,
+#    so the template's block lands beside the generated one and the generator
+#    reverts it on the next run — the same pull request reopens every week. In
+#    JSON that merge can also produce a DUPLICATE object key, which every parser
+#    reads last-wins, so the adopter's own block silently stops taking effect.
 # =============================================================================
 #
 # ROOT SCAFFOLDING A SYNCED WORKFLOW MAY ASSUME

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -44,10 +44,12 @@ name: Sync from Template
 #    section of the sync pull request body. Exclude a composite action as the
 #    DIRECTORY `.github/actions/<name>`, never as `<name>/action.yaml` alone,
 #    so the action's scripts are covered too.
-# 8. A file the adopter GENERATES belongs in EXCLUDE_PATHS. The sync line-merges,
-#    so the template's block lands beside the generated one and the generator
-#    reverts it on the next run — the same pull request reopens every week. In
-#    JSON that merge can also produce a DUPLICATE member name. RFC 8259 leaves
+# 8. A file the adopter GENERATES and the TEMPLATE also owns belongs in
+#    EXCLUDE_PATHS; one the template does not own is never delivered, so an
+#    entry for it is inert per note 7. The sync line-merges, so the template's
+#    block lands beside the generated one and the generator reverts it on the
+#    next run — the same pull request reopens every week. In JSON that merge
+#    can also produce a DUPLICATE member name. RFC 8259 leaves
 #    that case to the parser: jq, Python and JavaScript each keep the LAST one,
 #    so the adopter's own block silently stops taking effect, while another
 #    parser may keep the first or refuse the file outright.


### PR DESCRIPTION
## What & why

Two more cases in the customization notes at the top of `.github/workflows/template-sync.yaml`, for adopters setting `EXCLUDE_PATHS`. Comments only; the sync's behavior does not change.

Case 7 is a moved file. Note 6 already covers the stale local copy a move leaves behind. It does not cover the adopter's `EXCLUDE_PATHS` entry, which still names the old path, matches nothing, and lets the file arrive at its new one. `AlexanderMattTurner/agent-glovebox#6047` hit this when `check-claude-execution.sh` and `compose-claude-prompt.sh` moved into `.github/actions/claude-run/`: that repo excluded `claude-run/action.yaml` alone, so five files landed in an action it does not run. The note tells an adopter to exclude `.github/actions/<name>` as a directory.

Case 8 is a generated file. `template-sync.sh` merges line by line, so the template's block lands beside the generated one and the adopter's generator reverts it next run — the same pull request reopens every week. In JSON that merge can append a duplicate member name. RFC 8259 leaves that case to the parser: jq, Python and JavaScript each keep the last one, so the adopter's own block stops taking effect while the file stays valid JSON.

## Review focus

The notes are the only place an adopter learns this, because the sync warns about an inert entry in the pull request body and nothing fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfDL8uGbJs3X57aEHhWhTb