### PR TITLE
fix(template-sync): stop overwriting an adopter's file on a first sync

### DIFF
--- a/.github/scripts/template-sync-pr-body.sh
+++ b/.github/scripts/template-sync-pr-body.sh
@@ -13,7 +13,8 @@
 # Env, all optional except the first three, and all from template-sync.sh's
 # step outputs: TEMPLATE_REPO, TEMPLATE_SHA_SHORT, PR_BODY_PATH; then
 # CHANGED_FILES, CHANGELOG, DOWNGRADE_REPORT, AUTO_MERGED_FILES,
-# DECLINED_FILES, INERT_ENTRIES, DELETED_FILES, CONFLICT_REPORT, MARKERLESS_FILES.
+# DECLINED_FILES, INERT_ENTRIES, DELETED_FILES, CONFLICT_REPORT, MARKERLESS_FILES,
+# CHANGED_COUNT.
 #
 # This script's output is markdown, so a backtick in a single-quoted format
 # string is a code span, never a command substitution.
@@ -32,12 +33,21 @@ set -euo pipefail
 # One bullet per entry. The old body pasted these lists inline, where forty
 # paths on one line read as noise.
 bullets() {
+  local list="${1:-}" note=""
+  # cap_body_field puts its truncation note after a blank line, and `read -ra` below consumes only
+  # the first line. Split the note off first: otherwise the note vanishes and the shortened list
+  # reads as complete, which is the one thing a truncation notice exists to prevent.
+  if [[ "$list" == *$'\n\n'* ]]; then
+    note="${list#*$'\n\n'}"
+    list="${list%%$'\n\n'*}"
+  fi
   local -a items
   local item
-  read -ra items <<<"${1:-}"
+  read -ra items <<<"$list"
   for item in "${items[@]}"; do
     [[ -n "$item" ]] && printf -- '- `%s`\n' "$item"
   done
+  [[ -n "$note" ]] && printf '\n_%s_\n' "$note"
 }
 
 count() {
@@ -47,8 +57,10 @@ count() {
 }
 
 {
+  # CHANGED_COUNT, not a count of CHANGED_FILES: that list takes the truncation cap, so counting it
+  # would report the cap's size as the number of files this sync changed.
   printf 'Syncs %s file(s) from [%s](https://github.com/%s) at `%s`.\n' \
-    "$(count "${CHANGED_FILES:-}")" "$TEMPLATE_REPO" "$TEMPLATE_REPO" "$TEMPLATE_SHA_SHORT"
+    "${CHANGED_COUNT:-$(count "${CHANGED_FILES:-}")}" "$TEMPLATE_REPO" "$TEMPLATE_REPO" "$TEMPLATE_SHA_SHORT"
 
   if [[ -n "${CHANGELOG:-}" ]]; then
     printf '\n## What changed, and why\n\n%s\n' "$CHANGELOG"

--- a/.github/scripts/template-sync-pr-body.sh
+++ b/.github/scripts/template-sync-pr-body.sh
@@ -68,10 +68,10 @@ $DOWNGRADE_REPORT
 EOF
   fi
 
-  # Before the marker conflicts: a file GitHub parses carries no markers, so nothing
-  # on the branch shows the reader that a decision is outstanding.
+  # These files carry no markers, so nothing on the branch shows a decision is outstanding.
+  # The per-file entry in the conflict report says why each one was kept.
   if [[ -n "${MARKERLESS_FILES:-}" ]]; then
-    printf '\n## Kept local, no markers on the branch\n\nGitHub parses these files, and a conflict marker in one leaves it unparseable — a workflow with markers starts a run with zero jobs and a red that names no cause. So the sync kept this repo'"'"'s version and wrote no markers. The template'"'"'s change is NOT applied: port it by hand from the conflict report below.\n\n%s\n' \
+    printf '\n## Kept local, no markers on the branch\n\nThe sync kept this repo'"'"'s version of these files and applied no template change. Port each one by hand from its entry in the conflict report below.\n\n%s\n' \
       "$(bullets "$MARKERLESS_FILES")"
   fi
 

--- a/.github/scripts/template-sync-pr-body.sh
+++ b/.github/scripts/template-sync-pr-body.sh
@@ -13,7 +13,7 @@
 # Env, all optional except the first three, and all from template-sync.sh's
 # step outputs: TEMPLATE_REPO, TEMPLATE_SHA_SHORT, PR_BODY_PATH; then
 # CHANGED_FILES, CHANGELOG, DOWNGRADE_REPORT, AUTO_MERGED_FILES,
-# DECLINED_FILES, INERT_ENTRIES, DELETED_FILES, CONFLICT_REPORT.
+# DECLINED_FILES, INERT_ENTRIES, DELETED_FILES, CONFLICT_REPORT, MARKERLESS_FILES.
 #
 # This script's output is markdown, so a backtick in a single-quoted format
 # string is a code span, never a command substitution.
@@ -66,6 +66,13 @@ A "clean" 3-way auto-merge dropped lines that existed in this repo's local copy.
 
 $DOWNGRADE_REPORT
 EOF
+  fi
+
+  # Before the marker conflicts: a file GitHub parses carries no markers, so nothing
+  # on the branch shows the reader that a decision is outstanding.
+  if [[ -n "${MARKERLESS_FILES:-}" ]]; then
+    printf '\n## Kept local, no markers on the branch\n\nGitHub parses these files, and a conflict marker in one leaves it unparseable — a workflow with markers starts a run with zero jobs and a red that names no cause. So the sync kept this repo'"'"'s version and wrote no markers. The template'"'"'s change is NOT applied: port it by hand from the conflict report below.\n\n%s\n' \
+      "$(bullets "$MARKERLESS_FILES")"
   fi
 
   if [[ -n "${CONFLICT_REPORT:-}" ]]; then

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -172,7 +172,7 @@ is_ci_loaded() {
 # One conflict-report entry: the path, EXPLANATION, and the local→template diff.
 # The diff must be taken before any caller overwrites the local file.
 record_diff_conflict() {
-  local rel_path="$1" template_file="$2" explanation="$3"
+  local rel_path="$1" template_file="$2" explanation="$3" diff_rc=0
   echo "$rel_path" >>"$CONFLICT_FILES"
   {
     echo "### \`$rel_path\`"
@@ -183,7 +183,15 @@ record_diff_conflict() {
     echo "<summary>Diff (local → template)</summary>"
     echo ""
     echo '```diff'
-    diff -u "$rel_path" "$template_file" | head -500 || true
+    # `awk`, not `head -500`: head stops reading at its limit, so a still-writing diff takes SIGPIPE
+    # and the pipeline exits 141 under `set -o pipefail`. diff exits 1 when the files differ, which
+    # is every call here; anything above that is a real fault and must not reach the report as an
+    # empty diff block.
+    diff -u "$rel_path" "$template_file" | awk 'NR <= 500' || diff_rc=$?
+    if ((diff_rc > 1)); then
+      echo "::error::template-sync: diff failed on $rel_path (exit $diff_rc)." >&2
+      exit 1
+    fi
     echo '```'
     echo "</details>"
     echo ""
@@ -430,6 +438,8 @@ Resolve them: keep local customizations, adopt template improvements."
   local empty_base="$WORK_DIR/empty_base" merge_result="$WORK_DIR/no_base_result"
   : >"$empty_base"
   cp "$rel_path" "$merge_result"
+  # allow-exit-suppress: non-zero here means "conflicted", which the empty base guarantees and
+  # this path wants. merge_file_clean exits the script itself on a real merge-file fault (255).
   merge_file_clean "$merge_result" "$empty_base" "$template_file" || true
   cp "$merge_result" "$rel_path"
   rm -f "$empty_base" "$merge_result"

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -69,10 +69,10 @@ emit_attributed_changelog() {
   changed="$WORK_DIR/changed_here.txt"
   attributed="$WORK_DIR/attributed.txt"
   # `sed`, not `grep -v`: an all-filtered list makes grep exit 1 and `set -e`
-  # would kill the run. `.template-version` is rewritten above and the template
-  # ships none, so no commit can ever explain it; `_template` is this script's
-  # own untracked checkout, which `--others` reports and `rm -rf` removes a few
-  # lines below. Both would land in the unexplained list on every single sync.
+  # would kill the run. main() rewrites `.template-version` before it calls this
+  # and the template ships none, so no commit can ever explain it; `_template` is
+  # this script's own untracked checkout, which `--others` reports and main()
+  # removes next. Both would land in the unexplained list on every single sync.
   {
     git diff --name-only
     git ls-files --others --exclude-standard
@@ -83,9 +83,11 @@ emit_attributed_changelog() {
   # changed_count is emitted UNCAPPED beside the capped list, because the body leads with "Syncs N
   # file(s)" and counting the truncated list would report the cap's size as the sync's size.
   echo "changed_count=$(wc -l <"$changed" | tr -d ' ')" >>"$GITHUB_OUTPUT"
-  emit_multiline_output "changed_files" "$(cap_body_field "$changed_list" \
+  local capped_changed
+  capped_changed="$(cap_body_field "$changed_list" \
     "${CONFLICT_FILES_MAX_BYTES:-8000}" \
     "… list truncated; the sync log names every changed file.")"
+  emit_multiline_output "changed_files" "$capped_changed"
 
   [[ -n "$PREV_SHA" && "$PREV_SHA" != "$TEMPLATE_SHA" ]] || return 0
   if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
@@ -97,7 +99,7 @@ emit_attributed_changelog() {
   fi
 
   : >"$attributed"
-  local sha subject touched
+  local sha subject touched f
   while IFS=$'\t' read -r sha subject; do
     [[ -n "$sha" ]] || continue
     # Files this commit touched that this sync also rewrote here. `comm -12`
@@ -194,7 +196,7 @@ record_diff_conflict() {
     # empty diff block.
     diff -u "$rel_path" "$template_file" | awk 'NR <= 500' || diff_rc=$?
     if ((diff_rc > 1)); then
-      echo "::error::template-sync: diff failed on $rel_path (exit $diff_rc)." >&2
+      echo "::error::template-sync: the diff of $rel_path failed (exit $diff_rc)." >&2
       exit 1
     fi
     echo '```'
@@ -636,7 +638,8 @@ main() {
     # appends an English note — whose words template-sync-resolve.sh would split as paths and
     # template-sync-push.sh would hand to `git add`.
     if [[ -s "$CONFLICT_FILES" ]]; then
-      emit_multiline_output "conflict_files" "$(tr '\n' ' ' <"$CONFLICT_FILES")"
+      conflicts=$(tr '\n' ' ' <"$CONFLICT_FILES")
+      emit_multiline_output "conflict_files" "$conflicts"
     fi
     if [[ -s "$MARKERLESS_FILES" ]]; then
       markerless=$(tr '\n' ' ' <"$MARKERLESS_FILES")

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -1,257 +1,476 @@
 #!/usr/bin/env bash
+# kcov-exclude: a behavioral suite runs it as `bash <script>`, so no run is traced.
 # Sync template files into the current repo, producing outputs consumed by
 # .github/workflows/template-sync.yaml.
 #
 # Inputs (env):
-#   SYNC_PATHS        Space-separated paths to sync from the template
-#                     (path names containing spaces are NOT supported)
+#   SYNC_PATHS        Space-separated paths to sync from the template (no spaces in a path name)
 #   EXCLUDE_PATHS     Space-separated paths to exclude. An entry names one file
-#                     or one directory, and a directory entry covers every file
-#                     under it.
-#   OPT_IN_PATHS      Space-separated paths the template only UPDATES, never
-#                     INTRODUCES: absent from the child repo, they are skipped;
-#                     present, they sync normally. Opting in is creating the file
-#                     once; opting out is deleting it.
+#                     or one directory, which covers every file under it.
+#   OPT_IN_PATHS      Space-separated paths the template only UPDATES, never INTRODUCES:
+#                     absent here they are skipped, present they sync normally.
 #   GITHUB_OUTPUT     Path to GitHub Actions output file
 #
-# Assumes a sibling `_template/` directory containing a checkout of the
-# template repository at the desired ref. Reads `.template-version` (if
-# present) for the previously synced SHA and overwrites it with the new one.
+# Assumes a sibling `_template/` directory holding a checkout of the template repository at the
+# desired ref. Reads `.template-version` for the previously synced SHA and overwrites it.
 #
-# Side effects:
-#   - Creates/updates files inside the current repo to match the template
-#   - Writes /tmp/conflict_files.txt, /tmp/conflict_report.md,
-#     /tmp/deleted_files.txt, /tmp/auto_merged_files.txt,
-#     /tmp/declined_files.txt, /tmp/inert_entries.txt
-#   - Writes .template-sync-conflicts if there are unresolved conflicts
-#   - Appends key=value lines to $GITHUB_OUTPUT
+# Side effects: creates/updates files in this repo, writes the report files main() names under
+# WORK_DIR, and appends key=value lines to $GITHUB_OUTPUT.
+#
+# SELF-MODIFICATION SAFETY: this script lives under a synced path, so a run rewrites the very file
+# bash is executing, and bash re-reads a script between top-level commands. Two things prevent the
+# syntax error that would follow: every executable statement lives inside main(), so bash parses
+# main()'s whole body from the original bytes before the call rewrites the file; and main() exits
+# the shell FROM WITHIN.
 
 set -euo pipefail
 
-# Re-exec from an immutable copy outside any synced path. This script lives
-# under .github/scripts, a synced path, so mid-run the sync overwrites its own
-# file. bash reads a running script incrementally and, after the trailing
-# `main "$@"` returns, resumes reading top-level input at a saved byte offset;
-# a longer replacement shifts that offset into the new file's bytes and bash
-# executes a truncated fragment ("unexpected EOF while looking for matching
-# quote"). The main() wrapper below defers execution but NOT that post-main
-# resume, so it is not sufficient on its own. Running from a $TMPDIR copy the
-# sync never touches removes the hazard entirely. The re-exec'd pass removes
-# its own copy on exit (guard: only when $0 is the copy we created).
-if [[ -z "${TEMPLATE_SYNC_REEXEC:-}" ]]; then
-  _self_copy="$(mktemp)"
-  cat "$0" >"$_self_copy"
-  TEMPLATE_SYNC_REEXEC="$_self_copy" exec bash "$_self_copy" "$@"
-fi
-[[ "${TEMPLATE_SYNC_REEXEC:-}" == "$0" ]] && trap 'rm -f "$0"' EXIT
+# INVARIANT — an EXCLUDE_PATHS directory entry must cover every file under it, so the `/`* arm is
+# required beside the equality test. The sync tests one file path at a time, so a directory entry
+# never equals the path of a file inside it, and an equality-only test would sync every file the
+# entry was written to keep out.
+is_excluded() {
+  local candidate="$1" exclude
+  for exclude in "${EXCLUDE_PATHS[@]}"; do
+    [[ "$candidate" = "$exclude" || "$candidate" = "$exclude"/* ]] && return 0
+  done
+  return 1
+}
 
-# All logic lives in main(), called as the final line, so bash parses through
-# this file's closing brace before executing any of it.
+# An OPT_IN_PATHS directory entry covers every file under it, so the
+# `/`* arm is required beside the equality test, exactly as in is_excluded.
+# A template feature is only correct in a repo with no equivalent of its own: an
+# adopter that already publishes releases, and then received the template's own
+# version-bump workflow, ran two workflows racing the same bump.
+is_opt_in() {
+  local candidate="$1" opt_in
+  for opt_in in "${OPT_IN_PATHS[@]}"; do
+    [[ "$candidate" = "$opt_in" || "$candidate" = "$opt_in"/* ]] && return 0
+  done
+  return 1
+}
+
+# PROBLEM CLASS — a template file this repo deleted comes back on the next sync, since the sync
+# copies in any template file the repo does not have; this refusal is what makes the deletion hold.
+# The evidence is this repo's own deletion commit, not the template's tree: a commit that deleted
+# the path IS this repo saying it does not want the file, where the template tree at PREV_SHA only
+# says the file was available then, which is true of every template file this repo never adopted. A
+# path with no deletion commit was never here, so it is new and still arrives. The sync checks out
+# with `fetch-depth: 0`; a shallow checkout finds no deletion and falls back to copying.
+was_deleted_here() {
+  [[ "$(git log --diff-filter=D --format=%H -1 -- "$1")" != "" ]]
+}
+
+# Emit the `changed_files` and `changelog` outputs. The changelog maps each file this sync rewrote
+# to the template commit that explains it, so a reviewer reads intent rather than a raw log.
+emit_attributed_changelog() {
+  local changed body="" attributed unexplained kept=0 skipped=0
+  local -a range
+  changed="$WORK_DIR/changed_here.txt"
+  attributed="$WORK_DIR/attributed.txt"
+  # `sed`, not `grep -v`: an all-filtered list makes grep exit 1 and `set -e`
+  # would kill the run. `.template-version` is rewritten above and the template
+  # ships none, so no commit can ever explain it; `_template` is this script's
+  # own untracked checkout, which `--others` reports and `rm -rf` removes a few
+  # lines below. Both would land in the unexplained list on every single sync.
+  {
+    git diff --name-only
+    git ls-files --others --exclude-standard
+  } | sed -e '/^\.template-version$/d' -e '\#^_template/\?$#d' | sort -u >"$changed"
+  [[ -s "$changed" ]] || return 0
+  local changed_list
+  changed_list="$(tr '\n' ' ' <"$changed")"
+  echo "changed_files=$changed_list" >>"$GITHUB_OUTPUT"
+
+  [[ -n "$PREV_SHA" && "$PREV_SHA" != "$TEMPLATE_SHA" ]] || return 0
+  if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
+    range=("${PREV_SHA}..${TEMPLATE_SHA}")
+  else
+    echo "::warning::Previous template SHA $PREV_SHA is not in template history (force-push or rebase); attributing over the last 20 commits instead"
+    range=(-20 "$TEMPLATE_SHA")
+    body+="\`$PREV_SHA\` is no longer in the template's history, so this reads the last 20 commits rather than a range."$'\n\n'
+  fi
+
+  : >"$attributed"
+  local sha subject touched
+  while IFS=$'\t' read -r sha subject; do
+    [[ -n "$sha" ]] || continue
+    # Files this commit touched that this sync also rewrote here. `comm -12`
+    # over two sorted lists, so a commit touching only unsynced paths yields
+    # nothing and is skipped.
+    touched=$(comm -12 \
+      <(git -C _template show --pretty=format: --name-only "$sha" | sed '/^$/d' | sort -u) \
+      "$changed")
+    if [[ -z "$touched" ]]; then
+      skipped=$((skipped + 1))
+      continue
+    fi
+    kept=$((kept + 1))
+    body+="- \`${sha}\` ${subject}"$'\n'
+    while IFS= read -r f; do
+      [[ -n "$f" ]] || continue
+      body+="  - \`${f}\`"$'\n'
+      echo "$f" >>"$attributed"
+    done <<<"$touched"
+    # --no-merges: `git show --name-only` prints nothing for a merge commit, so
+    # a merge would count as "touched nothing here" while being exactly the
+    # commit that carried the files. Its branch commits are already in range.
+  done < <(git -C _template log --no-merges --format='%h%x09%s' "${range[@]}")
+
+  unexplained=$(comm -23 "$changed" <(sort -u "$attributed"))
+  if [[ -n "$unexplained" ]]; then
+    body+=$'\n'"Changed here with no commit in that range — a path synced for the first time, or one whose template history moved:"$'\n'
+    while IFS= read -r f; do
+      [[ -n "$f" ]] || continue
+      body+="- \`${f}\`"$'\n'
+    done <<<"$unexplained"
+  fi
+  [[ "$skipped" -eq 0 ]] || body+=$'\n'"${skipped} other template commit(s) in that range touched nothing this repo syncs."$'\n'
+  body=$(cap_body_field "$body" "${CHANGELOG_MAX_BYTES:-20000}" \
+    "…changelog truncated; read the template's own log for the rest.")
+  [[ "$kept" -eq 0 && -z "$unexplained" ]] || emit_multiline_output "changelog" "$body"
+}
+
+# A configuration entry that is accepted and matches nothing fails silently: the entry sits in the
+# list, the sync copies the file anyway, and the list reads as though it covers the file. The
+# warning is what makes a misspelled or stale entry visible. Read the template tree before the run
+# deletes it.
+report_inert_entries() {
+  local entry
+  for entry in "${EXCLUDE_PATHS[@]}" "${OPT_IN_PATHS[@]}"; do
+    [[ -e "_template/$entry" ]] && continue
+    echo "::warning::list entry names nothing in the template: $entry"
+    echo "$entry" >>"$INERT_ENTRIES"
+  done
+}
+
+# A "clean" 3-way merge that silently drops adopter content. The
+# base is the single repo-wide PREV_SHA, which is STALE for a file first synced at
+# another template SHA, and git then reports a clean merge for a result missing
+# lines this repo had. Counts the non-blank lines the result lost against the
+# pre-sync local. Sorted, so a line that merely moved does not count. `grep -c`
+# exits 1 printing "0" when nothing matches, so the default keeps set -e quiet.
+count_dropped_lines() {
+  local local_f="$1" result_f="$2" n
+  n=$(comm -23 <(sort "$local_f") <(sort "$result_f") |
+    grep -cv '^[[:space:]]*$') || n=0
+  printf '%s' "${n:-0}"
+}
+
+# A conflict marker committed into a file CI itself loads off the branch. GitHub reads every
+# workflow file to decide what to run, so markers there leave it unparseable: the run GitHub starts
+# has ZERO jobs, a `failure` conclusion, and a display name that falls back to the file path — a red
+# naming no cause, replacing every check the workflow was to report. A conflict in one of these
+# paths keeps the LOCAL file instead, which is what keeps the branch's workflows parseable.
+is_ci_loaded() {
+  case "$1" in
+  .github/workflows/* | .github/actions/* | .github/scripts/*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+# One conflict-report entry: the path, EXPLANATION, and the local→template diff.
+# The diff must be taken before any caller overwrites the local file.
+record_diff_conflict() {
+  local rel_path="$1" template_file="$2" explanation="$3"
+  echo "$rel_path" >>"$CONFLICT_FILES"
+  {
+    echo "### \`$rel_path\`"
+    echo ""
+    echo "$explanation"
+    echo ""
+    echo "<details>"
+    echo "<summary>Diff (local → template)</summary>"
+    echo ""
+    echo '```diff'
+    diff -u "$rel_path" "$template_file" | head -500 || true
+    echo '```'
+    echo "</details>"
+    echo ""
+  } >>"$CONFLICT_REPORT"
+}
+
+# A conflict in a file CI loads writes nothing and joins MARKERLESS_FILES, the short path list the
+# PR body prints ahead of the report. Every other conflict leaves markers in the tree; this one
+# writes nothing, so the report is its ONLY record, and the template's version reaches the reviewer
+# as a diff.
+record_ci_loaded_conflict() {
+  local rel_path="$1" template_file="$2"
+  echo "CONFLICT (local kept, CI loads this file): $rel_path"
+  echo "$rel_path" >>"$MARKERLESS_FILES"
+  record_diff_conflict "$rel_path" "$template_file" \
+    "**The template change is NOT applied.** CI loads this file off the branch.
+A conflict marker in it makes the workflow unloadable, or the step a bash syntax error.
+GitHub then reports a failure that names no cause. The sync keeps the local file unchanged.
+Port the template's change by hand."
+}
+
+# Random sentinel suffix: prefer /proc uuid, fall back to uuidgen/$RANDOM for
+# stripped-down environments.
+random_token() {
+  if [[ -r /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+  elif command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  else
+    printf '%s_%s_%s' "$$" "$RANDOM" "$RANDOM"
+  fi
+}
+
+# Every field the PR body assembles is capped here, so the body stays under Linux's MAX_ARG_STRLEN
+# (128 KiB per single string) and the PR is created. peter-evans/create-pull-request receives `body:`
+# as the INPUT_BODY environment variable and the runner exec's node with it, so a single env string
+# over that limit makes execve fail with E2BIG and the action never starts. Conflict excerpts, up to
+# 500 lines per file across many synced files, blow past it. The truncation lands on an entry
+# boundary using byte-accurate head -c/wc -c, never splitting a UTF-8 sequence, a conflict fence or
+# a path, and appends a pointer to the branch that carries the rest.
+cap_body_field() {
+  local content="$1" max="$2" note="$3" bytes cut
+  bytes=$(printf '%s' "$content" | wc -c)
+  if ((bytes <= max)); then
+    printf '%s' "$content"
+    return
+  fi
+  cut=$(head -c "$max" <<<"$content")
+  # Trim back to the last separator, newline THEN space: the report and the changelog are
+  # newline-separated, while the path lists are ONE space-joined line, where a newline-only trim
+  # matches nothing and the tail becomes a fragment that still reads like a real path
+  # (`.github/workflows/c`). With no separator at all not one entry fits, so the note goes alone.
+  if [[ "$cut" == *$'\n'* ]]; then
+    cut="${cut%$'\n'*}"
+  elif [[ "$cut" == *' '* ]]; then
+    cut="${cut% *}"
+  else
+    cut=""
+  fi
+  printf '%s\n\n%s' "$cut" "$note"
+}
+
+# Random-suffixed sentinel so user-controlled content can't terminate the
+# GITHUB_OUTPUT block early.
+emit_multiline_output() {
+  local key="$1" content="$2" sentinel
+  sentinel="EOF_$(random_token)"
+  {
+    echo "${key}<<${sentinel}"
+    printf '%s\n' "$content"
+    echo "$sentinel"
+  } >>"$GITHUB_OUTPUT"
+}
+
+# merge_file_clean RESULT BASE OTHER — 3-way merge RESULT in place; true on a clean merge, false
+# when it wrote conflict markers. git merge-file exits with the CONFLICT COUNT, and with 255 on a
+# real failure such as an unreadable path or binary input, so treating "non-zero" as "conflicted"
+# would commit a merge that never ran as a merge that conflicted. 255 is separated out and kills the
+# sync.
+merge_file_clean() {
+  local rc=0
+  git merge-file -L "local" -L "base" -L "template" "$1" "$2" "$3" >/dev/null 2>&1 || rc=$?
+  if ((rc == 255)); then
+    echo "::error::template-sync: git merge-file failed on $1 — refusing to guess at the merge." >&2
+    exit 1
+  fi
+  ((rc == 0))
+}
+
+# Resolve a single file's sync outcome using a 3-way merge of the file at PREV_SHA
+# (base), the current local file, and the template's HEAD. Decision tree:
+#   1. File is new in template → copy it in.
+#   2. Files are already identical → no-op.
+#   3. No merge base (first sync or lost history) → conflict markers, both sides kept.
+#   4. Template is unchanged since base → local diverged alone; keep local.
+#   5. Local is unchanged since base → template advanced alone; adopt template.
+#   6. Both sides changed → attempt a 3-way merge:
+#      a. Clean merge → write merged result.
+#      b. Conflict → write conflict markers, so both sides reach the reviewer.
+process_file() {
+  local rel_path="$1"
+  local template_file="_template/$rel_path"
+
+  local parent_dir
+  parent_dir=$(dirname "$rel_path")
+
+  # A path the child made a symlink, or one under a symlinked ancestor, is never written; checked
+  # before the mkdir below. The child may have made one deliberately — a dotfiles repo pointing
+  # `.claude/settings.json` at another repo it clones at runtime — and writing it goes wrong three
+  # ways: `cp` through a dangling link errors out, through a live one it escapes into the link
+  # target, and `mkdir -p` on a symlinked directory fails outright.
+  if [[ -L "$rel_path" ]]; then
+    echo "Skipping symlink: $rel_path (local structure preserved)"
+    return
+  fi
+  local ancestor="$parent_dir"
+  while [[ "$ancestor" != "." && "$ancestor" != "/" && -n "$ancestor" ]]; do
+    if [[ -L "$ancestor" ]]; then
+      echo "Skipping under symlinked dir: $rel_path ($ancestor is a symlink)"
+      return
+    fi
+    ancestor=$(dirname "$ancestor")
+  done
+
+  [[ "$parent_dir" != "." ]] && mkdir -p "$parent_dir" # bare-mkdir-ok: Linux CI runner (no BSD mkdir -p symlink semantics)
+
+  # Case 1: absent locally — a new template file, unless this repo removed it.
+  if [[ ! -f "$rel_path" ]]; then
+    if is_opt_in "$rel_path"; then
+      echo "Opt-in only, not present locally: $rel_path (copy it from the template to adopt it)"
+      return
+    fi
+    if was_deleted_here "$rel_path"; then
+      echo "Declined: $rel_path (deleted here since the last sync; not re-added)"
+      echo "$rel_path" >>"$DECLINED_FILES"
+      return
+    fi
+    cp "$template_file" "$rel_path"
+    echo "Added: $rel_path"
+    return
+  fi
+
+  # Case 2: already identical.
+  if diff -q "$rel_path" "$template_file" >/dev/null 2>&1; then
+    return
+  fi
+
+  # Case 3: no merge base — first sync or history unavailable.
+  if [[ "$PREV_SHA" = "" ]]; then
+    record_no_base_conflict "$rel_path" "$template_file"
+    return
+  fi
+
+  local safe_name
+  safe_name=$(echo "$rel_path" | tr '/' '_')
+  local base_file="$WORK_DIR/merge_base_${safe_name}"
+
+  if ! git -C _template show "${PREV_SHA}:${rel_path}" >"$base_file" 2>/dev/null; then
+    rm -f "$base_file"
+    record_no_base_conflict "$rel_path" "$template_file"
+    return
+  fi
+
+  # Case 4: template unchanged since base — local diverged alone; keep local.
+  if diff -q "$base_file" "$template_file" >/dev/null 2>&1; then
+    echo "Unchanged in template: $rel_path (keeping local version)"
+    rm -f "$base_file"
+    return
+  fi
+
+  # Case 5: local unchanged since base — template advanced alone; adopt it.
+  if diff -q "$base_file" "$rel_path" >/dev/null 2>&1; then
+    cp "$template_file" "$rel_path"
+    echo "Updated: $rel_path (local was unmodified)"
+    rm -f "$base_file"
+    return
+  fi
+
+  # Case 6: both sides changed — attempt a 3-way merge.
+  local merge_result="$WORK_DIR/merge_result_${safe_name}"
+  cp "$rel_path" "$merge_result"
+
+  if merge_file_clean "$merge_result" "$base_file" "$template_file"; then
+    # Measured against the pre-sync local, which $rel_path still holds.
+    local dropped
+    dropped=$(count_dropped_lines "$rel_path" "$merge_result")
+    cp "$merge_result" "$rel_path"
+    echo "Auto-merged: $rel_path (clean 3-way merge)"
+    echo "$rel_path" >>"$AUTO_MERGED_FILES"
+    if [[ "${dropped:-0}" -gt 0 ]]; then
+      echo "$rel_path" >>"$DOWNGRADE_FILES"
+      # The %s are printf specifiers, not shell expansions.
+      # shellcheck disable=SC2016
+      printf -- '- `%s` — auto-merge dropped %s line(s) present in the local copy\n' \
+        "$rel_path" "$dropped" >>"$DOWNGRADE_REPORT"
+    fi
+    rm -f "$base_file" "$merge_result"
+    return
+  fi
+
+  # Case 6b: conflict — keep markers so both sides reach the reviewer.
+  if is_ci_loaded "$rel_path"; then
+    record_ci_loaded_conflict "$rel_path" "$template_file"
+    rm -f "$base_file" "$merge_result"
+    return
+  fi
+  cp "$merge_result" "$rel_path"
+  echo "CONFLICT (merge markers): $rel_path"
+  echo "$rel_path" >>"$CONFLICT_FILES"
+  {
+    echo "### \`$rel_path\`"
+    echo ""
+    echo "3-way merge produced **conflict markers** (\`<<<<<<<\`/\`=======\`/\`>>>>>>>\`)."
+    echo "Resolve them: keep local customizations, adopt template improvements."
+    echo ""
+    echo "<details>"
+    echo "<summary>View file with conflict markers</summary>"
+    echo ""
+    echo "\`\`\`"
+    head -500 "$rel_path"
+    echo "\`\`\`"
+    echo "</details>"
+    echo ""
+  } >>"$CONFLICT_REPORT"
+  rm -f "$base_file" "$merge_result"
+}
+
+# With no common ancestor the merge runs against an EMPTY base, so a template file with no ancestor
+# can never silently replace the local one. The case is not exotic: a file developed here and later
+# ported upstream has no ancestor at the previously-synced template SHA, so copying the template
+# over it would delete every local change made since the port, with nothing in the diff to show a
+# merge was ever skipped.
+record_no_base_conflict() {
+  local rel_path="$1" template_file="$2"
+  if is_ci_loaded "$rel_path"; then
+    record_ci_loaded_conflict "$rel_path" "$template_file"
+    return
+  fi
+  echo "CONFLICT (no base): $rel_path"
+  record_diff_conflict "$rel_path" "$template_file" \
+    "No merge base available (first sync, or the template added this path after the last sync).
+Both versions are kept as **conflict markers** (\`<<<<<<<\`/\`=======\`/\`>>>>>>>\`).
+Resolve them: keep local customizations, adopt template improvements."
+  local empty_base="$WORK_DIR/empty_base" merge_result="$WORK_DIR/no_base_result"
+  : >"$empty_base"
+  cp "$rel_path" "$merge_result"
+  merge_file_clean "$merge_result" "$empty_base" "$template_file" || true
+  cp "$merge_result" "$rel_path"
+  rm -f "$empty_base" "$merge_result"
+}
+
+# All file-mutating logic lives here so main()'s body is fully parsed before the call rewrites this
+# file — see SELF-MODIFICATION SAFETY in the header. Letting main() return and fall off the end is
+# NOT safe: bash reads the next line off disk and hits the rewritten bytes. `main "$@"; exit` on one
+# line would work too, but shfmt splits it back onto two, reintroducing the unsafe trailing read.
 main() {
-
-  SYNC_PATHS="${SYNC_PATHS:-}"
-  EXCLUDE_PATHS="${EXCLUDE_PATHS:-}"
-  OPT_IN_PATHS="${OPT_IN_PATHS:-}"
+  # Read space-separated env strings into arrays so loop sites can use "${arr[@]}".
+  read -ra SYNC_PATHS <<<"${SYNC_PATHS:-}"
+  read -ra EXCLUDE_PATHS <<<"${EXCLUDE_PATHS:-}"
+  read -ra OPT_IN_PATHS <<<"${OPT_IN_PATHS:-}"
   : "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
 
   # Allow tests to point at alternative temp dirs.
   WORK_DIR="${TEMPLATE_SYNC_WORK_DIR:-/tmp}"
   CONFLICT_FILES="$WORK_DIR/conflict_files.txt"
   CONFLICT_REPORT="$WORK_DIR/conflict_report.md"
+  MARKERLESS_FILES="$WORK_DIR/markerless_files.txt"
   DELETED_FILES="$WORK_DIR/deleted_files.txt"
   AUTO_MERGED_FILES="$WORK_DIR/auto_merged_files.txt"
-  DOWNGRADE_FILES="$WORK_DIR/downgrade_files.txt"
-  DOWNGRADE_REPORT="$WORK_DIR/downgrade_report.md"
   DECLINED_FILES="$WORK_DIR/declined_files.txt"
   INERT_ENTRIES="$WORK_DIR/inert_entries.txt"
+  DOWNGRADE_FILES="$WORK_DIR/downgrade_files.txt"
+  DOWNGRADE_REPORT="$WORK_DIR/downgrade_report.md"
   PREV_TEMPLATE_FILES="$WORK_DIR/prev_template_files.txt"
 
   : >"$CONFLICT_FILES"
   : >"$CONFLICT_REPORT"
+  : >"$MARKERLESS_FILES"
   : >"$DELETED_FILES"
   : >"$AUTO_MERGED_FILES"
-  : >"$DOWNGRADE_FILES"
-  : >"$DOWNGRADE_REPORT"
   : >"$DECLINED_FILES"
   : >"$INERT_ENTRIES"
+  : >"$DOWNGRADE_FILES"
+  : >"$DOWNGRADE_REPORT"
   # WORK_DIR persists between runs, so a stale list from an earlier run would
   # otherwise feed the deleted-in-template scan below.
   : >"$PREV_TEMPLATE_FILES"
-
-  # An EXCLUDE_PATHS entry names one file or one directory, and a directory
-  # entry covers every file under it. The `/`* arm is what makes the directory
-  # form work: the sync tests one file path at a time, so a directory entry
-  # never equals the path of a file inside it, and an equality-only test syncs
-  # every file the entry was written to keep out.
-  is_excluded() {
-    local candidate="$1" exclude
-    for exclude in $EXCLUDE_PATHS; do
-      [[ "$candidate" = "$exclude" || "$candidate" = "$exclude"/* ]] && return 0
-    done
-    return 1
-  }
-
-  # PROBLEM CLASS — a template file the adopter deleted comes back on the next
-  # sync. Case 1 copies in any template file the adopter does not have, so a
-  # deletion there survives only until the next sync run: one sync restored 44
-  # files an adopter had already removed more than once. This refusal is what
-  # makes that deletion hold.
-  #
-  # The evidence is the adopter's own history, not the template's tree. A commit
-  # that deleted the path IS the adopter saying it does not want the file. The
-  # template tree at PREV_SHA only says the file was available then, which is
-  # also true of every template file the adopter never adopted — reading that as
-  # a deletion would decline a genuinely new file forever. A path with no
-  # deletion commit was never there, so it is new and still arrives. The sync
-  # checks out with fetch-depth: 0; a shallow checkout finds no deletion and
-  # falls back to copying in.
-  was_deleted_here() {
-    [[ -n "$(git log --diff-filter=D --format=%H -1 -- "$1")" ]]
-  }
-
-  # PROBLEM CLASS — a configuration entry that is accepted and matches nothing.
-  # An EXCLUDE_PATHS or OPT_IN_PATHS entry naming a path the template does not
-  # ship covers nothing, and it fails silently: the entry sits in the list, the
-  # sync treats the file as unlisted, and the list reads as though it covers it.
-  # This warning is what makes a misspelled or stale entry visible. Read the
-  # template tree before the run deletes it.
-  report_inert_entries() {
-    local entry
-    for entry in $EXCLUDE_PATHS $OPT_IN_PATHS; do
-      [[ -e "_template/$entry" ]] && continue
-      echo "::warning::list entry names nothing in the template: $entry"
-      echo "$entry" >>"$INERT_ENTRIES"
-    done
-  }
-
-  # A file the template may update but must never introduce. Some template
-  # features are only correct in a repo that has no equivalent of its own — the
-  # release workflow is the case that motivated this: a consumer with its own
-  # publisher that also received auto-version.yaml ended up with two workflows
-  # racing the same semver bump on every push to the default branch.
-  # An OPT_IN_PATHS entry names one file or one directory, on the same terms as
-  # is_excluded above.
-  is_opt_in() {
-    local candidate="$1" opt_in
-    for opt_in in $OPT_IN_PATHS; do
-      [[ "$candidate" = "$opt_in" || "$candidate" = "$opt_in"/* ]] && return 0
-    done
-    return 1
-  }
-
-  # Generate a random sentinel suffix. Prefers /proc/sys/kernel/random/uuid
-  # (always present on Linux runners and inside containers) but falls back to
-  # `uuidgen` or $RANDOM so the script works in stripped-down environments.
-  random_token() {
-    if [[ -r /proc/sys/kernel/random/uuid ]]; then
-      cat /proc/sys/kernel/random/uuid
-    elif command -v uuidgen >/dev/null 2>&1; then
-      uuidgen
-    else
-      printf '%s_%s_%s' "$$" "$RANDOM" "$RANDOM"
-    fi
-  }
-
-  # Emit a multi-line GITHUB_OUTPUT block using a random-suffixed sentinel so
-  # user-controlled content can't accidentally terminate the block early.
-  emit_multiline_output() {
-    local key="$1" content="$2" sentinel
-    sentinel="EOF_$(random_token)"
-    {
-      echo "${key}<<${sentinel}"
-      printf '%s\n' "$content"
-      echo "$sentinel"
-    } >>"$GITHUB_OUTPUT"
-  }
-
-  # Say WHY the tree changed: name each template commit that moved a file THIS
-  # sync actually rewrote, and the files it moved. The old body pasted a raw
-  # `git log --oneline` of the whole template, most of whose commits touch paths
-  # this repo never syncs — so the reader could not tell which commit explains
-  # any given file. Runs before `rm -rf _template`, and after the worktree
-  # carries the sync, because it needs both.
-  #
-  # A file with no commit in range is listed apart rather than dropped: it is
-  # real (a path synced for the first time, or a history the template rewrote),
-  # and silence about it would read as "nothing else changed".
-  emit_attributed_changelog() {
-    local changed body="" attributed unexplained kept=0 skipped=0
-    local -a range
-    changed="$WORK_DIR/changed_here.txt"
-    attributed="$WORK_DIR/attributed.txt"
-    # `sed`, not `grep -v`: an all-filtered list makes grep exit 1 and `set -e`
-    # would kill the run. `.template-version` is rewritten above and the template
-    # ships none, so no commit can ever explain it; `_template` is this script's
-    # own untracked checkout, which `--others` reports and `rm -rf` removes a few
-    # lines below. Both would land in the unexplained list on every single sync.
-    {
-      git diff --name-only
-      git ls-files --others --exclude-standard
-    } | sed -e '/^\.template-version$/d' -e '\#^_template/\?$#d' | sort -u >"$changed"
-    [[ -s "$changed" ]] || return 0
-    local changed_list
-    changed_list="$(tr '\n' ' ' <"$changed")"
-    echo "changed_files=$changed_list" >>"$GITHUB_OUTPUT"
-
-    [[ -n "$PREV_SHA" && "$PREV_SHA" != "$TEMPLATE_SHA" ]] || return 0
-    if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
-      range=("${PREV_SHA}..${TEMPLATE_SHA}")
-    else
-      echo "::warning::Previous template SHA $PREV_SHA is not in template history (force-push or rebase); attributing over the last 20 commits instead"
-      range=(-20 "$TEMPLATE_SHA")
-      body+="\`$PREV_SHA\` is no longer in the template's history, so this reads the last 20 commits rather than a range."$'\n\n'
-    fi
-
-    : >"$attributed"
-    local sha subject touched
-    while IFS=$'\t' read -r sha subject; do
-      [[ -n "$sha" ]] || continue
-      # Files this commit touched that this sync also rewrote here. `comm -12`
-      # over two sorted lists, so a commit touching only unsynced paths yields
-      # nothing and is skipped.
-      touched=$(comm -12 \
-        <(git -C _template show --pretty=format: --name-only "$sha" | sed '/^$/d' | sort -u) \
-        "$changed")
-      if [[ -z "$touched" ]]; then
-        skipped=$((skipped + 1))
-        continue
-      fi
-      kept=$((kept + 1))
-      body+="- \`${sha}\` ${subject}"$'\n'
-      while IFS= read -r f; do
-        [[ -n "$f" ]] || continue
-        body+="  - \`${f}\`"$'\n'
-        echo "$f" >>"$attributed"
-      done <<<"$touched"
-      # --no-merges: `git show --name-only` prints nothing for a merge commit, so
-      # a merge would count as "touched nothing here" while being exactly the
-      # commit that carried the files. Its branch commits are already in range.
-    done < <(git -C _template log --no-merges --format='%h%x09%s' "${range[@]}")
-
-    unexplained=$(comm -23 "$changed" <(sort -u "$attributed"))
-    if [[ -n "$unexplained" ]]; then
-      body+=$'\n'"Changed here with no commit in that range — a path synced for the first time, or one whose template history moved:"$'\n'
-      while IFS= read -r f; do
-        [[ -n "$f" ]] || continue
-        body+="- \`${f}\`"$'\n'
-      done <<<"$unexplained"
-    fi
-    [[ "$skipped" -eq 0 ]] || body+=$'\n'"${skipped} other template commit(s) in that range touched nothing this repo syncs."$'\n'
-    [[ "$kept" -eq 0 && -z "$unexplained" ]] || emit_multiline_output "changelog" "$body"
-  }
-
-  # Count non-blank lines present in the pre-sync local file but absent from a
-  # candidate result. A clean 3-way merge should preserve every adopter line; a
-  # nonzero count means the merge REMOVED content the adopter had — the silent
-  # downgrade this report exists to surface. Order-insensitive (sorted comm) so a
-  # merely-moved line does not count. grep -c exits 1 with "0" when nothing
-  # matches, so the ||-default keeps set -e from aborting on an all-preserved file.
-  count_dropped_lines() {
-    local local_f="$1" result_f="$2" n
-    n=$(comm -23 <(sort "$local_f") <(sort "$result_f") |
-      grep -cv '^[[:space:]]*$') || n=0
-    printf '%s' "${n:-0}"
-  }
 
   #############################################
   # Version tracking
@@ -276,210 +495,19 @@ main() {
   echo "$TEMPLATE_SHA" >.template-version
 
   #############################################
-  # File processing
-  #############################################
-
-  # Resolve a single file's sync outcome using a 3-way merge strategy:
-  #
-  #   base     = the file at PREV_SHA in the template (last known common ancestor)
-  #   local    = the current file in the child repo
-  #   template = the file at HEAD in the template
-  #
-  # Decision tree:
-  #   1. File is new in template → copy it in.
-  #   2. Files are already identical → no-op.
-  #   3. No merge base (first sync or lost history) → apply template, record conflict.
-  #   4. Template is unchanged since base → local diverged alone; keep local.
-  #   5. Local is unchanged since base → template advanced alone; adopt template.
-  #   6. Both sides changed → attempt a 3-way merge:
-  #      a. Clean merge → write merged result.
-  #      b. Conflict → write conflict markers for Claude to resolve.
-  process_file() {
-    local rel_path="$1"
-    local template_file="_template/$rel_path"
-
-    local parent_dir
-    parent_dir=$(dirname "$rel_path")
-
-    # Case 0: the child deliberately made this path — or an ancestor directory —
-    # a symlink (e.g. a dotfiles repo pointing .claude/settings.json or
-    # .claude/hooks/ at another repo it clones at runtime). Never write it: cp
-    # through a dangling link errors out, through a live one it escapes into the
-    # link target, and mkdir -p on a symlinked directory fails outright. Leave
-    # the local structure alone; checked before the mkdir below.
-    if [[ -L "$rel_path" ]]; then
-      echo "Skipping symlink: $rel_path (local structure preserved)"
-      return
-    fi
-    local ancestor="$parent_dir"
-    while [[ "$ancestor" != "." && "$ancestor" != "/" && -n "$ancestor" ]]; do
-      if [[ -L "$ancestor" ]]; then
-        echo "Skipping under symlinked dir: $rel_path ($ancestor is a symlink)"
-        return
-      fi
-      ancestor=$(dirname "$ancestor")
-    done
-
-    if [[ "$parent_dir" != "." ]]; then
-      mkdir -p "$parent_dir"
-      [[ -d "$parent_dir" ]] || {
-        echo "::error::could not create $parent_dir for $rel_path" >&2
-        return 1
-      }
-    fi
-
-    # Case 1: absent locally — a new template file, unless the adopter removed it.
-    if [[ ! -f "$rel_path" ]]; then
-      if is_opt_in "$rel_path"; then
-        echo "Opt-in only, not present locally: $rel_path (skipping — copy it from the template to adopt it)"
-        return
-      fi
-      if was_deleted_here "$rel_path"; then
-        echo "Declined: $rel_path (deleted in the adopter since the last sync; not re-added)"
-        echo "$rel_path" >>"$DECLINED_FILES"
-        return
-      fi
-      cp "$template_file" "$rel_path"
-      echo "Added: $rel_path"
-      return
-    fi
-
-    # Case 2: already identical.
-    if diff -q "$rel_path" "$template_file" >/dev/null 2>&1; then
-      return
-    fi
-
-    # Case 3: no merge base — first sync or history unavailable.
-    if [[ -z "$PREV_SHA" ]]; then
-      record_no_base_conflict "$rel_path" "$template_file"
-      return
-    fi
-
-    local safe_name
-    safe_name=$(echo "$rel_path" | tr '/' '_')
-    local base_file="$WORK_DIR/merge_base_${safe_name}"
-
-    if ! git -C _template show "${PREV_SHA}:${rel_path}" >"$base_file" 2>/dev/null; then
-      rm -f "$base_file"
-      record_no_base_conflict "$rel_path" "$template_file"
-      return
-    fi
-
-    # Case 4: template unchanged since base — local diverged alone; keep local.
-    if diff -q "$base_file" "$template_file" >/dev/null 2>&1; then
-      echo "Unchanged in template: $rel_path (keeping local version)"
-      rm -f "$base_file"
-      return
-    fi
-
-    # Case 5: local unchanged since base — template advanced alone; adopt it.
-    if diff -q "$base_file" "$rel_path" >/dev/null 2>&1; then
-      cp "$template_file" "$rel_path"
-      echo "Updated: $rel_path (local was unmodified)"
-      rm -f "$base_file"
-      return
-    fi
-
-    # Case 6: both sides changed — attempt a 3-way merge.
-    local merge_result="$WORK_DIR/merge_result_${safe_name}"
-    cp "$rel_path" "$merge_result"
-
-    # --diff3 keeps the merge-base section between `|||||||` and `=======` in a
-    # conflict. It is what lets the structural resolver work on the result at
-    # all: mergiraf refuses a diff2-style conflict outright and returns no
-    # solution, so without this every sync conflict would need a model or a
-    # human. It also shows a human reviewer what the text was before either side
-    # touched it.
-    if git merge-file --diff3 -L "local" -L "base" -L "template" \
-      "$merge_result" "$base_file" "$template_file" 2>/dev/null; then
-      # Detect a silent downgrade: the merge base here is the single repo-wide
-      # PREV_SHA, which can be STALE for a file first synced at a different
-      # template SHA. A stale base makes git report a "clean" merge while
-      # actually dropping adopter-modified lines. Measure that against the
-      # pre-sync local ($rel_path, not yet overwritten) and surface it loudly so
-      # the reviewer never trusts "auto-merged" to mean "nothing lost".
-      local dropped
-      dropped=$(count_dropped_lines "$rel_path" "$merge_result")
-      cp "$merge_result" "$rel_path"
-      echo "Auto-merged: $rel_path (clean 3-way merge)"
-      echo "$rel_path" >>"$AUTO_MERGED_FILES"
-      if [[ "${dropped:-0}" -gt 0 ]]; then
-        echo "$rel_path" >>"$DOWNGRADE_FILES"
-        # %s are printf specifiers, not shell expansions; single quotes are correct.
-        # shellcheck disable=SC2016
-        printf -- '- `%s` — auto-merge dropped %s line(s) present in the local copy\n' \
-          "$rel_path" "$dropped" >>"$DOWNGRADE_REPORT"
-      fi
-      rm -f "$base_file" "$merge_result"
-      return
-    fi
-
-    # Case 6b: conflict markers produced — keep them for Claude to resolve.
-    cp "$merge_result" "$rel_path"
-    echo "CONFLICT (merge markers): $rel_path"
-    echo "$rel_path" >>"$CONFLICT_FILES"
-    {
-      echo "### \`$rel_path\`"
-      echo ""
-      echo "3-way merge produced **conflict markers** (\`<<<<<<<\`/\`=======\`/\`>>>>>>>\`)."
-      echo "Resolve them: keep local customizations, adopt template improvements."
-      echo ""
-      echo "<details>"
-      echo "<summary>View file with conflict markers</summary>"
-      echo ""
-      echo "\`\`\`"
-      head -500 "$rel_path"
-      echo "\`\`\`"
-      echo "</details>"
-      echo ""
-    } >>"$CONFLICT_REPORT"
-    rm -f "$base_file" "$merge_result"
-  }
-
-  record_no_base_conflict() {
-    local rel_path="$1" template_file="$2"
-    echo "CONFLICT (no base): $rel_path"
-    echo "$rel_path" >>"$CONFLICT_FILES"
-    {
-      echo "### \`$rel_path\`"
-      echo ""
-      echo "No merge base available (first sync or file history unavailable)."
-      echo "Template version has been applied. Restore any important local customizations."
-      echo ""
-      echo "<details>"
-      echo "<summary>Diff (old local → new template)</summary>"
-      echo ""
-      echo "\`\`\`diff"
-      # diff exits 0 (identical) or 1 (differs); anything higher is a real error.
-      # Capture into a variable so truncating with `head` can't SIGPIPE the diff.
-      diff_rc=0
-      diff_out=$(diff -u "$rel_path" "$template_file") || diff_rc=$?
-      [[ "${diff_rc:-0}" -le 1 ]] || exit "${diff_rc}"
-      head -500 <<<"$diff_out"
-      echo "\`\`\`"
-      echo "</details>"
-      echo ""
-    } >>"$CONFLICT_REPORT"
-    cp "$template_file" "$rel_path"
-  }
-
-  #############################################
   # Detect deleted files + process sync paths
   #############################################
 
-  # A path is "deleted" only if it existed in the template at PREV_SHA but no
-  # longer exists at the current template HEAD. This avoids false positives for
-  # project-specific files that were never in the template.
-  if [[ -n "$PREV_SHA" ]]; then
-    if ! git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES"; then
-      : >"$PREV_TEMPLATE_FILES" # PREV_SHA not in template history; treat as no prior files
-    fi
+  # A path counts as deleted only if it existed at PREV_SHA but not at template
+  # HEAD — avoids flagging project-specific files that were never in the template.
+  if [[ "$PREV_SHA" != "" ]]; then
+    git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES" || true
   fi
 
-  for path in $SYNC_PATHS; do
+  for path in "${SYNC_PATHS[@]}"; do
     is_excluded "$path" && continue
 
-    if [[ -n "$PREV_SHA" ]]; then
+    if [[ "$PREV_SHA" != "" ]]; then
       while IFS= read -r prev_file; do
         case "$prev_file" in "$path" | "$path/"*) ;; *) continue ;; esac
         is_excluded "$prev_file" && continue
@@ -514,80 +542,93 @@ main() {
   # Set outputs
   #############################################
 
+  # Capped per the cap_body_field invariant; the largest list, so the likeliest to
+  # push the body past MAX_ARG_STRLEN.
   if [[ -s "$AUTO_MERGED_FILES" ]]; then
     auto_merged=$(tr '\n' ' ' <"$AUTO_MERGED_FILES")
-    echo "auto_merged_files=$auto_merged" >>"$GITHUB_OUTPUT"
+    capped_auto_merged="$(cap_body_field "$auto_merged" \
+      "${CONFLICT_FILES_MAX_BYTES:-8000}" \
+      "… list truncated; the sync log names every auto-merged file.")"
+    emit_multiline_output "auto_merged_files" "$capped_auto_merged"
   fi
 
+  # Capped per the cap_body_field invariant; grows with the rejected template files.
   if [[ -s "$INERT_ENTRIES" ]]; then
     inert=$(tr '\n' ' ' <"$INERT_ENTRIES")
-    echo "inert_entries=$inert" >>"$GITHUB_OUTPUT"
+    capped_inert="$(cap_body_field "$inert" \
+      "${CONFLICT_FILES_MAX_BYTES:-8000}" \
+      "… list truncated; the sync log names every inert entry.")"
+    emit_multiline_output "inert_entries" "$capped_inert"
   fi
 
-  if [[ -s "$DECLINED_FILES" ]]; then
-    declined=$(tr '\n' ' ' <"$DECLINED_FILES")
-    echo "declined_files=$declined" >>"$GITHUB_OUTPUT"
-  fi
-
-  # Downgrade risk: files whose "clean" auto-merge dropped adopter content. This
-  # is the loud counterpart to the silent regression the sync used to ship — the
-  # PR body renders it as a prominent "adopter is ahead" section so the reviewer
-  # eyeballs exactly these files instead of trusting the auto-merge.
+  # The loud counterpart to a silent downgrade: the PR body names these files so a
+  # reviewer reads them instead of trusting "auto-merged". Capped per the
+  # cap_body_field invariant; has_downgrades stays a single-line flag.
   if [[ -s "$DOWNGRADE_FILES" ]]; then
     downgrade=$(tr '\n' ' ' <"$DOWNGRADE_FILES")
-    {
-      echo "has_downgrades=true"
-      echo "downgrade_files=$downgrade"
-    } >>"$GITHUB_OUTPUT"
-    downgrade_report_content="$(cat "$DOWNGRADE_REPORT")"
-    emit_multiline_output "downgrade_report" "$downgrade_report_content"
+    capped_downgrade="$(cap_body_field "$downgrade" \
+      "${CONFLICT_FILES_MAX_BYTES:-8000}" \
+      "… list truncated; the sync log names every downgraded file.")"
+    echo "has_downgrades=true" >>"$GITHUB_OUTPUT"
+    emit_multiline_output "downgrade_files" "$capped_downgrade"
+    downgrade_report="$(cat "$DOWNGRADE_REPORT")"
+    capped_downgrade_report="$(cap_body_field "$downgrade_report" \
+      "${CONFLICT_REPORT_MAX_BYTES:-40000}" \
+      "_Downgrade report truncated; the sync log names every downgraded file._")"
+    emit_multiline_output "downgrade_report" "$capped_downgrade_report"
   else
     echo "has_downgrades=false" >>"$GITHUB_OUTPUT"
   fi
 
-  if [[ -s "$CONFLICT_FILES" ]]; then
-    # paste, not `tr '\n' ' '`: the file ends in a newline, so tr leaves a
-    # TRAILING space. That space reaches .template-sync-conflicts below, where
-    # pre-commit's trailing-whitespace hook rewrites the file and fails the run —
-    # on every consumer that has a conflict.
-    conflicts=$(paste -sd' ' "$CONFLICT_FILES")
-    {
-      echo "has_conflicts=true"
-      echo "conflict_files=$conflicts"
-    } >>"$GITHUB_OUTPUT"
-    # Cap the total conflict report before it becomes the PR body. GitHub passes
-    # the body to the create-pull-request action through the environment, and a
-    # body over the exec arg/env limit aborts PR creation with E2BIG ("Argument
-    # list too long") before it starts -- reached when many files have no merge
-    # base (each contributes a full old->new diff). The complete conflicted-file
-    # list is preserved in .template-sync-conflicts, so truncating the narrative
-    # detail here loses nothing load-bearing.
-    max_report_bytes=60000
-    if [[ "$(wc -c <"$CONFLICT_REPORT")" -gt "$max_report_bytes" ]]; then
-      capped="${CONFLICT_REPORT}.capped"
-      head -c "$max_report_bytes" "$CONFLICT_REPORT" | sed '$d' >"$capped"
-      printf '\n\n_Conflict report truncated at %d KB. Every conflicted file is listed in .template-sync-conflicts._\n' "$((max_report_bytes / 1000))" >>"$capped"
-      mv "$capped" "$CONFLICT_REPORT"
-    fi
-    conflict_report_content="$(cat "$CONFLICT_REPORT")"
-    emit_multiline_output "conflict_report" "$conflict_report_content"
-    echo "Template updates available for: $conflicts" >.template-sync-conflicts
-  else
-    echo "has_conflicts=false" >>"$GITHUB_OUTPUT"
-    rm -f .template-sync-conflicts
+  if [[ -s "$DECLINED_FILES" ]]; then
+    declined=$(tr '\n' ' ' <"$DECLINED_FILES")
+    capped_declined="$(cap_body_field "$declined" \
+      "${CONFLICT_FILES_MAX_BYTES:-8000}" \
+      "… list truncated; the sync log names every declined file.")"
+    emit_multiline_output "declined_files" "$capped_declined"
   fi
 
+  if [[ -s "$CONFLICT_FILES" ]]; then
+    conflicts=$(tr '\n' ' ' <"$CONFLICT_FILES")
+    echo "has_conflicts=true" >>"$GITHUB_OUTPUT"
+    # A capped field goes through emit_multiline_output, never `echo k=v`: cap_body_field puts a
+    # blank line before its note, so the instant a cap fires the value spans lines and the
+    # single-line GITHUB_OUTPUT form makes the runner reject the file with "Invalid format" and kill
+    # the step. The note carries no backticks: the workflow interpolates these values inside `{0}`,
+    # where a nested backtick renders as broken inline code.
+    capped_conflicts="$(cap_body_field "$conflicts" \
+      "${CONFLICT_FILES_MAX_BYTES:-8000}" \
+      "… list truncated; the full set is the conflicted files on the template-sync branch.")"
+    emit_multiline_output "conflict_files" "$capped_conflicts"
+    if [[ -s "$MARKERLESS_FILES" ]]; then
+      markerless=$(tr '\n' ' ' <"$MARKERLESS_FILES")
+      capped_markerless="$(cap_body_field "$markerless" \
+        "${CONFLICT_FILES_MAX_BYTES:-8000}" \
+        "… list truncated; see the report below.")"
+      emit_multiline_output "markerless_files" "$capped_markerless"
+    fi
+    conflict_report="$(cat "$CONFLICT_REPORT")"
+    capped_conflict_report="$(cap_body_field "$conflict_report" \
+      "${CONFLICT_REPORT_MAX_BYTES:-40000}" \
+      "_Conflict report truncated (the full report exceeded the PR-body size limit). Every file under **Conflicted files** above carries \`<<<<<<<\`/\`=======\`/\`>>>>>>>\` markers on the \`template-sync\` branch — resolve the remaining ones from those. The exception is any file under **Kept local**, if this body carries that list: those carry no markers, and their template-side change survives only in the part of this report that fits._")"
+    emit_multiline_output "conflict_report" "$capped_conflict_report"
+  else
+    echo "has_conflicts=false" >>"$GITHUB_OUTPUT"
+  fi
+
+  # Capped per the cap_body_field invariant; has_deletions stays a single-line flag.
   if [[ -s "$DELETED_FILES" ]]; then
     deleted=$(tr '\n' ' ' <"$DELETED_FILES")
-    {
-      echo "has_deletions=true"
-      echo "deleted_files=$deleted"
-    } >>"$GITHUB_OUTPUT"
+    capped_deleted="$(cap_body_field "$deleted" \
+      "${CONFLICT_FILES_MAX_BYTES:-8000}" \
+      "… list truncated; the sync log names every deleted file.")"
+    echo "has_deletions=true" >>"$GITHUB_OUTPUT"
+    emit_multiline_output "deleted_files" "$capped_deleted"
   else
     echo "has_deletions=false" >>"$GITHUB_OUTPUT"
   fi
 
-  if git diff --quiet && [[ -z "$(git ls-files --others --exclude-standard)" ]]; then
+  if git diff --quiet && [[ "$(git ls-files --others --exclude-standard)" = "" ]]; then
     echo "has_changes=false" >>"$GITHUB_OUTPUT"
   else
     changed_paths=$({
@@ -599,6 +640,9 @@ main() {
       echo "changed_paths=$changed_paths"
     } >>"$GITHUB_OUTPUT"
   fi
+
+  # Per the header SELF-MODIFICATION SAFETY invariant: exit from inside main.
+  exit 0
 }
 
 main "$@"

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -180,7 +180,7 @@ is_ci_loaded() {
 # The diff must be taken before any caller overwrites the local file. This writes the REPORT only;
 # each caller decides whether the path also joins CONFLICT_FILES or MARKERLESS_FILES.
 record_diff_conflict() {
-  local rel_path="$1" template_file="$2" explanation="$3" diff_rc=0
+  local rel_path="$1" template_file="$2" explanation="$3" report="${4:-$CONFLICT_REPORT}" diff_rc=0
   {
     echo "### \`$rel_path\`"
     echo ""
@@ -202,7 +202,7 @@ record_diff_conflict() {
     echo '```'
     echo "</details>"
     echo ""
-  } >>"$CONFLICT_REPORT"
+  } >>"$report"
 }
 
 # A conflict in a file CI loads writes nothing and joins MARKERLESS_FILES, the short path list the
@@ -213,10 +213,14 @@ record_diff_conflict() {
 # and template-sync-resolve.sh documents it as marker-bearing paths. A marker-free file handed to
 # mergiraf comes back unchanged, which the resolver scores DETERMINISTIC, which arms auto-merge on a
 # sync whose own PR body says to port the file by hand.
+# A markerless entry goes in its OWN report file, which the emit step puts FIRST. The report takes a
+# byte cap, and a marker-bearing file loses nothing when its entry is cut — its content is on the
+# branch. A markerless file's entry is the only copy of the template's change anywhere, and the sync
+# still advances .template-version, so the next run sees no change and never reports it again.
 record_markerless_conflict() {
   local rel_path="$1" template_file="$2" explanation="$3"
   echo "$rel_path" >>"$MARKERLESS_FILES"
-  record_diff_conflict "$rel_path" "$template_file" "$explanation"
+  record_diff_conflict "$rel_path" "$template_file" "$explanation" "$MARKERLESS_REPORT"
 }
 
 record_ci_loaded_conflict() {
@@ -491,6 +495,7 @@ main() {
   WORK_DIR="${TEMPLATE_SYNC_WORK_DIR:-/tmp}"
   CONFLICT_FILES="$WORK_DIR/conflict_files.txt"
   CONFLICT_REPORT="$WORK_DIR/conflict_report.md"
+  MARKERLESS_REPORT="$WORK_DIR/markerless_report.md"
   MARKERLESS_FILES="$WORK_DIR/markerless_files.txt"
   DELETED_FILES="$WORK_DIR/deleted_files.txt"
   AUTO_MERGED_FILES="$WORK_DIR/auto_merged_files.txt"
@@ -502,6 +507,7 @@ main() {
 
   : >"$CONFLICT_FILES"
   : >"$CONFLICT_REPORT"
+  : >"$MARKERLESS_REPORT"
   : >"$MARKERLESS_FILES"
   : >"$DELETED_FILES"
   : >"$AUTO_MERGED_FILES"
@@ -648,10 +654,10 @@ main() {
         "… list truncated; see the report below.")"
       emit_multiline_output "markerless_files" "$capped_markerless"
     fi
-    conflict_report="$(cat "$CONFLICT_REPORT")"
+    conflict_report="$(cat "$MARKERLESS_REPORT" "$CONFLICT_REPORT")"
     capped_conflict_report="$(cap_body_field "$conflict_report" \
       "${CONFLICT_REPORT_MAX_BYTES:-40000}" \
-      "_Conflict report truncated (the full report exceeded the PR-body size limit). Every file under **Conflicted files** above carries \`<<<<<<<\`/\`=======\`/\`>>>>>>>\` markers on the \`template-sync\` branch — resolve the remaining ones from those. The exception is any file under **Kept local**, if this body carries that list: those carry no markers, and their template-side change survives only in the part of this report that fits._")"
+      "_Conflict report truncated (the full report exceeded the PR-body size limit). Every entry cut from the end is a file carrying \`<<<<<<<\`/\`=======\`/\`>>>>>>>\` markers on the \`template-sync\` branch — resolve those from the markers. Every **Kept local** entry is printed first, because the report is the only copy of what those files would have received._")"
     emit_multiline_output "conflict_report" "$capped_conflict_report"
   else
     echo "has_conflicts=false" >>"$GITHUB_OUTPUT"

--- a/.github/scripts/template-sync.sh
+++ b/.github/scripts/template-sync.sh
@@ -80,7 +80,12 @@ emit_attributed_changelog() {
   [[ -s "$changed" ]] || return 0
   local changed_list
   changed_list="$(tr '\n' ' ' <"$changed")"
-  echo "changed_files=$changed_list" >>"$GITHUB_OUTPUT"
+  # changed_count is emitted UNCAPPED beside the capped list, because the body leads with "Syncs N
+  # file(s)" and counting the truncated list would report the cap's size as the sync's size.
+  echo "changed_count=$(wc -l <"$changed" | tr -d ' ')" >>"$GITHUB_OUTPUT"
+  emit_multiline_output "changed_files" "$(cap_body_field "$changed_list" \
+    "${CONFLICT_FILES_MAX_BYTES:-8000}" \
+    "… list truncated; the sync log names every changed file.")"
 
   [[ -n "$PREV_SHA" && "$PREV_SHA" != "$TEMPLATE_SHA" ]] || return 0
   if git -C _template cat-file -e "$PREV_SHA" 2>/dev/null; then
@@ -170,10 +175,10 @@ is_ci_loaded() {
 }
 
 # One conflict-report entry: the path, EXPLANATION, and the local→template diff.
-# The diff must be taken before any caller overwrites the local file.
+# The diff must be taken before any caller overwrites the local file. This writes the REPORT only;
+# each caller decides whether the path also joins CONFLICT_FILES or MARKERLESS_FILES.
 record_diff_conflict() {
   local rel_path="$1" template_file="$2" explanation="$3" diff_rc=0
-  echo "$rel_path" >>"$CONFLICT_FILES"
   {
     echo "### \`$rel_path\`"
     echo ""
@@ -202,11 +207,20 @@ record_diff_conflict() {
 # PR body prints ahead of the report. Every other conflict leaves markers in the tree; this one
 # writes nothing, so the report is its ONLY record, and the template's version reaches the reviewer
 # as a diff.
+# INVARIANT — a markerless path never joins CONFLICT_FILES. That output is the resolver's input,
+# and template-sync-resolve.sh documents it as marker-bearing paths. A marker-free file handed to
+# mergiraf comes back unchanged, which the resolver scores DETERMINISTIC, which arms auto-merge on a
+# sync whose own PR body says to port the file by hand.
+record_markerless_conflict() {
+  local rel_path="$1" template_file="$2" explanation="$3"
+  echo "$rel_path" >>"$MARKERLESS_FILES"
+  record_diff_conflict "$rel_path" "$template_file" "$explanation"
+}
+
 record_ci_loaded_conflict() {
   local rel_path="$1" template_file="$2"
   echo "CONFLICT (local kept, CI loads this file): $rel_path"
-  echo "$rel_path" >>"$MARKERLESS_FILES"
-  record_diff_conflict "$rel_path" "$template_file" \
+  record_markerless_conflict "$rel_path" "$template_file" \
     "**The template change is NOT applied.** CI loads this file off the branch.
 A conflict marker in it makes the workflow unloadable, or the step a bash syntax error.
 GitHub then reports a failure that names no cause. The sync keeps the local file unchanged.
@@ -271,9 +285,15 @@ emit_multiline_output() {
 # real failure such as an unreadable path or binary input, so treating "non-zero" as "conflicted"
 # would commit a merge that never ran as a merge that conflicted. 255 is separated out and kills the
 # sync.
+#
+# --diff3 is load-bearing, not cosmetic: it writes the `||||||| base` section mergiraf needs to
+# re-merge structurally. install-mergiraf.sh proves that contract with a probe carrying that exact
+# marker. Without the flag every conflict falls through tier 1 of template-sync-resolve.sh to the
+# paid model tier, `all_deterministic` never holds, and no sync auto-merges again — with no red
+# anywhere to say so.
 merge_file_clean() {
   local rc=0
-  git merge-file -L "local" -L "base" -L "template" "$1" "$2" "$3" >/dev/null 2>&1 || rc=$?
+  git merge-file --diff3 -L "local" -L "base" -L "template" "$1" "$2" "$3" >/dev/null 2>&1 || rc=$?
   if ((rc == 255)); then
     echo "::error::template-sync: git merge-file failed on $1 — refusing to guess at the merge." >&2
     exit 1
@@ -430,18 +450,27 @@ record_no_base_conflict() {
     record_ci_loaded_conflict "$rel_path" "$template_file"
     return
   fi
+  local empty_base="$WORK_DIR/empty_base" merge_result="$WORK_DIR/no_base_result"
+  : >"$empty_base"
+  cp "$rel_path" "$merge_result"
+  if merge_file_clean "$merge_result" "$empty_base" "$template_file"; then
+    # One side matches the empty base — an empty local file, or an empty template file — so the
+    # merge is clean and writes no markers. Taking the result would replace the local file unseen.
+    rm -f "$empty_base" "$merge_result"
+    echo "CONFLICT (no base, local kept, no markers possible): $rel_path"
+    record_markerless_conflict "$rel_path" "$template_file" \
+      "**The template change is NOT applied.** One side of this first-sync collision is empty, so a
+merge against an empty base is clean and writes no conflict markers. Taking it would replace the
+local file with nothing to show a merge was skipped. Port the template's change by hand."
+    return
+  fi
   echo "CONFLICT (no base): $rel_path"
   record_diff_conflict "$rel_path" "$template_file" \
     "No merge base available (first sync, or the template added this path after the last sync).
 Both versions are kept as **conflict markers** (\`<<<<<<<\`/\`=======\`/\`>>>>>>>\`).
 Resolve them: keep local customizations, adopt template improvements."
-  local empty_base="$WORK_DIR/empty_base" merge_result="$WORK_DIR/no_base_result"
-  : >"$empty_base"
-  cp "$rel_path" "$merge_result"
-  # allow-exit-suppress: non-zero here means "conflicted", which the empty base guarantees and
-  # this path wants. merge_file_clean exits the script itself on a real merge-file fault (255).
-  merge_file_clean "$merge_result" "$empty_base" "$template_file" || true
   cp "$merge_result" "$rel_path"
+  echo "$rel_path" >>"$CONFLICT_FILES"
   rm -f "$empty_base" "$merge_result"
 }
 
@@ -511,7 +540,9 @@ main() {
   # A path counts as deleted only if it existed at PREV_SHA but not at template
   # HEAD — avoids flagging project-specific files that were never in the template.
   if [[ "$PREV_SHA" != "" ]]; then
-    git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES" || true
+    if ! git -C _template ls-tree -r --name-only "$PREV_SHA" 2>/dev/null >"$PREV_TEMPLATE_FILES"; then
+      : >"$PREV_TEMPLATE_FILES" # PREV_SHA not in template history; treat as no prior files
+    fi
   fi
 
   for path in "${SYNC_PATHS[@]}"; do
@@ -552,8 +583,8 @@ main() {
   # Set outputs
   #############################################
 
-  # Capped per the cap_body_field invariant; the largest list, so the likeliest to
-  # push the body past MAX_ARG_STRLEN.
+  # Capped per the cap_body_field invariant. Every path list the PR body prints takes the cap,
+  # because the body reaches create-pull-request as ONE environment string against one execve limit.
   if [[ -s "$AUTO_MERGED_FILES" ]]; then
     auto_merged=$(tr '\n' ' ' <"$AUTO_MERGED_FILES")
     capped_auto_merged="$(cap_body_field "$auto_merged" \
@@ -598,18 +629,15 @@ main() {
     emit_multiline_output "declined_files" "$capped_declined"
   fi
 
-  if [[ -s "$CONFLICT_FILES" ]]; then
-    conflicts=$(tr '\n' ' ' <"$CONFLICT_FILES")
+  if [[ -s "$CONFLICT_FILES" || -s "$MARKERLESS_FILES" ]]; then
     echo "has_conflicts=true" >>"$GITHUB_OUTPUT"
-    # A capped field goes through emit_multiline_output, never `echo k=v`: cap_body_field puts a
-    # blank line before its note, so the instant a cap fires the value spans lines and the
-    # single-line GITHUB_OUTPUT form makes the runner reject the file with "Invalid format" and kill
-    # the step. The note carries no backticks: the workflow interpolates these values inside `{0}`,
-    # where a nested backtick renders as broken inline code.
-    capped_conflicts="$(cap_body_field "$conflicts" \
-      "${CONFLICT_FILES_MAX_BYTES:-8000}" \
-      "… list truncated; the full set is the conflicted files on the template-sync branch.")"
-    emit_multiline_output "conflict_files" "$capped_conflicts"
+    # UNCAPPED, unlike every list above: conflict_files never reaches the PR body, so no execve
+    # limit applies to it. It is the resolver's input, and cap_body_field both drops paths and
+    # appends an English note — whose words template-sync-resolve.sh would split as paths and
+    # template-sync-push.sh would hand to `git add`.
+    if [[ -s "$CONFLICT_FILES" ]]; then
+      emit_multiline_output "conflict_files" "$(tr '\n' ' ' <"$CONFLICT_FILES")"
+    fi
     if [[ -s "$MARKERLESS_FILES" ]]; then
       markerless=$(tr '\n' ' ' <"$MARKERLESS_FILES")
       capped_markerless="$(cap_body_field "$markerless" \
@@ -625,6 +653,9 @@ main() {
   else
     echo "has_conflicts=false" >>"$GITHUB_OUTPUT"
   fi
+  # The retired .template-sync-conflicts sidecar: an earlier sync committed it into adopters that
+  # conflicted, and nothing writes or removes it any more. The branch's own markers are the record.
+  rm -f .template-sync-conflicts
 
   # Capped per the cap_body_field invariant; has_deletions stays a single-line flag.
   if [[ -s "$DELETED_FILES" ]]; then

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -249,6 +249,7 @@ jobs:
           TEMPLATE_REPO: ${{ env.TEMPLATE_REPO }}
           TEMPLATE_SHA_SHORT: ${{ steps.sync.outputs.template_sha_short }}
           CHANGED_FILES: ${{ steps.sync.outputs.changed_files }}
+          CHANGED_COUNT: ${{ steps.sync.outputs.changed_count }}
           CHANGELOG: ${{ steps.sync.outputs.changelog }}
           DOWNGRADE_REPORT: ${{ steps.sync.outputs.downgrade_report }}
           AUTO_MERGED_FILES: ${{ steps.sync.outputs.auto_merged_files }}

--- a/.github/workflows/template-sync.yaml
+++ b/.github/workflows/template-sync.yaml
@@ -256,6 +256,7 @@ jobs:
           INERT_ENTRIES: ${{ steps.sync.outputs.inert_entries }}
           DELETED_FILES: ${{ steps.sync.outputs.deleted_files }}
           CONFLICT_REPORT: ${{ steps.sync.outputs.conflict_report }}
+          MARKERLESS_FILES: ${{ steps.sync.outputs.markerless_files }}
           PR_BODY_PATH: ${{ runner.temp }}/template-sync-body.md
           BASE_SHA: ${{ github.sha }}
         run: |

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -916,8 +916,11 @@ def test_a_ci_loaded_conflict_keeps_the_local_file_free_of_markers(
 
     outputs = parse_outputs(output_file)
     assert outputs["has_conflicts"] == "true"
-    assert ci_path in outputs["conflict_files"]
     assert ci_path in outputs["markerless_files"]
+    # Never in conflict_files: that output is template-sync-resolve.sh's input, documented as
+    # marker-bearing paths. mergiraf hands a marker-free file back unchanged, the resolver scores
+    # that DETERMINISTIC, and auto-merge then lands a sync whose body says to port it by hand.
+    assert ci_path not in outputs.get("conflict_files", "")
     # The local file is untouched, so CI can still load it.
     assert (child / ci_path).read_text(encoding="utf-8") == local_text
     # The template's version still reaches the reviewer.
@@ -944,7 +947,12 @@ def test_a_marker_conflict_is_not_listed_as_markerless(workdir: Path) -> None:
     assert outputs["has_conflicts"] == "true"
     assert "config/a.txt" in outputs["conflict_files"]
     assert "markerless_files" not in outputs
-    assert "<<<<<<< local" in (child / "config" / "a.txt").read_text(encoding="utf-8")
+    body = (child / "config" / "a.txt").read_text(encoding="utf-8")
+    assert "<<<<<<< local" in body
+    # `||||||| base`, from `git merge-file --diff3`. mergiraf re-merges from that section, so
+    # without it template-sync-resolve.sh's structural tier resolves nothing and every conflict
+    # falls to the model tier — with no check going red to say so.
+    assert "||||||| base" in body
 
 
 def test_template_adopting_a_downstream_file_does_not_clobber_it(workdir: Path) -> None:
@@ -971,6 +979,7 @@ def test_template_adopting_a_downstream_file_does_not_clobber_it(workdir: Path) 
     body = (child / "config" / "a.txt").read_text(encoding="utf-8")
     assert "local work since the port" in body
     assert "<<<<<<< local" in body and ">>>>>>> template" in body
+    assert "||||||| base" in body
 
 
 def test_a_merge_that_could_not_run_fails_the_sync(workdir: Path) -> None:
@@ -992,3 +1001,88 @@ def test_a_merge_that_could_not_run_fails_the_sync(workdir: Path) -> None:
     assert "git merge-file failed on" in result.stderr
     # The local file is left exactly as it was — a failed merge writes nothing.
     assert (child / "config" / "a.bin").read_bytes() == b"local\x00\n"
+
+
+def test_an_empty_side_on_a_first_sync_is_reported_markerless(workdir: Path) -> None:
+    """An empty local file merges CLEAN against the empty base, so no markers land.
+
+    Taking that merge would replace the adopter's file with the template's and leave nothing in
+    the tree to show a merge was skipped, which is the same loss the no-base path exists to stop.
+    """
+    child = workdir / "child"
+    template = workdir / "template"
+    write(template / "config" / "a.txt", "template version\n")
+    commit_all(template)
+    write(child / "config" / "a.txt", "")
+    commit_all(child)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    assert outputs["has_conflicts"] == "true"
+    assert "config/a.txt" in outputs["markerless_files"]
+    assert "config/a.txt" not in outputs.get("conflict_files", "")
+    assert (child / "config" / "a.txt").read_text(encoding="utf-8") == ""
+    assert "template version" in outputs["conflict_report"]
+
+
+def test_the_conflict_path_list_is_never_capped(workdir: Path) -> None:
+    """conflict_files feeds template-sync-resolve.sh, not the PR body.
+
+    A cap would both drop paths the resolver must see and append prose the resolver would split
+    as whitespace-separated paths, which template-sync-push.sh then hands to `git add`.
+    """
+    child = workdir / "child"
+    template = workdir / "template"
+    # Long enough that the space-joined list clears the 8000-byte cap the other lists take,
+    # so a cap re-applied here would actually fire and this case would go red.
+    names = [f"{'deliberately-long-path-segment-' * 7}{n}.txt" for n in range(40)]
+    for name in names:
+        write(template / "config" / name, "shared\n")
+    prev_sha = commit_all(template)
+    for name in names:
+        write(child / "config" / name, "LOCAL change\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
+    for name in names:
+        write(template / "config" / name, "TEMPLATE change\n")
+    commit_all(template)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    listed = outputs["conflict_files"].split()
+    assert sorted(listed) == sorted(f"config/{name}" for name in names)
+    assert "truncated" not in outputs["conflict_files"]
+
+
+def test_a_truncated_path_list_keeps_its_notice_in_the_body(workdir: Path) -> None:
+    """The PR body renders a capped list with `read -ra`, which reads one line.
+
+    cap_body_field puts its notice after a blank line, so a renderer that stops at the first line
+    drops the notice and presents the shortened list as the complete one.
+    """
+    body_script = REPO_ROOT / ".github" / "scripts" / "template-sync-pr-body.sh"
+    out = workdir / "body.md"
+    truncated = "config/a.txt config/b.txt\n\n… list truncated; the sync log names every deleted file."
+    subprocess.run(
+        ["bash", str(body_script)],
+        check=True,
+        env={
+            **os.environ,
+            "TEMPLATE_REPO": "o/r",
+            "TEMPLATE_SHA_SHORT": "abc1234",
+            "PR_BODY_PATH": str(out),
+            "DELETED_FILES": truncated,
+        },
+        capture_output=True,
+        text=True,
+    )
+    rendered = out.read_text(encoding="utf-8")
+    assert "- `config/a.txt`" in rendered
+    assert "- `config/b.txt`" in rendered
+    assert "list truncated" in rendered
+    # The notice is prose, not one bullet per word.
+    assert "- `truncated;`" not in rendered

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -1085,3 +1085,40 @@ def test_a_truncated_path_list_keeps_its_notice_in_the_body(workdir: Path) -> No
     assert "list truncated" in rendered
     # The notice is prose, not one bullet per word.
     assert "- `truncated;`" not in rendered
+
+
+def test_a_markerless_entry_survives_the_report_cap(workdir: Path) -> None:
+    """The report is the ONLY copy of a markerless conflict's template-side change.
+
+    A marker-bearing file keeps its content on the branch, so losing its report entry costs
+    nothing. A markerless one loses the change for good: the sync still advances
+    `.template-version`, so the next run sees the template file as unchanged and never reports it.
+    """
+    child = workdir / "child"
+    template = workdir / "template"
+    # Enough marker-bearing conflicts to blow the 40 KB report cap on their own.
+    filler = "x" * 300
+    for n in range(20):
+        write(
+            child / "config" / f"f{n}.txt",
+            "".join(f"L{i} {filler}\n" for i in range(60)),
+        )
+        write(
+            template / "config" / f"f{n}.txt",
+            "".join(f"T{i} {filler}\n" for i in range(60)),
+        )
+    write(child / ".github" / "workflows" / "ci.yaml", "local-side\n")
+    write(template / ".github" / "workflows" / "ci.yaml", "template-side\n")
+    commit_all(child)
+    commit_all(template)
+
+    result, output_file = run_sync(child, template, sync_paths="config .github")
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    report = outputs["conflict_report"]
+    assert "truncated" in report, "the cap must fire, or this case proves nothing"
+    assert ".github/workflows/ci.yaml" in outputs["markerless_files"]
+    # The entry's own heading and its diff line, not a phrase the cap note also carries.
+    assert "### `.github/workflows/ci.yaml`" in report
+    assert "+template-side" in report

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -22,7 +22,16 @@ def write(path: Path, content: str) -> None:
 
 
 def parse_outputs(github_output: Path) -> dict[str, str]:
-    """Parse a GITHUB_OUTPUT file. Supports both key=value and key<<EOF blocks."""
+    """Parse a GITHUB_OUTPUT file, rejecting what the real runner rejects.
+
+    The runner reads `key=value` one line at a time, so a value that spans lines
+    leaves its continuation sitting on its own; finding no `=` there, the runner
+    aborts the whole step with `Unable to process file command 'output'
+    successfully. Invalid format`. A parser that skipped such a line would call a
+    file green that kills the sync in production, and multi-line values are
+    exactly what `cap_body_field` produces the moment a cap fires — so the strict
+    read is what makes any capping test mean anything at all.
+    """
     text = github_output.read_text(encoding="utf-8")
     result: dict[str, str] = {}
     lines = text.splitlines()
@@ -40,6 +49,11 @@ def parse_outputs(github_output: Path) -> dict[str, str]:
         elif "=" in line:
             key, value = line.split("=", 1)
             result[key] = value
+        elif line.strip():
+            raise AssertionError(
+                f"line {i + 1} of GITHUB_OUTPUT is neither a key=value nor a "
+                f"heredoc header, so the runner would abort the step: {line!r}"
+            )
         i += 1
     return result
 
@@ -139,7 +153,6 @@ def test_3way_merge_outcomes(
     else:
         assert "<<<<<<<" in body and ">>>>>>>" in body
         assert "config/a.txt" in outputs["conflict_files"]
-        assert (child / ".template-sync-conflicts").exists()
 
 
 def test_adds_new_file_from_template(workdir: Path) -> None:
@@ -217,12 +230,14 @@ def test_no_base_conflict_when_local_differs_without_prev_sha(workdir: Path) -> 
     outputs = parse_outputs(output_file)
     assert outputs["has_conflicts"] == "true"
     assert "config/a.txt" in outputs["conflict_files"]
-    # The script overwrites the local file with the template version and
-    # emits a diff in conflict_report for human review — the report content
-    # is load-bearing for the downstream PR template.
-    assert (child / "config" / "a.txt").read_text(
-        encoding="utf-8"
-    ) == "template version\n"
+    # Both versions survive as conflict markers. The sync used to `cp` the
+    # template over the local file and tell the reader to restore whatever it
+    # had just destroyed; a first sync is exactly when the adopter's own
+    # content is least recoverable, so nothing here overwrites it.
+    merged = (child / "config" / "a.txt").read_text(encoding="utf-8")
+    assert "local version" in merged
+    assert "template version" in merged
+    assert "<<<<<<<" in merged and ">>>>>>>" in merged
     assert "local version" in outputs["conflict_report"]
     assert "template version" in outputs["conflict_report"]
 
@@ -231,8 +246,8 @@ def test_conflict_report_is_capped_for_many_no_base_files(workdir: Path) -> None
     """Many no-merge-base files must not produce an unbounded PR body. The report
     becomes the create-pull-request body (passed through the environment); an
     oversized body aborts PR creation with E2BIG ("Argument list too long"). The
-    report is capped, and the full file list still lands in
-    .template-sync-conflicts so nothing load-bearing is lost."""
+    report is capped, and the branch itself carries the complete record: every
+    conflicted file holds markers, so nothing load-bearing is lost."""
     child = workdir / "child"
     template = workdir / "template"
     big_local = "".join(f"local line {i}\n" for i in range(700))
@@ -253,11 +268,13 @@ def test_conflict_report_is_capped_for_many_no_base_files(workdir: Path) -> None
     # Uncapped this would be ~120 KB (12 files x head -500 of the per-file diff).
     assert len(report.encode()) <= 62000, len(report.encode())
     assert "truncated" in report
-    assert ".template-sync-conflicts" in report
-    # The complete conflicted-file list is preserved out-of-band.
-    listed = (child / ".template-sync-conflicts").read_text(encoding="utf-8")
+    # The cap note sends the reader to the markers, which is where the complete
+    # record lives: every conflicted file carries them, however little of the
+    # report fits.
+    assert "<<<<<<<" in report
     for n in range(12):
-        assert f"config/f{n}.txt" in listed
+        merged = (child / "config" / f"f{n}.txt").read_text(encoding="utf-8")
+        assert "<<<<<<<" in merged and ">>>>>>>" in merged
 
 
 def test_detects_deleted_files(workdir: Path) -> None:
@@ -472,10 +489,13 @@ def test_opt_in_path_present_locally_is_updated(workdir: Path) -> None:
     """Opting in is creating the file once — after that it syncs like any other."""
     child = workdir / "child"
     template = workdir / "template"
+    write(template / "config" / "opt-in.txt", "v1 adopted earlier\n")
+    prev_sha = commit_all(template)
+    write(child / "config" / "opt-in.txt", "v1 adopted earlier\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
     write(template / "config" / "opt-in.txt", "v2 from template\n")
     commit_all(template)
-    write(child / "config" / "opt-in.txt", "v1 adopted earlier\n")
-    commit_all(child)
 
     result, _ = run_sync(
         child,
@@ -860,3 +880,115 @@ def test_a_merge_commit_is_not_counted_as_touching_nothing(workdir: Path) -> Non
 
     assert "feat(config): move the file" in changelog
     assert "touched nothing this repo syncs" not in changelog
+
+
+@pytest.mark.parametrize("with_merge_base", [True, False], ids=["3way", "no-base"])
+@pytest.mark.parametrize(
+    "ci_path",
+    [
+        ".github/workflows/ci.yaml",
+        ".github/actions/report/action.yaml",
+        ".github/scripts/lib-decide-range.sh",
+    ],
+    ids=["workflow", "composite-action", "step-script"],
+)
+def test_a_ci_loaded_conflict_keeps_the_local_file_free_of_markers(
+    workdir: Path, with_merge_base: bool, ci_path: str
+) -> None:
+    """GitHub parses these files, so a conflict marker in one makes it
+    unparseable: the run starts with zero jobs and a red that names no cause.
+    The sync keeps the local file whole and reports the template's version."""
+    child = workdir / "child"
+    template = workdir / "template"
+    local_text = "local-side\n"
+
+    if with_merge_base:
+        write(template / ci_path, "base-side\n")
+        prev_sha = commit_all(template)
+        (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    write(child / ci_path, local_text)
+    commit_all(child)
+    write(template / ci_path, "template-side\n")
+    commit_all(template)
+
+    result, output_file = run_sync(child, template, sync_paths=".github")
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    assert outputs["has_conflicts"] == "true"
+    assert ci_path in outputs["conflict_files"]
+    assert ci_path in outputs["markerless_files"]
+    # The local file is untouched, so CI can still load it.
+    assert (child / ci_path).read_text(encoding="utf-8") == local_text
+    # The template's version still reaches the reviewer.
+    assert "template-side" in outputs["conflict_report"]
+    assert "NOT applied" in outputs["conflict_report"]
+
+
+def test_a_marker_conflict_is_not_listed_as_markerless(workdir: Path) -> None:
+    child = workdir / "child"
+    template = workdir / "template"
+
+    write(template / "config" / "a.txt", "shared\n")
+    prev_sha = commit_all(template)
+    write(child / "config" / "a.txt", "LOCAL change\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
+    write(template / "config" / "a.txt", "TEMPLATE change\n")
+    commit_all(template)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    assert outputs["has_conflicts"] == "true"
+    assert "config/a.txt" in outputs["conflict_files"]
+    assert "markerless_files" not in outputs
+    assert "<<<<<<< local" in (child / "config" / "a.txt").read_text(encoding="utf-8")
+
+
+def test_template_adopting_a_downstream_file_does_not_clobber_it(workdir: Path) -> None:
+    child = workdir / "child"
+    template = workdir / "template"
+
+    # Last synced state: the template does not carry config/a.txt at all.
+    write(template / "unrelated.txt", "seed\n")
+    prev_sha = commit_all(template)
+    write(child / "config" / "a.txt", "shared\nlocal work since the port\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
+
+    # The template later adopts the file, at the state it had when ported.
+    write(template / "config" / "a.txt", "shared\n")
+    commit_all(template)
+
+    result, output_file = run_sync(child, template, sync_paths="config")
+    assert result.returncode == 0, result.stderr
+
+    outputs = parse_outputs(output_file)
+    assert outputs["has_conflicts"] == "true"
+    assert "config/a.txt" in outputs["conflict_files"]
+    body = (child / "config" / "a.txt").read_text(encoding="utf-8")
+    assert "local work since the port" in body
+    assert "<<<<<<< local" in body and ">>>>>>> template" in body
+
+
+def test_a_merge_that_could_not_run_fails_the_sync(workdir: Path) -> None:
+    child = workdir / "child"
+    template = workdir / "template"
+
+    (template / "config").mkdir(parents=True)
+    (template / "config" / "a.bin").write_bytes(b"base\x00\n")
+    prev_sha = commit_all(template)
+    (child / "config").mkdir(parents=True)
+    (child / "config" / "a.bin").write_bytes(b"local\x00\n")
+    (child / ".template-version").write_text(prev_sha, encoding="utf-8")
+    commit_all(child)
+    (template / "config" / "a.bin").write_bytes(b"template\x00\n")
+    commit_all(template)
+
+    result, _ = run_sync(child, template, sync_paths="config")
+    assert result.returncode != 0
+    assert "git merge-file failed on" in result.stderr
+    # The local file is left exactly as it was — a failed merge writes nothing.
+    assert (child / "config" / "a.bin").read_bytes() == b"local\x00\n"

--- a/tests/test_template_sync.py
+++ b/tests/test_template_sync.py
@@ -268,10 +268,9 @@ def test_conflict_report_is_capped_for_many_no_base_files(workdir: Path) -> None
     # Uncapped this would be ~120 KB (12 files x head -500 of the per-file diff).
     assert len(report.encode()) <= 62000, len(report.encode())
     assert "truncated" in report
-    # The cap note sends the reader to the markers, which is where the complete
-    # record lives: every conflicted file carries them, however little of the
-    # report fits.
-    assert "<<<<<<<" in report
+    # The note's own words, not a marker: every per-file explanation quotes
+    # `<<<<<<<` verbatim, so asserting the marker passes with no note at all.
+    assert "exceeded the PR-body size limit" in report
     for n in range(12):
         merged = (child / "config" / f"f{n}.txt").read_text(encoding="utf-8")
         assert "<<<<<<<" in merged and ">>>>>>>" in merged


### PR DESCRIPTION
## What & why

The script that copies template files into an adopter repo had two copies: this one, and the diverged copy `agent-glovebox` runs weekly. Take the running copy, so the next change lands once. On a first-sync collision this one still ran `cp "$template_file" "$rel_path"` and told the reader to restore what it had just destroyed. **Every adopter's next run can now produce conflict markers where it used to produce a silent overwrite.**

- A collision with no merge base keeps both sides as conflict markers. When one side is empty the merge is clean and writes none, so the sync keeps the local file and reports it instead.
- A file GitHub parses — a workflow, a composite action, a step script — keeps the local version whole and reports the template's change under a new `markerless_files` output. A marker in one of those makes the run start with zero jobs and a red that names no cause.
- A `git merge-file` that cannot run fails the sync instead of writing a half-merged file.

`emit_attributed_changelog` stays: it is this repository's, and the running copy never had it. Its body now goes through `cap_body_field` like every other output.

```
# before: the adopter's file is gone
$ cat config/a.txt
template version

# after: both sides survive
$ cat config/a.txt
<<<<<<< local
local version
||||||| base
=======
template version
>>>>>>> template
```

The script now refactors helpers out of main() and adds three features the running copy brought: a check for CI-loaded files that must stay marker-free; a `markerless_files` output for first-sync collisions where both sides are kept but the merge is clean (so markers don't land); and stricter merge-file failure handling. `conflict_files` is the resolver's input, so it holds marker-bearing paths only and takes no cap — a cap dropped paths the resolver must see and appended prose it would split as paths. Markerless report entries print first, because the report is the only copy of what those files would have received and the cap cuts from the end.

Three smaller ones from the same round: `changed_files` takes the cap it lacked, beside a new uncapped `changed_count`; the body's list renderer stopped dropping a truncation notice; and the run sweeps out the retired `.template-sync-conflicts` sidecar that earlier syncs committed into adopters.

## Review focus

Read `record_no_base_conflict`, `record_markerless_conflict` and `merge_file_clean` in `.github/scripts/template-sync.sh` first. The invariant one screen cannot show: a path in `markerless_files` must never be in `conflict_files`, because `template-sync-resolve.sh` treats its input as marker-bearing and mergiraf scores a marker-free file DETERMINISTIC — which arms auto-merge on a sync whose own body says to port that file by hand.

## How it was tested

`timeout 180 uv run pytest tests/test_template_sync.py -q` — 42 passed, 13 of them new or rewritten. Each was run against the pre-fix script and goes red for its own reason, not a setup error.

`parse_outputs` in the test file now raises on a `GITHUB_OUTPUT` line that is neither `key=value` nor a heredoc header. The runner aborts the step on one, so the lax parser called a file green that would kill the sync in production.

## Decisions made

The conflict report no longer writes a `.template-sync-conflicts` sidecar. The branch already carries the complete record — every conflicted file holds markers — so the capped report points there instead of at a second, committed copy of that list.

The port takes no dry-run parity period. `agent-glovebox` has run this script live for weeks, and the sync's product is a pull request a human reads rather than a merge.